### PR TITLE
Initial email content

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -2,6 +2,7 @@ const express = require('express')
 const router = express.Router()
 
 require('./routes/application')(router)
+require('./routes/email')(router)
 
 // Render other application pages
 router.all('/search-results', (req, res) => {

--- a/app/routes/email.js
+++ b/app/routes/email.js
@@ -1,0 +1,11 @@
+/**
+ * Email routes
+ */
+module.exports = router => {
+  // Render email pages
+  router.all('/email/:applicationId/:view', (req, res) => {
+    res.render(`email/${req.params.view}`, {
+      applicationId: req.params.applicationId
+    })
+  })
+}

--- a/app/views/application/index.njk
+++ b/app/views/application/index.njk
@@ -29,10 +29,16 @@
     <div class="govuk-grid-column-one-third">
       <div class="app-card">
         <h2 class="govuk-heading-m">Status</h2>
-        {{ govukTag({
-          classes: "app-tag--" + status | status + " govuk-!-margin-bottom-4",
-          text: status | status("title") | capitalize
-        }) }}
+        {% if status.declined or status.accepted %}
+          <a href="/email/{{ applicationId }}/candidate-{{ status | status }}-offer">
+        {% endif %}
+          {{ govukTag({
+            classes: "app-tag--" + status | status + " govuk-!-margin-bottom-4",
+            text: status | status("title") | capitalize
+          }) }}
+        {% if status.declined or status.accepted %}
+          </a>
+        {% endif %}
         <dl class="app-definition-list">
           <dt>Application submitted<dt>
           <dd>{{ status.submitted.date | date("dd LLL yyyy") }}</dd>

--- a/app/views/email/candidate-accepted-offer.njk
+++ b/app/views/email/candidate-accepted-offer.njk
@@ -1,0 +1,22 @@
+{% extends "_email.njk" %}
+
+{% set application = data.applications[applicationId] %}
+{% set name = [application["personal-details"]["given-name"], application["personal-details"]["family-name"]] | join(" ") %}
+{% set title = "Manage teacher training applications: " + name + " has accepted your offer to join " + application.course %}
+{% set from = "apply-for-teacher-training@education.gov.uk" %}
+{% set to = "admin@provider-name.example" %}
+
+{% block content %}
+  <p class="govuk-body">Dear [Provider name],</p>
+  <p class="govuk-body">We’re pleased to tell you that <strong>{{ name }}</strong> has accepted your offer to join <strong>{{ application.course }}</strong> starting September 2020.</p>
+  <p class="govuk-body">You can check candidate responses any time by logging into <a href="/">Manage teacher training applications</a>.</p>
+
+  <h2 class="govuk-heading-m">Next steps</h2>
+  <p class="govuk-body">Please get in touch with {{ application["personal-details"]["given-name"] }} to follow up on any conditions or recommendations you have set out.</p>
+  <p class="govuk-body">You can refer to these in the offer email we sent to the candidate (we cc’d you on this email).</p>
+  <p class="govuk-body">Please email us at <a href="mailto:mailto:becomingateacher@digital.education.gov.uk">becomingateacher@digital.education.gov.uk</a> when this candidate has met their conditions and has been enrolled. We can then pass their details on to our funding department at the Department for Education.</p>
+  <p class="govuk-body">Thank you for your continuing participation in piloting the DfE Apply service. If you have questions or concerns, please email <a href="mailto:mailto:becomingateacher@digital.education.gov.uk">becomingateacher@digital.education.gov.uk</a>.</p>
+  <p class="govuk-body">Regards,
+  <p class="govuk-body">Apply for teacher training<br>
+    Department for Education</p>
+{% endblock %}

--- a/app/views/email/candidate-declined-offer.njk
+++ b/app/views/email/candidate-declined-offer.njk
@@ -1,0 +1,17 @@
+{% extends "_email.njk" %}
+
+{% set application = data.applications[applicationId] %}
+{% set name = [application["personal-details"]["given-name"], application["personal-details"]["family-name"]] | join(" ") %}
+{% set title = "Manage teacher training applications: " + name + " has declined your offer to join " + application.course %}
+{% set from = "apply-for-teacher-training@education.gov.uk" %}
+{% set to = "admin@provider-name.example" %}
+
+{% block content %}
+  <p class="govuk-body">Dear [Provider name],</p>
+  <p class="govuk-body">We’re getting in touch to let you know that <strong>{{ name }}</strong> has declined your offer to join <strong>{{ application.course }}</strong>.
+  <p class="govuk-body">You can check candidate responses any time by logging into <a href="/">Manage teacher training applications</a>.</p>
+  <p class="govuk-body">Thank you for your continuing participation in piloting the DfE Apply service. If you have questions or concerns, please email <a href="mailto:becomingateacher@digital.education.gov.uk">becomingateacher@digital.education.gov.uk</a>.</p>
+  <p class="govuk-body">Regards,
+  <p class="govuk-body">Apply for teacher training<br>
+    Department for Education</p>
+{% endblock %}


### PR DESCRIPTION
- Email sent when candidate declines an offer
- Email sent when candidate accepts an offer.

Links to these emails are hidden in the UI. For an accepted or declined application, click on the status badge to see the respective message.

<img width="330" alt="Status badge" src="https://user-images.githubusercontent.com/813383/66827596-f180a580-ef46-11e9-85da-7e02acb880d2.png">
 