### PR TITLE
Content change course, location, provider

### DIFF
--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -197,7 +197,11 @@ module.exports = router => {
     if (decision === 'offer') {
       res.redirect(`/application/${applicationId}/offer`)
     } else if (decision === 'different-course') {
-        res.redirect(`/application/${applicationId}/different-course`)
+      res.redirect(`/application/${applicationId}/different-course/course`)
+    } else if (decision === 'different-location') {
+      res.redirect(`/application/${applicationId}/different-course/location`)
+    } else if (decision === 'different-provider') {
+      res.redirect(`/application/${applicationId}/different-course/provider`)
     } else {
       res.redirect(`/application/${applicationId}/reject`)
     }

--- a/app/routes/make-different-offer.js
+++ b/app/routes/make-different-offer.js
@@ -74,16 +74,16 @@ module.exports = router => {
     let furtherConditions = [];
 
     if (req.session.data['condition-1']) {
-      furtherConditions.push({ id: uuid(), description: req.session.data['condition-1'], met: false })
+      furtherConditions.push({ description: req.session.data['condition-1'] })
     }
     if (req.session.data['condition-2']) {
-      furtherConditions.push({ id: uuid(), description: req.session.data['condition-2'], met: false })
+      furtherConditions.push({ description: req.session.data['condition-2'] })
     }
     if (req.session.data['condition-3']) {
-      furtherConditions.push({ id: uuid(), description: req.session.data['condition-3'], met: false })
+      furtherConditions.push({ description: req.session.data['condition-3'] })
     }
     if (req.session.data['condition-4']) {
-      furtherConditions.push({ id: uuid(), description: req.session.data['condition-4'], met: false })
+      furtherConditions.push({ description: req.session.data['condition-4'] })
     }
 
     let recommendations = req.session.data.recommendations
@@ -107,22 +107,22 @@ module.exports = router => {
       return {
         id: uuid(),
         description: item,
-        complete: false
+        status: 'Pending'
       }
     })
 
     const conditions = []
     if (req.session.data['condition-1']) {
-      conditions.push({ id: uuid(), description: req.session.data['condition-1'], met: false })
+      conditions.push({ id: uuid(), description: req.session.data['condition-1'], status: 'Pending' })
     }
     if (req.session.data['condition-2']) {
-      conditions.push({ id: uuid(), description: req.session.data['condition-2'], met: false })
+      conditions.push({ id: uuid(), description: req.session.data['condition-2'], status: 'Pending' })
     }
     if (req.session.data['condition-3']) {
-      conditions.push({ id: uuid(), description: req.session.data['condition-3'], met: false })
+      conditions.push({ id: uuid(), description: req.session.data['condition-3'], status: 'Pending' })
     }
     if (req.session.data['condition-4']) {
-      conditions.push({ id: uuid(), description: req.session.data['condition-4'], met: false })
+      conditions.push({ id: uuid(), description: req.session.data['condition-4'], status: 'Pending' })
     }
     application.offer.conditions = conditions;
 

--- a/app/routes/make-offer.js
+++ b/app/routes/make-offer.js
@@ -27,16 +27,16 @@ module.exports = router => {
     let furtherConditions = [];
 
     if (req.session.data['condition-1']) {
-      furtherConditions.push({ id: uuid(), description: req.session.data['condition-1'], met: false })
+      furtherConditions.push({ description: req.session.data['condition-1']})
     }
     if (req.session.data['condition-2']) {
-      furtherConditions.push({ id: uuid(), description: req.session.data['condition-2'], met: false })
+      furtherConditions.push({ description: req.session.data['condition-2']})
     }
     if (req.session.data['condition-3']) {
-      furtherConditions.push({ id: uuid(), description: req.session.data['condition-3'], met: false })
+      furtherConditions.push({ description: req.session.data['condition-3']})
     }
     if (req.session.data['condition-4']) {
-      furtherConditions.push({ id: uuid(), description: req.session.data['condition-4'], met: false })
+      furtherConditions.push({ description: req.session.data['condition-4']})
     }
 
     let recommendations = req.session.data.recommendations
@@ -61,22 +61,22 @@ module.exports = router => {
       return {
         id: uuid(),
         description: item,
-        complete: false
+        status: 'Pending'
       }
     })
 
     const conditions = []
     if (req.session.data['condition-1']) {
-      conditions.push({ id: uuid(), description: req.session.data['condition-1'], met: false })
+      conditions.push({ id: uuid(), description: req.session.data['condition-1'], status: 'Pending' })
     }
     if (req.session.data['condition-2']) {
-      conditions.push({ id: uuid(), description: req.session.data['condition-2'], met: false })
+      conditions.push({ id: uuid(), description: req.session.data['condition-2'], status: 'Pending' })
     }
     if (req.session.data['condition-3']) {
-      conditions.push({ id: uuid(), description: req.session.data['condition-3'], met: false })
+      conditions.push({ id: uuid(), description: req.session.data['condition-3'], status: 'Pending' })
     }
     if (req.session.data['condition-4']) {
-      conditions.push({ id: uuid(), description: req.session.data['condition-4'], met: false })
+      conditions.push({ id: uuid(), description: req.session.data['condition-4'], status: 'Pending' })
     }
     application.offer.conditions = conditions;
 

--- a/app/views/application/decision.njk
+++ b/app/views/application/decision.njk
@@ -63,7 +63,8 @@
     {{ govukRadios({
       fieldset: {
         legend: {
-          html: "Choose response",
+          html: "Choose response (you'll be able to add conditions and recommendations)",
+
           classes: "govuk-fieldset__legend--m",
           isPageHeading: true
         }
@@ -73,21 +74,29 @@
       name: "decision",
       items: [{
         value: "offer",
-        text: "Make an offer for this course",
-        hint: {
-          text: "You'll be able to include any conditions or recommendations"
-        },
+        text: "Make an offer",
+
         checked: checked("decision", "offer")
-      }, {
+      },
+      {
+        value: "offer",
+        text: "Make an offer but change course",
+
+        checked: checked("decision", "offer")
+      },{
+        value: "offer",
+        text: "Make an offer but change location",
+
+        checked: checked("decision", "offer")
+      },
+      {
         value: "different-course",
-        text: "Make an offer for a different course",
-        hint: {
-          text: "You'll be able to include any conditions or recommendations"
-        },
+        text: "Make an offer but change training provider",
+
         checked: checked("decision", "different-offer")
       }, {
         value: "reject",
-        text: "Reject this application",
+        text: "Reject application",
         checked: checked("decision", "reject")
       }]
     }) }}

--- a/app/views/application/decision.njk
+++ b/app/views/application/decision.njk
@@ -63,8 +63,7 @@
     {{ govukRadios({
       fieldset: {
         legend: {
-          html: "Choose response (you'll be able to add conditions and recommendations)",
-
+          html: "Choose response",
           classes: "govuk-fieldset__legend--m",
           isPageHeading: true
         }
@@ -79,21 +78,20 @@
         checked: checked("decision", "offer")
       },
       {
-        value: "offer",
+        value: "different-course",
         text: "Make an offer but change course",
 
-        checked: checked("decision", "offer")
+        checked: checked("decision", "different-course")
       },{
-        value: "offer",
+        value: "different-location",
         text: "Make an offer but change location",
 
-        checked: checked("decision", "offer")
+        checked: checked("decision", "different-location")
       },
       {
-        value: "different-course",
+        value: "different-provider",
         text: "Make an offer but change training provider",
-
-        checked: checked("decision", "different-offer")
+        checked: checked("decision", "different-provider")
       }, {
         value: "reject",
         text: "Reject application",

--- a/app/views/application/different-course--conditions.njk
+++ b/app/views/application/different-course--conditions.njk
@@ -89,7 +89,6 @@
           }
         }) }}
 
-
         {{ govukButton({
           text: "Continue"
         }) }}

--- a/app/views/application/different-course--confirm.njk
+++ b/app/views/application/different-course--confirm.njk
@@ -7,7 +7,7 @@
 
 {% block pageNavigation %}
   {{ govukBackLink({
-    href: "/application/" + application.id + '/mark-conditions'
+    href: "/application/" + application.id + '/different-course/conditions'
   }) }}
 {% endblock %}
 

--- a/app/views/application/different-course--provider.njk
+++ b/app/views/application/different-course--provider.njk
@@ -2,7 +2,7 @@
 
 {% set application = applications[applicationId] %}
 {% set name = [application["personal-details"]["given-name"], application["personal-details"]["family-name"]] | join(" ") %}
-{% set title = "Choose provider" %}
+{% set title = "Change training provider" %}
 
 {% block pageNavigation %}
   {{ govukBackLink({
@@ -12,7 +12,9 @@
 
 {% block content %}
 
+
   <h1 class="govuk-heading-xl">{{title}}</h1>
+  <h2 class="govuk-heading-m">Current candidate choices</h2>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       {% include "_includes/application-summary.njk" %}
@@ -21,7 +23,7 @@
         {{ govukRadios({
           fieldset: {
             legend: {
-              html: "Select training provider",
+              html: "Select alternative provider",
               classes: "govuk-fieldset__legend--m"
             }
           },


### PR DESCRIPTION
Better UX to edit course, location, provider

Hi @adamsilver 
I tweaked the order again because although location seems less important than course we show them as course, location and provider and I feel we should be consistent. From candidate POV where they train probably just as important as what.
Have done some words – this bit should be body copy:
**(you'll be able to add conditions and recommendations)**

![Screenshot 2020-02-18 at 12 17 39](https://user-images.githubusercontent.com/38726669/74735481-af46d800-5248-11ea-89ea-259292c992cd.png)

Then further into the journey it should be something like (have done this for training provider but not others:

Change training provider
Current candidate choices
Select alternative provider

Change course
Current candidate choices
Select alternative course

Change location
Current candidate choices
Select alternative location

At this point, we shouldn't present the current training provider as an option should we? Just alternatives:
![Screenshot 2020-02-18 at 12 20 08](https://user-images.githubusercontent.com/38726669/74735651-077dda00-5249-11ea-8118-0d642841143d.png)





