### PR TITLE
Add getting support answer to provider interface

### DIFF
--- a/app/data/applications.js
+++ b/app/data/applications.js
@@ -1821,6 +1821,7 @@ module.exports = {
       //   'postal-code': 'SO1  8UZ'
       // }
     },
+    'reasonable-adjustments': 'I currently require use of a wheelchair, so any interview location needs to be accessible. I should be back on my feet by the time I begin my training.',
     'work-history': {
       1: {
         role: 'Care Partner',

--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -2,5 +2,8 @@ const applications = require('./applications')
 
 module.exports = {
   applications,
-  bare: process.env.BARE
+  bare: process.env.BARE,
+  flags: {
+    interview_preferences: false
+  }
 }

--- a/app/views/_includes/application/personal-statement.njk
+++ b/app/views/_includes/application/personal-statement.njk
@@ -1,16 +1,20 @@
 {% set vocationKeyHtml %}
   <h3 class="govuk-heading-s govuk-!-margin-bottom-0">Vocation</h3>
-  <p class="govuk-hint">(Question to candidate:“Why do you want to be a teacher?”)</p>
+  <p class="govuk-hint">(Question to candidate: “Why do you want to be a teacher?”)</p>
 {% endset %}
 
 {% set subjectKnowledgeKeyHtml %}
   <h3 class="govuk-heading-s govuk-!-margin-bottom-0">Subject knowledge</h3>
-  <p class="govuk-hint">(Question to candidate:“Your knowledge about the subject you want to teach”)</p>
+  <p class="govuk-hint">(Question to candidate: “Your knowledge about the subject you want to teach”)</p>
+{% endset %}
+
+{% set supportKeyHtml %}
+  <h3 class="govuk-heading-s govuk-!-margin-bottom-0">Any support needed</h3>
 {% endset %}
 
 {% set miscellaneousKeyHtml %}
   <h3 class="govuk-heading-s govuk-!-margin-bottom-0">Additional information</h3>
-  <p class="govuk-hint">(Question to candidate:“Is there anything else you would like to tell us about your application?”)</p>
+  <p class="govuk-hint">(Question to candidate: “Is there anything else you would like to tell us about your application?”)</p>
 {% endset %}
 
 {{ govukSummaryList({
@@ -34,6 +38,13 @@
     },
     value: {
       html: application["personal-statement"].interview | nl2br or "—"
+    }
+  } if data.flags.interview_preferences == true, {
+    key: {
+      html: supportKeyHtml
+    },
+    value: {
+      html: application["reasonable-adjustments"] | nl2br or "—"
     }
   }, {
     key: {


### PR DESCRIPTION
Adds ‘Getting support to become a teacher’ question to view of application form that providers see:

<img width="1016" alt="Screenshot 2019-12-18 at 15 01 34" src="https://user-images.githubusercontent.com/813383/71101519-c3217f80-21ae-11ea-8887-052e6718e475.png">

At this stage, this is more about surfacing this answer in the provider interface. We need to carry out research about how best to present this information to providers.

See [corresponding PR for candidate application question](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training-prototype/pull/301).