### PR TITLE
Adam titan permissions

### DIFF
--- a/app/routes/users.js
+++ b/app/routes/users.js
@@ -36,8 +36,12 @@ module.exports = router => {
   })
 
   router.post('/users/new', (req, res) => {
+    res.redirect(`/users/new-check`);
+  })
+
+  router.post('/users/new-check', (req, res) => {
     req.flash('success', 'user-invited');
-    res.redirect(`/users`);
+    res.redirect(`/users/`);
   })
 
   router.post('/users/change-name', (req, res) => {

--- a/app/views/onboard/index.njk
+++ b/app/views/onboard/index.njk
@@ -1,0 +1,47 @@
+{% extends "_content-wide.njk" %}
+
+{% set title = "Set up relationships for Titan Partnership Ltd" %}
+
+{% block pageNavigation %}
+  {# {{ govukBackLink({
+    href: "/users/"
+  }) }} #}
+{% endblock %}
+
+{% block primary %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <form novalidate action="/onboard/step2">
+        <h2 class="govuk-heading-m">For courses ratified by Titan Partnership Ltd</h2>
+
+        {{ govukCheckboxes({
+          idPrefix: "permissions",
+          name: "permissions",
+          fieldset: {
+            legend: {
+              html: "Titan Partnership Ltd can",
+              classes: "govuk-fieldset__legend--s"
+            }
+          },
+          items: [
+            {
+              value: "Make decisions",
+              text: "Make decisions"
+            },
+            {
+              value: "See safeguarding information",
+              text: "See safeguarding information"
+            }
+          ]
+        }) }}
+
+        {{govukButton({
+          text: "Continue"
+        })}}
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/onboard/step2.njk
+++ b/app/views/onboard/step2.njk
@@ -1,0 +1,68 @@
+{% extends "_content-wide.njk" %}
+
+{% set title = "Set up relationships for Aston Manor Academy" %}
+
+{% block pageNavigation %}
+  {{ govukBackLink({
+    href: "/onboard/"
+  }) }}
+{% endblock %}
+
+{% block primary %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <form novalidate action="/onboard/step3">
+        <h2 class="govuk-heading-m">For courses ratified by Titan Partnership Ltd</h2>
+
+        {{ govukCheckboxes({
+          idPrefix: "permissions",
+          name: "permissions",
+          fieldset: {
+            legend: {
+              html: "Titan Partnership Ltd can",
+              classes: "govuk-fieldset__legend--s"
+            }
+          },
+          items: [
+            {
+              value: "Make decisions",
+              text: "Make decisions"
+            },
+            {
+              value: "See safeguarding information",
+              text: "See safeguarding information"
+            }
+          ]
+        }) }}
+
+        {{ govukCheckboxes({
+          idPrefix: "permissions",
+          name: "permissions",
+          fieldset: {
+            legend: {
+              html: "Aston Manor Academy can",
+              classes: "govuk-fieldset__legend--s"
+            }
+          },
+          items: [
+            {
+              value: "Make decisions",
+              text: "Make decisions"
+            },
+            {
+              value: "See safeguarding information",
+              text: "See safeguarding information"
+            }
+          ]
+        }) }}
+
+        {{govukButton({
+          text: "Continue"
+        })}}
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/onboard/step3.njk
+++ b/app/views/onboard/step3.njk
@@ -1,0 +1,93 @@
+{% extends "_content-wide.njk" %}
+
+{% set title = "Check permissions before saving them" %}
+
+{% block pageNavigation %}
+  {{ govukBackLink({
+    href: "/onboard/step2"
+  }) }}
+{% endblock %}
+
+{% block primary %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <form novalidate action="/">
+
+        <h2 class="govuk-heading-l">Relationships for Titan Partnership Ltd</h2>
+
+        {% set permissionsOneHtml %}
+          <p>Titan Partnership Ltd can:</p>
+          <ul class="list list--bullet">
+            <li>make decisions</li>
+            <li>see safeguarding information</li>
+          </ul>
+        {% endset %}
+        {{ govukSummaryList({
+          rows: [
+            {
+              key: {
+                text: "For courses ratified by Titan Partnership Ltd"
+              },
+              value: {
+                html: permissionsOneHtml
+              },
+              actions: {
+                items: [
+                  {
+                    href: "/onboard",
+                    text: "Change",
+                    visuallyHiddenText: "name"
+                  }
+                ]
+              }
+            }
+          ]
+        }) }}
+
+        <h2 class="govuk-heading-l">Relationships for Aston Manor Academy</h2>
+
+        {% set permissionsTwoHtml %}
+          <p>Titan Partnership Ltd can:</p>
+          <ul class="list list--bullet">
+            <li>make decisions</li>
+            <li>see safeguarding information</li>
+          </ul>
+
+          <p>Aston Manor Academy can:</p>
+          <ul class="list list--bullet">
+            <li>make decisions</li>
+            <li>see safeguarding information</li>
+          </ul>
+        {% endset %}
+        {{ govukSummaryList({
+          rows: [
+            {
+              key: {
+                text: "For courses ratified by Titan Partnership Ltd"
+              },
+              value: {
+                html: permissionsTwoHtml
+              },
+              actions: {
+                items: [
+                  {
+                    href: "/onboard/step2",
+                    text: "Change",
+                    visuallyHiddenText: "name"
+                  }
+                ]
+              }
+            }
+          ]
+        }) }}
+
+        {{govukButton({
+          text: "Save permissions"
+        })}}
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/users/index.njk
+++ b/app/views/users/index.njk
@@ -19,18 +19,18 @@
       })}}
       <div class="app-application-card">
         <div>
-          <h2 class="govuk-heading-m govuk-!-margin-bottom-1"><a class="govuk-link govuk-link--no-visited-state" href="/users/show">Harry Potter</a></h2>
-          <p class="govuk-!-margin-bottom-1">harry.potter@wizardschool.com</p>
-          <p class="govuk-!-font-size-16 govuk-caption-m govuk-!-margin-bottom-0">Somerset SCITT consortium and one more</p>
+          <h2 class="govuk-heading-m govuk-!-margin-bottom-1"><a class="govuk-link govuk-link--no-visited-state" href="/users/show">Ross Anderson</a></h2>
+          <p class="govuk-!-margin-bottom-1">ross.anderson@titan.org.uk</p>
+          <p class="govuk-!-font-size-16 govuk-caption-m govuk-!-margin-bottom-0">Aston Manor Academy and Titan Partnership Ltd</p>
         </div>
       </div>
-      <div class="app-application-card">
+      {# <div class="app-application-card">
         <div>
           <h2 class="govuk-heading-m govuk-!-margin-bottom-1"><a class="govuk-link govuk-link--no-visited-state" href="/users/show">Hermione Granger</a></h2>
           <p class="govuk-!-margin-bottom-1">hermione.granger@wizardschool.com</p>
           <p class="govuk-!-font-size-16 govuk-caption-m govuk-!-margin-bottom-0">Somerset SCITT consortium and one more</p>
         <div>
-      </div>
+      </div> #}
     </div>
   </div>
 

--- a/app/views/users/new-check.njk
+++ b/app/views/users/new-check.njk
@@ -5,7 +5,7 @@
 
 {% block pageNavigation %}
   {{ govukBackLink({
-    href: "/users/"
+    href: "/users/new"
   }) }}
 {% endblock %}
 

--- a/app/views/users/new-check.njk
+++ b/app/views/users/new-check.njk
@@ -1,0 +1,131 @@
+{% extends "_content-wide.njk" %}
+
+{% set primaryNavId = 'users' %}
+{% set title = "Check details before you send the invite" %}
+
+{% block pageNavigation %}
+  {{ govukBackLink({
+    href: "/users/"
+  }) }}
+{% endblock %}
+
+{% block primary %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      {% set permissionsHtml %}
+        <p>Aston Manor Academy</p>
+        <ul class="govuk-list govuk-list--bullet">
+          <li>manage organisation</li>
+          <li>manage users</li>
+          <li>make decisions</li>
+        </ul>
+
+        <p>Titan Partnership Ltd</p>
+        <ul class="govuk-list govuk-list--bullet">
+          <li>manage organisation</li>
+          <li>manage users</li>
+          <li>make decisions</li>
+        </ul>
+      {% endset %}
+
+      {{ govukSummaryList({
+        rows: [
+          {
+            key: {
+              text: "First name"
+            },
+            value: {
+              text: "Bill"
+            },
+            actions: {
+              items: [
+                {
+                  href: "/users/new",
+                  text: "Change",
+                  visuallyHiddenText: "name"
+                }
+              ]
+            }
+          },
+          {
+            key: {
+              text: "Last name"
+            },
+            value: {
+              text: "Wessel"
+            },
+            actions: {
+              items: [
+                {
+                  href: "/users/new",
+                  text: "Change",
+                  visuallyHiddenText: "name"
+                }
+              ]
+            }
+          },
+          {
+            key: {
+              text: "Email address"
+            },
+            value: {
+              text: "bill.wessel@titan.org.uk"
+            },
+            actions: {
+              items: [
+                {
+                  href: "/users/new",
+                  text: "Change",
+                  visuallyHiddenText: "date of birth"
+                }
+              ]
+            }
+          },
+          {
+            key: {
+              text: "Permissions"
+            },
+            value: {
+              html: permissionsHtml
+            },
+            actions: {
+              items: [
+                {
+                  href: "/users/new",
+                  text: "Change",
+                  visuallyHiddenText: "contact information"
+                }
+              ]
+            }
+          }
+        ]
+      }) }}
+
+
+      <h2 class="govuk-heading-l">What Bill will be able to do</h2>
+
+      <p>For Aston Manor Academy, he’ll be able to:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>manage organisation</li>
+        <li>manage users</li>
+        <li>make decisions</li>
+      </ul>
+
+      <p>For Titan Partnership Ltd, he’ll be able to:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>manage organisation</li>
+        <li>manage users</li>
+        <li>make decisions</li>
+      </ul>
+
+      <form novalidate method="post">
+        {{govukButton({
+          text: "Invite user"
+        })}}
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/users/new.njk
+++ b/app/views/users/new.njk
@@ -68,6 +68,13 @@
             },
             items: [
               {
+                value: "Manage organisation",
+                text: "Manage organisation",
+                hint: {
+                  text: "Setup relationships and configure offer conditions"
+                }
+              },
+              {
                 value: "Manage users",
                 text: "Manage users",
                 hint: {
@@ -79,6 +86,13 @@
                 text: "Make decisions",
                 hint: {
                   text: "Make and change offers"
+                }
+              },
+              {
+                value: "See safeguarding information",
+                text: "See safeguarding information",
+                hint: {
+                  text: "See safeguarding information that candidates disclose in their application"
                 }
               }
             ]
@@ -97,6 +111,13 @@
             },
             items: [
               {
+                value: "Manage organisation",
+                text: "Manage organisation",
+                hint: {
+                  text: "Setup relationships and configure offer conditions"
+                }
+              },
+              {
                 value: "Manage users",
                 text: "Manage users",
                 hint: {
@@ -109,6 +130,13 @@
                 hint: {
                   text: "Make and change offers"
                 }
+              },
+              {
+                value: "See safeguarding information",
+                text: "See safeguarding information",
+                hint: {
+                  text: "See safeguarding information that candidates disclose in their application"
+                }
               }
             ]
           }) }}
@@ -119,24 +147,24 @@
           name: "provider",
           fieldset: {
             legend: {
-              text: "Permissions",
+              text: "Providers",
               classes: "govuk-fieldset__legend--m"
             }
           },
           hint: {
-            text: "Select at least one provider"
+            text: "Select at least one provider this user will have access to"
           },
           items: [
             {
-              value: "Somerset SCITT consortium",
-              text: "Somerset SCITT consortium",
+              value: "Aston Manor Academy",
+              text: "Aston Manor Academy",
               conditional: {
                 html: p1PermissionsHtml
               }
             },
             {
-              value: "The Beach Teaching School",
-              text: "The Beach Teaching School",
+              value: "Titan Partnership Ltd",
+              text: "Titan Partnership Ltd",
               conditional: {
                 html: p2PermissionsHtml
               }

--- a/app/views/users/new.njk
+++ b/app/views/users/new.njk
@@ -173,7 +173,7 @@
         }) }}
 
         {{govukButton({
-          text: "Invite user"
+          text: "Continue"
         })}}
       </form>
     </div>


### PR DESCRIPTION
- Add flow for onboarding (setting up relationships between organisations)
- Update add user flow to reflect new organisation relationships

## org

![image](https://user-images.githubusercontent.com/37163/79362100-12e63c80-7f3e-11ea-9e94-c9814e876723.png)

![image](https://user-images.githubusercontent.com/37163/79362119-18dc1d80-7f3e-11ea-803c-f7e7733c7443.png)

![image](https://user-images.githubusercontent.com/37163/79362135-1ed1fe80-7f3e-11ea-871f-c64f99f88904.png)

## User

![image](https://user-images.githubusercontent.com/37163/79362695-d0712f80-7f3e-11ea-89f7-9cd0d83f6409.png)

![image](https://user-images.githubusercontent.com/37163/79362673-c94a2180-7f3e-11ea-9330-61c15be1f660.png)

## Notes

- This is a very first stab just to get some feedback from users
- Content needs work for sure
- The check answers screen for adding users isn't clear enough. In this example especially, it just duplicates what's in the summary list above. If we can iterate this in the morning, fab.

cc @billwessel-dfe @laurahermionetennant92 

