### PR TITLE
Show conditions on confirmation screens for marking as met/not met

### DIFF
--- a/app/views/application/confirm-conditions-met.njk
+++ b/app/views/application/confirm-conditions-met.njk
@@ -20,6 +20,12 @@
 
       {% include "_includes/application-summary.njk" %}
 
+      <h2 class="govuk-heading-l">Conditions</h2>
+
+      {{appTaskList({
+        items: conditions
+      })}}
+
       <form method="post">
         {{ govukButton({
           text: "Confirm"

--- a/app/views/application/confirm-conditions-not-met.njk
+++ b/app/views/application/confirm-conditions-not-met.njk
@@ -20,6 +20,12 @@
 
       {% include "_includes/application-summary.njk" %}
 
+      <h2 class="govuk-heading-l">Conditions</h2>
+
+      {{appTaskList({
+        items: conditions
+      })}}
+
       <form method="post">
         {{ govukButton({
           text: "Confirm",


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/37163/73651265-fdba7b00-467b-11ea-84fb-168d96b5f007.png)

After:
![image](https://user-images.githubusercontent.com/37163/73651248-f4c9a980-467b-11ea-87a8-20e13912e7ce.png)

Same for other path.