### PR TITLE
Make ‘change offer’ flows consistent with ‘Make offer’ flows

### DIFF
--- a/app/views/_includes/offer-summary.njk
+++ b/app/views/_includes/offer-summary.njk
@@ -1,31 +1,24 @@
 {{ govukSummaryList({
-        rows: [{
-          key: {
-            text: "Candidate name"
-          },
-          value: {
-            text: name
-          }
-        }, {
-          key: {
-            text: "Provider"
-          },
-          value: {
-            html: application.provider
-          }
-        }, {
-          key: {
-            text: "Course"
-          },
-          value: {
-            html: application.course
-          }
-        }, {
-          key: {
-            text: "Location"
-          },
-          value: {
-            html: "Alliance Academy, Edgeware, Road Name, SW1 1AA"
-          }
-        }
-      ]}) }}
+  rows: [{
+    key: {
+      text: "Provider"
+    },
+    value: {
+      html: application.provider
+    }
+  }, {
+    key: {
+      text: "Course"
+    },
+    value: {
+      html: application.course
+    }
+  }, {
+    key: {
+      text: "Location"
+    },
+    value: {
+      html: "Alliance Academy, Edgeware, Road Name, SW1 1AA"
+    }
+  }
+]}) }}

--- a/app/views/offer/change-course/confirm.njk
+++ b/app/views/offer/change-course/confirm.njk
@@ -15,7 +15,7 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-
+      <span class="govuk-caption-xl">{{name}}</span>
       <h1 class="govuk-heading-xl">{{title}}</h1>
 
       <h2 class="govuk-heading-l">Your existing offer</h2>
@@ -26,13 +26,6 @@
 
       {{ govukSummaryList({
         rows: [{
-          key: {
-            text: "Candidate name"
-          },
-          value: {
-            text: name
-          }
-        }, {
           key: {
             text: "Provider"
           },
@@ -45,6 +38,15 @@
           },
           value: {
             html: data.course
+          },
+          actions: {
+            items: [
+              {
+                href: "/application/" + application.id + "/offer/change-course",
+                text: "Change",
+                visuallyHiddenText: "location"
+              }
+            ]
           }
         }, {
           key: {
@@ -52,6 +54,15 @@
           },
           value: {
             html: data.location
+          },
+          actions: {
+            items: [
+              {
+                href: "/application/" + application.id + "/offer/change-course/location",
+                text: "Change",
+                visuallyHiddenText: "location"
+              }
+            ]
           }
         }
       ]}) }}

--- a/app/views/offer/change-course/course.njk
+++ b/app/views/offer/change-course/course.njk
@@ -2,7 +2,7 @@
 
 {% set application = applications[applicationId] %}
 {% set name = [application["personal-details"]["given-name"], application["personal-details"]["family-name"]] | join(" ") %}
-{% set title = "Select alternative course" %}
+{% set title = "Change course" %}
 
 {% block pageNavigation %}
   {{ govukBackLink({

--- a/app/views/offer/change-course/course.njk
+++ b/app/views/offer/change-course/course.njk
@@ -2,7 +2,7 @@
 
 {% set application = applications[applicationId] %}
 {% set name = [application["personal-details"]["given-name"], application["personal-details"]["family-name"]] | join(" ") %}
-{% set title = "Make an offer but change course" %}
+{% set title = "Select alternative course" %}
 
 {% block pageNavigation %}
   {{ govukBackLink({
@@ -11,18 +11,20 @@
 {% endblock %}
 
 {% block content %}
-  <h1 class="govuk-heading-xl">{{title}}</h1>
-  <h2 class="govuk-heading-m">Your existing offer</h2>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      {% include "_includes/offer-summary.njk" %}
+      {% set h1 %}
+        <span class="govuk-caption-xl">{{name}}</span>
+        {{title}}
+      {% endset %}
       <form method="post">
 
         {{ govukRadios({
           fieldset: {
             legend: {
-              html: "Select course",
-              classes: "govuk-fieldset__legend--m"
+              html: h1,
+              isPageheading: true,
+              classes: "govuk-fieldset__legend--xl"
             }
           },
           idPrefix: "course",

--- a/app/views/offer/change-course/location.njk
+++ b/app/views/offer/change-course/location.njk
@@ -2,7 +2,7 @@
 
 {% set application = applications[applicationId] %}
 {% set name = [application["personal-details"]["given-name"], application["personal-details"]["family-name"]] | join(" ") %}
-{% set title = "Choose location" %}
+{% set title = "Select location" %}
 
 {% block pageNavigation %}
   {{ govukBackLink({
@@ -11,18 +11,20 @@
 {% endblock %}
 
 {% block content %}
-  <h1 class="govuk-heading-xl">{{title}}</h1>
-  <h2 class="govuk-heading-m">Your existing offer</h2>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      {% include "_includes/offer-summary.njk" %}
+      {% set h1 %}
+        <span class="govuk-caption-xl">{{name}}</span>
+        {{title}}
+      {% endset %}
       <form method="post">
 
         {{ govukRadios({
           fieldset: {
             legend: {
-              html: "Select location",
-              classes: "govuk-fieldset__legend--m"
+              html: h1,
+              isPageHeading: true,
+              classes: "govuk-fieldset__legend--xl"
             }
           },
           idPrefix: "location",

--- a/app/views/offer/change-location/confirm.njk
+++ b/app/views/offer/change-location/confirm.njk
@@ -15,7 +15,7 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-
+      <span class="govuk-caption-xl">{{name}}</span>
       <h1 class="govuk-heading-xl">{{title}}</h1>
 
       <h2 class="govuk-heading-l">Your existing offer</h2>
@@ -26,13 +26,6 @@
 
       {{ govukSummaryList({
         rows: [{
-          key: {
-            text: "Candidate name"
-          },
-          value: {
-            text: name
-          }
-        }, {
           key: {
             text: "Provider"
           },
@@ -52,6 +45,15 @@
           },
           value: {
             html: data.location
+          },
+          actions: {
+            items: [
+              {
+                href: "/application/" + application.id + "/offer/change-location",
+                text: "Change",
+                visuallyHiddenText: "location"
+              }
+            ]
           }
         }
       ]}) }}

--- a/app/views/offer/change-location/location.njk
+++ b/app/views/offer/change-location/location.njk
@@ -2,7 +2,7 @@
 
 {% set application = applications[applicationId] %}
 {% set name = [application["personal-details"]["given-name"], application["personal-details"]["family-name"]] | join(" ") %}
-{% set title = "Select alternative location" %}
+{% set title = "Change location" %}
 
 {% block pageNavigation %}
   {{ govukBackLink({

--- a/app/views/offer/change-location/location.njk
+++ b/app/views/offer/change-location/location.njk
@@ -2,7 +2,7 @@
 
 {% set application = applications[applicationId] %}
 {% set name = [application["personal-details"]["given-name"], application["personal-details"]["family-name"]] | join(" ") %}
-{% set title = "Change location" %}
+{% set title = "Select alternative location" %}
 
 {% block pageNavigation %}
   {{ govukBackLink({
@@ -11,18 +11,20 @@
 {% endblock %}
 
 {% block content %}
-  <h1 class="govuk-heading-xl">{{title}}</h1>
-  <h2 class="govuk-heading-m">Your existing offer</h2>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      {% include "_includes/offer-summary.njk" %}
+      {% set h1 %}
+        <span class="govuk-caption-xl">{{name}}</span>
+        {{title}}
+      {% endset %}
       <form method="post">
 
         {{ govukRadios({
           fieldset: {
             legend: {
-              html: "Select location",
-              classes: "govuk-fieldset__legend--m"
+              html: h1,
+              isPageHeading: true,
+              classes: "govuk-fieldset__legend--xl"
             }
           },
           idPrefix: "location",

--- a/app/views/offer/change-provider/confirm.njk
+++ b/app/views/offer/change-provider/confirm.njk
@@ -7,7 +7,7 @@
 
 {% block pageNavigation %}
   {{ govukBackLink({
-    href: "/application/" + application.id + '/offer/change-provider/conditions'
+    href: "/application/" + application.id + '/offer/change-provider/location'
   }) }}
 {% endblock %}
 

--- a/app/views/offer/change-provider/confirm.njk
+++ b/app/views/offer/change-provider/confirm.njk
@@ -15,7 +15,7 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-
+      <span class="govuk-caption-xl">{{name}}</span>
       <h1 class="govuk-heading-xl">{{title}}</h1>
 
       <h2 class="govuk-heading-l">Your existing offer</h2>
@@ -27,17 +27,19 @@
       {{ govukSummaryList({
         rows: [{
           key: {
-            text: "Candidate name"
-          },
-          value: {
-            text: name
-          }
-        }, {
-          key: {
             text: "Provider"
           },
           value: {
             html: data.trainingprovider
+          },
+          actions: {
+            items: [
+              {
+                href: "/application/" + application.id + "/offer/change-provider",
+                text: "Change",
+                visuallyHiddenText: "provider"
+              }
+            ]
           }
         }, {
           key: {
@@ -45,6 +47,15 @@
           },
           value: {
             html: data.course
+          },
+          actions: {
+            items: [
+              {
+                href: "/application/" + application.id + "/offer/change-provider/course",
+                text: "Change",
+                visuallyHiddenText: "course"
+              }
+            ]
           }
         }, {
           key: {
@@ -52,6 +63,15 @@
           },
           value: {
             html: data.location
+          },
+          actions: {
+            items: [
+              {
+                href: "/application/" + application.id + "/offer/change-provider/location",
+                text: "Change",
+                visuallyHiddenText: "location"
+              }
+            ]
           }
         }
       ]}) }}

--- a/app/views/offer/change-provider/course.njk
+++ b/app/views/offer/change-provider/course.njk
@@ -2,7 +2,7 @@
 
 {% set application = applications[applicationId] %}
 {% set name = [application["personal-details"]["given-name"], application["personal-details"]["family-name"]] | join(" ") %}
-{% set title = "Choose new course" %}
+{% set title = "Select course" %}
 
 {% block pageNavigation %}
   {{ govukBackLink({
@@ -11,18 +11,21 @@
 {% endblock %}
 
 {% block content %}
-  <h1 class="govuk-heading-xl">{{title}}</h1>
-  <h2 class="govuk-heading-m">Your existing offer</h2>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      {% include "_includes/offer-summary.njk" %}
+      {% set h1 %}
+        <span class="govuk-caption-xl">{{name}}</span>
+        {{title}}
+      {% endset %}
+
       <form method="post">
 
         {{ govukRadios({
           fieldset: {
             legend: {
-              html: "Select course",
-              classes: "govuk-fieldset__legend--m"
+              html: h1,
+              isPageHeading: true,
+              classes: "govuk-fieldset__legend--xl"
             }
           },
           idPrefix: "course",

--- a/app/views/offer/change-provider/location.njk
+++ b/app/views/offer/change-provider/location.njk
@@ -2,7 +2,7 @@
 
 {% set application = applications[applicationId] %}
 {% set name = [application["personal-details"]["given-name"], application["personal-details"]["family-name"]] | join(" ") %}
-{% set title = "Choose new location" %}
+{% set title = "Select location" %}
 
 {% block pageNavigation %}
   {{ govukBackLink({
@@ -11,18 +11,21 @@
 {% endblock %}
 
 {% block content %}
-  <h1 class="govuk-heading-xl">{{title}}</h1>
-  <h2 class="govuk-heading-m">Your existing offer</h2>
+
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      {% include "_includes/offer-summary.njk" %}
+      {% set h1 %}
+        <span class="govuk-caption-xl">{{name}}</span>
+        {{title}}
+      {% endset %}
       <form method="post">
 
         {{ govukRadios({
           fieldset: {
             legend: {
-              html: "Select location",
-              classes: "govuk-fieldset__legend--m"
+              html: h1,
+              isPageHeading: true,
+              classes: "govuk-fieldset__legend--xl"
             }
           },
           idPrefix: "location",

--- a/app/views/offer/change-provider/provider.njk
+++ b/app/views/offer/change-provider/provider.njk
@@ -2,7 +2,7 @@
 
 {% set application = applications[applicationId] %}
 {% set name = [application["personal-details"]["given-name"], application["personal-details"]["family-name"]] | join(" ") %}
-{% set title = "Change training provider" %}
+{% set title = "Select alternative training provider" %}
 
 {% block pageNavigation %}
   {{ govukBackLink({
@@ -11,18 +11,20 @@
 {% endblock %}
 
 {% block content %}
-  <h1 class="govuk-heading-xl">{{title}}</h1>
-  <h2 class="govuk-heading-m">Your existing offer</h2>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      {% include "_includes/offer-summary.njk" %}
+      {% set h1 %}
+        <span class="govuk-caption-xl">{{name}}</span>
+        {{title}}
+      {% endset %}
       <form method="post">
 
         {{ govukRadios({
           fieldset: {
             legend: {
-              html: "Select alternative provider",
-              classes: "govuk-fieldset__legend--m"
+              html: h1,
+              isPageHeading: true,
+              classes: "govuk-fieldset__legend--xl"
             }
           },
           idPrefix: "trainingprovider",

--- a/app/views/offer/change-provider/provider.njk
+++ b/app/views/offer/change-provider/provider.njk
@@ -2,7 +2,7 @@
 
 {% set application = applications[applicationId] %}
 {% set name = [application["personal-details"]["given-name"], application["personal-details"]["family-name"]] | join(" ") %}
-{% set title = "Select alternative training provider" %}
+{% set title = "Change training provider" %}
 
 {% block pageNavigation %}
   {{ govukBackLink({


### PR DESCRIPTION
- Deduped candidate name on check screens
- Add standard change links on check answers page
- Match content where possible with make offer flows