### PR TITLE
Include suitability to work with children in provider view

### DIFF
--- a/app/views/_includes/application/personal-statement.njk
+++ b/app/views/_includes/application/personal-statement.njk
@@ -12,6 +12,11 @@
   <h3 class="govuk-heading-s govuk-!-margin-bottom-0">Any support needed</h3>
 {% endset %}
 
+{% set suitabilityKeyHtml %}
+  <h3 class="govuk-heading-s govuk-!-margin-bottom-0">Safeguarding</h3>
+  <p class="govuk-hint">We ask the candidate if they want to disclose anything before their DBS check.</p>
+{% endset %}
+
 {{ govukSummaryList({
   rows: [{
     key: {
@@ -40,6 +45,13 @@
     },
     value: {
       html: application["reasonable-adjustments"] | nl2br or "—"
+    }
+  }, {
+    key: {
+      html: suitabilityKeyHtml
+    },
+    value: {
+      html: application["suitability"] | nl2br or "Nothing disclosed"
     }
   }]
 }) }}


### PR DESCRIPTION
- Label suitability as "safeguarding" for providers, as it's a term they know and understand.
- Put the details at the bottom because:
   - most users won't complete these details
   - we don't want providers to reject candidates who do disclose something out of hand

Goes with https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training-prototype/pull/323

![Screen Shot 2020-01-21 at 09 38 37](https://user-images.githubusercontent.com/319055/72797727-8e836680-3c39-11ea-9444-49e790ecfb52.png)
