### PR TITLE
New statuses and making an offer

### DIFF
--- a/app/assets/sass/components/_tag.scss
+++ b/app/assets/sass/components/_tag.scss
@@ -4,6 +4,7 @@
   color: govuk-colour("dark-grey");
   margin-top: -3px;
   margin-bottom: -3px;
+  white-space: nowrap;
 }
 
 .app-tag--new {
@@ -12,19 +13,23 @@
   color: govuk-colour("blue");
   margin-top: -3px;
   margin-bottom: -3px;
+  white-space: nowrap;
 }
 
 .app-tag--review {
   background: govuk-colour("orange");
   color: govuk-colour("white");
+  white-space: nowrap;
 }
 
 .app-tag--recruited {
   background: govuk-colour("turquoise");
   color: govuk-colour("white");
+  white-space: nowrap;
 }
 
 .app-tag--rejected {
   background: govuk-colour("red");
   color: govuk-colour("white");
+  white-space: nowrap;
 }

--- a/app/filters.js
+++ b/app/filters.js
@@ -66,7 +66,7 @@ module.exports = (env) => {
       case "recruited":
         return "Confirmed"
       case "review":
-        return "In progress"
+        return "Interviewing"
       case "recruited":
         return "Offer accepted"
       default:

--- a/app/filters.js
+++ b/app/filters.js
@@ -61,6 +61,19 @@ module.exports = (env) => {
     }
   }
 
+  filters.statusName = (status) => {
+    switch(status) {
+      case "recruited":
+        return "Confirmed"
+      case "review":
+        return "In progress"
+      case "recruited":
+        return "Offer accepted"
+      default:
+        return status
+    }
+  }
+
   /**
    * Convert object to array
    * @type {Object} obj

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -17,6 +17,14 @@ module.exports = router => {
     })
   })
 
+  router.post('/application/:applicationId/changed-status', (req, res) => {
+    if (req.body.status == "offer") {
+      res.redirect(`/application/${req.params.applicationId}/make-offer`)
+    } else {
+      res.redirect(`/application/${req.params.applicationId}`)
+    }
+  })
+
   // Render other application pages
   router.all('/application/:applicationId/:view', (req, res) => {
     res.render(`application/${req.params.view}`, {

--- a/app/views/application/change-status.njk
+++ b/app/views/application/change-status.njk
@@ -1,7 +1,8 @@
 {% extends "_form-wide.njk" %}
 
 {% set application = applications[applicationId] %}
-{% set formaction = "/application/" + application.id %}
+{% set formaction = "/application/" + application.id + "/changed-status" %}
+{% set parent = application.name + " – " + application.course %}
 {% set title = "Change status" %}
 
 {% block pageNavigation %}
@@ -12,31 +13,6 @@
 
 {% block primary %}
   {% set isPrimaryCourse = application.course.includes("Primary") %}
-
-  {% set currentStatusHtml %}
-    {{ govukTag({
-      classes: "app-tag--" + application.status,
-      text: application.status | capitalize
-    }) }}
-  {% endset %}
-
-  {{ govukSummaryList({
-    rows: [{
-      key: {
-        text: "Candidate"
-      },
-      value: {
-        text: application.name
-      }
-    }, {
-      key: {
-        text: "Course"
-      },
-      value: {
-        text: application.course
-      }
-    }]
-  }) }}
 
   {% set rejectedHtml %}
     {{ govukRadios({
@@ -88,6 +64,7 @@
 
   {{ govukRadios({
     idPrefix: "status",
+    classes: "govuk-!-margin-top-2",
     name: "status",
     items: [{
       value: "new",
@@ -95,15 +72,19 @@
       checked: application.status == "new"
     } if application.status == "new", {
       value: "review",
-      text: "In review",
+      text: "Invite to interview",
       checked: application.status == "review"
     }, {
+      value: "offer",
+      text: "Make offer",
+      checked: application.status == "offer"
+    }, {
       value: "recruited",
-      text: "Recruited",
+      text: "Confirm enrolment",
       checked: application.status == "recruited"
     }, {
       value: "rejected",
-      text: "Rejected",
+      text: "Reject candidate",
       checked: application.status == "rejected",
       conditional: {
         html: rejectedHtml
@@ -112,7 +93,7 @@
   }) }}
 
   {{ govukButton({
-    text: "Change status"
+    text: "Continue"
   }) }}
 
   <p class="govuk-body"><a href="{{ formaction }}">Cancel</a></p>

--- a/app/views/application/index.njk
+++ b/app/views/application/index.njk
@@ -84,7 +84,7 @@
     <h2 class="govuk-heading-m">Status</h2>
     {{ govukTag({
       classes: "app-tag--" + application.status + " govuk-!-margin-bottom-4",
-      text: application.status | capitalize
+      text: application.status | statusName | capitalize
     }) }}
     <dl class="govuk-body">
       <dt class="govuk-!-font-weight-bold">Application submitted<dt>

--- a/app/views/application/make-offer.njk
+++ b/app/views/application/make-offer.njk
@@ -1,0 +1,117 @@
+{% extends "_form-wide.njk" %}
+
+{% set application = applications[applicationId] %}
+{% set formaction = "/application/" + application.id %}
+{% set parent = application.name + " – " + application.course %}
+{% set title = "Make an offer" %}
+
+{% block pageNavigation %}
+  {{ govukBackLink({
+    href: "/application/" + application.id + "/change-status"
+  }) }}
+{% endblock %}
+
+{% block primary %}
+  {% set detailsHtml %}
+    {{ govukSummaryList({
+      rows: [{
+        key: {
+          text: "Full name"
+        },
+        value: {
+          text: application.name
+        }
+      }, {
+        key: {
+          text: "Course"
+        },
+        value: {
+          html: application.course + "<br />PGCE with QTS full time"
+        }
+      }, {
+        key: {
+          text: "Starting"
+        },
+        value: {
+          text: "September 2020"
+        }
+      }, {
+        key: {
+          text: "Preferred location"
+        },
+        value: {
+          html: "Alliance Academy<br />Edgeware, Road Name, SW1 1AA"
+        }
+      }]
+    }) }}
+  {% endset %}
+
+  {% set conditionalHtml %}
+    {{ detailsHtml | safe }}
+
+    {{ govukTextarea({
+      id: "condition-of-offer-1",
+      name: "condition-of-offer-1",
+      rows: 5,
+      label: {
+        text: "First condition",
+        classes: "govuk-label--s"
+      }
+    }) }}
+
+    {{ govukTextarea({
+      id: "condition-of-offer-2",
+      name: "condition-of-offer-2",
+      rows: 5,
+      label: {
+        text: "Second condition (optional)",
+        classes: "govuk-label--s"
+      }
+    }) }}
+
+    {{ govukTextarea({
+      id: "condition-of-offer-3",
+      name: "condition-of-offer-3",
+      rows: 5,
+      label: {
+        text: "Third condition (optional)",
+        classes: "govuk-label--s"
+      }
+    }) }}
+
+    {{ govukTextarea({
+      id: "condition-of-offer-further",
+      name: "condition-of-offer-further",
+      rows: 10,
+      label: {
+        text: "Further conditions (optional)",
+        classes: "govuk-label--s"
+      }
+    }) }}
+  {% endset %}
+
+  {{ govukRadios({
+    idPrefix: "status",
+    classes: "govuk-!-margin-top-2",
+    name: "status",
+    items: [{
+      value: "conditional",
+      text: "Make a conditional offer",
+      conditional: {
+        html: conditionalHtml
+      }
+    }, {
+      value: "unconditional",
+      text: "Make an unconditional offer",
+      conditional: {
+        html: detailsHtml
+      }
+    }]
+  }) }}
+
+  {{ govukButton({
+    text: "Make offer"
+  }) }}
+
+  <p class="govuk-body"><a href="{{ formaction }}">Cancel</a></p>
+{% endblock %}

--- a/app/views/index.njk
+++ b/app/views/index.njk
@@ -44,21 +44,25 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-one-quarter">
       <div class="app-card">
-        <h2 class="govuk-heading-s">
+        <h2 class="govuk-heading-s govuk-!-margin-bottom-6">
           <a href="/">All applications ({{ applications | length | default("0") }})</a>
         </h2>
 
-        <h2 class="govuk-heading-s">
-          <a href="?status=new">New ({{ new | length | default("0") }})</a>
-        </h2>
-
         <h2 class="govuk-heading-s govuk-!-margin-bottom-1">
-          <a href="?status=review">In progress ({{ review | length | default("0") }})</a>
+          <a href="?status=new">New ({{ new | length | default("0") }})</a>
         </h2>
         <ul class="govuk-list govuk-body-s">
           <li><a href="#">References pending</a></li>
-          <li><a href="#">Invited to interview</a></li>
+          <li><a href="#">References submitted</a></li>
         </ul>
+
+        <h2 class="govuk-heading-s govuk-!-margin-bottom-6">
+          <a href="?status=review">Interviewing ({{ review | length | default("0") }})</a>
+        </h2>
+        {# <ul class="govuk-list govuk-body-s">
+          <li><a href="#">References pending</a></li>
+          <li><a href="#">Invited to interview</a></li>
+        </ul> #}
 
         <h2 class="govuk-heading-s govuk-!-margin-bottom-1">
           <a href="#">Offer made (2)</a>
@@ -66,11 +70,10 @@
         <ul class="govuk-list govuk-body-s">
           <li><a href="#">Conditional</a></li>
           <li><a href="#">Unconditional</a></li>
-          <li><a href="#">Accepted</a></li>
-          <li><a href="#">Meeting conditions</a></li>
+          <li><a href="#">Accepted (conditional)</a></li>
         </ul>
 
-        <h2 class="govuk-heading-s">
+        <h2 class="govuk-heading-s govuk-!-margin-bottom-6">
           <a href="?status=recruited">Confirmed ({{ recruited | length | default("0") }})</a>
         </h2>
 
@@ -131,7 +134,7 @@
       {% elif status == "rejected" %}
         {% set applications = rejected %}
       {% endif %}
-      <table class="govuk-table govuk-!-font-size-16" data-module="sortable-table">
+      <table class="govuk-table" data-module="sortable-table">
         <thead class="govuk-table__head">
           <tr class="govuk-table__row">
             <th class="govuk-table__header" scope="col" aria-sort="none">Name</th>

--- a/app/views/index.njk
+++ b/app/views/index.njk
@@ -10,7 +10,7 @@
   {% set recruited = applications | filterBy("status", "recruited") %}
   {% set rejected = applications | filterBy("status", "rejected") %}
 
-  {{ appCardList({
+  {# {{ appCardList({
     items: [{
       classes: "app-status",
       href: "/",
@@ -39,82 +39,145 @@
     }]
   }) }}
 
-  <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--m">
+  <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--m"> #}
 
-  {{ appSearch({
-    classes: "govuk-!-margin-bottom-4",
-    action: "/search-results",
-    method: "get",
-    input: {
-      id: "search",
-      name: "q"
-    },
-    label: {
-      text: "Find an application",
-      classes: "govuk-!-font-weight-bold"
-    },
-    hint: {
-      text: "You can search by candidate name or application number"
-    },
-    button: {
-      text: "Search"
-    }
-  }) }}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-one-quarter">
+      <div class="app-card">
+        <h2 class="govuk-heading-s">
+          <a href="/">All applications ({{ applications | length | default("0") }})</a>
+        </h2>
 
-  {% if status == "new" %}
-    {% set applications = new %}
-  {% elif status == "review" %}
-    {% set applications = review %}
-  {% elif status == "recruited" %}
-    {% set applications = recruited %}
-  {% elif status == "rejected" %}
-    {% set applications = rejected %}
-  {% endif %}
-  <table class="govuk-table" data-module="sortable-table">
-    <thead class="govuk-table__head">
-      <tr class="govuk-table__row">
-        <th class="govuk-table__header" scope="col" aria-sort="none">Candidate name</th>
-        <th class="govuk-table__header govuk-!-width-one-third" scope="col" aria-sort="none">Course</th>
-        <th class="govuk-table__header" scope="col">Status</th>
-        <th class="govuk-table__header govuk-table__header--numeric" scope="col" aria-sort="none">Submitted</th>
-      {% if status == "recruited" or status == "rejected" %}
-        <th class="govuk-table__header govuk-table__header--numeric" scope="col" aria-sort="none">{{ status | capitalize }}</th>
-      {% else %}
-        <th class="govuk-table__header govuk-table__header--numeric" scope="col" aria-sort="none">Rejected by default</th>
-      {% endif %}
-      </tr>
-    </thead>
-    <tbody class="govuk-table__body">
-    {% for a in applications | reverse %}
-      {% set rbd = a.submitted | addDays(40) %}
-      {% set remaining = rbd | daysFromNow(rbd) %}
-      <tr class="govuk-table__row">
-        <td class="govuk-table__cell">
-          <a href="/application/{{ a.id }}">{{ a.name }}</a>
-        </td>
-        <td class="govuk-table__cell">{{ a.course }}</td>
-        <td class="govuk-table__cell">
-          {{ govukTag({
-            classes: "app-tag--" + a.status,
-            text: a.status
-          }) }}
-        </td>
-        <td class="govuk-table__cell govuk-table__cell--numeric" data-sort-value="{{ a.submitted | date("yyyyMMdd") }}">{{ a.submitted | date("d LLL yyyy") }}</td>
-      {% if status == "recruited" %}
-        <td class="govuk-table__cell govuk-table__cell--numeric" data-sort-value="{{ a.recruited | date("yyyyMMdd") }}">{{ a.recruited | date("d LLL yyyy") }}</td>
+        <h2 class="govuk-heading-s">
+          <a href="?status=new">New ({{ new | length | default("0") }})</a>
+        </h2>
+
+        <h2 class="govuk-heading-s govuk-!-margin-bottom-1">
+          <a href="?status=review">In progress ({{ review | length | default("0") }})</a>
+        </h2>
+        <ul class="govuk-list govuk-body-s">
+          <li><a href="#">References pending</a></li>
+          <li><a href="#">Invited to interview</a></li>
+        </ul>
+
+        <h2 class="govuk-heading-s govuk-!-margin-bottom-1">
+          <a href="#">Offer made (2)</a>
+        </h2>
+        <ul class="govuk-list govuk-body-s">
+          <li><a href="#">Conditional</a></li>
+          <li><a href="#">Unconditional</a></li>
+          <li><a href="#">Accepted</a></li>
+          <li><a href="#">Meeting conditions</a></li>
+        </ul>
+
+        <h2 class="govuk-heading-s">
+          <a href="?status=recruited">Confirmed ({{ recruited | length | default("0") }})</a>
+        </h2>
+
+        <h2 class="govuk-heading-s govuk-!-margin-bottom-1">
+          <a href="?status=rejected">Rejected ({{ rejected | length | default("0") }})</a>
+        </h2>
+        <ul class="govuk-list govuk-body-s">
+          <li><a href="#">Rejected by us</a></li>
+          <li><a href="#">Rejected by default</a></li>
+          <li><a href="#">Withdrawn</a></li>
+          <li><a href="#">Offer rejected</a></li>
+          <li><a href="#">Declined by default</a></li>
+        </ul>
+      </div>
+    </div>
+    <div class="govuk-grid-column-two-thirds" style="width: 75%">
+      {{ appSearch({
+        classes: "govuk-!-margin-bottom-4",
+        action: "/search-results",
+        method: "get",
+        input: {
+          id: "search",
+          name: "q"
+        },
+        label: {
+          text: "Find an application",
+          classes: "govuk-!-font-weight-bold"
+        },
+        hint: {
+          text: "You can search by candidate name or application number"
+        },
+        button: {
+          text: "Search"
+        }
+      }) }}
+
+      <hr class="govuk-section-break govuk-section-break--m">
+
+      {% if status == "new" %}
+        <h2 class="govuk-heading-l">New applications</h2>
+      {% elif status == "review" %}
+        <h2 class="govuk-heading-l">In progress</h2>
+      {% elif status == "recruited" %}
+        <h2 class="govuk-heading-l">Confirmed</h2>
       {% elif status == "rejected" %}
-        <td class="govuk-table__cell govuk-table__cell--numeric" data-sort-value="{{ a.rejected | date("yyyyMMdd") }}">{{ a.rejected | date("d LLL yyyy") }}</td>
+        <h2 class="govuk-heading-l">Rejected</h2>
       {% else %}
-        <td class="govuk-table__cell govuk-table__cell--numeric" data-sort-value="{{ rbd | date("yyyyMMdd") }}">
-        {% if a.status == "recruited" or a.status == "rejected" %}
-          –
-        {% else %}
-          {{ remaining }} days
-        {% endif %}
-        </td>
+        <h2 class="govuk-heading-l">All applications</h2>
       {% endif %}
-      </tr>
-    {% endfor %}
-    </tbody>
-  </table>
+
+
+      {% if status == "new" %}
+        {% set applications = new %}
+      {% elif status == "review" %}
+        {% set applications = review %}
+      {% elif status == "recruited" %}
+        {% set applications = recruited %}
+      {% elif status == "rejected" %}
+        {% set applications = rejected %}
+      {% endif %}
+      <table class="govuk-table govuk-!-font-size-16" data-module="sortable-table">
+        <thead class="govuk-table__head">
+          <tr class="govuk-table__row">
+            <th class="govuk-table__header" scope="col" aria-sort="none">Name</th>
+            <th class="govuk-table__header govuk-!-width-one-third" scope="col" aria-sort="none">Course</th>
+            <th class="govuk-table__header" scope="col">Status</th>
+            <th class="govuk-table__header govuk-table__header--numeric" scope="col" aria-sort="none">Received</th>
+          {% if status == "recruited" or status == "rejected" %}
+            <th class="govuk-table__header govuk-table__header--numeric" scope="col" aria-sort="none">{{ status | capitalize }}</th>
+          {% else %}
+            <th class="govuk-table__header govuk-table__header--numeric" scope="col" aria-sort="none">Reject by default</th>
+          {% endif %}
+          </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+        {% for a in applications | reverse %}
+          {% set rbd = a.submitted | addDays(40) %}
+          {% set remaining = rbd | daysFromNow(rbd) %}
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell">
+              <a href="/application/{{ a.id }}">{{ a.name }}</a>
+            </td>
+            <td class="govuk-table__cell">{{ a.course }}</td>
+            <td class="govuk-table__cell">
+              {{ govukTag({
+                classes: "app-tag--" + a.status,
+                text: a.status | statusName
+              }) }}
+            </td>
+            <td class="govuk-table__cell govuk-table__cell--numeric" data-sort-value="{{ a.submitted | date("yyyyMMdd") }}">{{ a.submitted | date("d LLL yyyy") }}</td>
+          {% if status == "recruited" %}
+            <td class="govuk-table__cell govuk-table__cell--numeric" data-sort-value="{{ a.recruited | date("yyyyMMdd") }}">{{ a.recruited | date("d LLL yyyy") }}</td>
+          {% elif status == "rejected" %}
+            <td class="govuk-table__cell govuk-table__cell--numeric" data-sort-value="{{ a.rejected | date("yyyyMMdd") }}">{{ a.rejected | date("d LLL yyyy") }}</td>
+          {% else %}
+            <td class="govuk-table__cell govuk-table__cell--numeric" data-sort-value="{{ rbd | date("yyyyMMdd") }}">
+            {% if a.status == "recruited" or a.status == "rejected" %}
+              –
+            {% else %}
+              {{ remaining }} days
+            {% endif %}
+            </td>
+          {% endif %}
+          </tr>
+        {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </div>
 {% endblock %}


### PR DESCRIPTION
This branch is currently driving the Heroku app for research:
https://manage-applications-beta.herokuapp.com/

## Changes
- Rename existing statuses
- Introduce new child-statuses
- Make actions on "change status" active
- Add screen for making an offer

### Statuses
- In review and recruited didn't make sense to users
- It wasn't clear where interviewing and offers made would sit
- Top level statuses are ones that the provider can put a candidate into:
  - New
  - Interviewing (previously In review)
  - Offer made
  - Confirmed (previously recruited)
  - Rejected
- Sub-status represent the variety of states within those top levels, eg rejected for different reasons, or types of offer and whether conditions are met or unmet.

This is a quick design to get the statuses in, there's no reason the nice panel boxes can't come back somehow:
![Screen Shot 2019-09-05 at 16 44 50](https://user-images.githubusercontent.com/319055/64360753-00e50880-d003-11e9-80c0-4243f46caa13.png)

### Making an offer
- The design is added to prompt conversation. It is not final. I would expect something where the user can add as many conditions as they choose, probably in a page-per-thing sort of journey, or selecting from a predefined/provider managed list of conditions
- In research we will ask if entering separate items is useful versus UCAS's approach of a single text box
- We will also ask if creating a reusable list of conditions will help
- Users can't edit conditions and they aren't shown anywhere yet
- Updating status still doesn't work

![localhost_3001_application_105_make-offer](https://user-images.githubusercontent.com/319055/64360896-53262980-d003-11e9-90cc-a68b93fcbc95.png)

### Active status changes

![localhost_3001_application_5_change-status](https://user-images.githubusercontent.com/319055/64360909-5ae5ce00-d003-11e9-86c1-b18c08bbe8b9.png)

### Homepage

![localhost_3001_](https://user-images.githubusercontent.com/319055/64360953-7224bb80-d003-11e9-9d1d-ef2b744c0da7.png)
