### PR TITLE
Add location name to card and details and add filter

### DIFF
--- a/app/data/applications.js
+++ b/app/data/applications.js
@@ -6,6 +6,7 @@ module.exports = {
     accreditingbody: "Somerset SCITT Consortium",
     provider: 'Somerset SCITT Consortium',
     course: 'Primary (3-7) (X121)',
+    locationname: 'Lingfield - training location',
     submittedDate: '2019-07-15',
     status: 'Accepted',
     notes: {
@@ -73,6 +74,7 @@ module.exports = {
     accreditingbody: "Somerset SCITT Consortium",
     provider: 'Somerset SCITT Consortium',
     course: 'Primary (5-11) (X100)',
+    locationname: 'Lingfield - training location',
     submittedDate: '2019-07-15',
     status: 'Conditions met',
     offer: {
@@ -133,6 +135,7 @@ module.exports = {
     accreditingbody: "Somerset SCITT Consortium",
     provider: 'Growing Expert Teachers',
     course: 'Primary (2S8T)',
+    locationname: 'Main site',
     submittedDate: '2019-07-15',
     status: 'Enrolled',
     notes: {
@@ -202,6 +205,7 @@ module.exports = {
     accreditingbody: "Somerset SCITT Consortium",
     provider: 'Growing Expert Teachers',
     course: 'Primary (2S8T)',
+    locationname: 'Main site',
     submittedDate: '2019-07-15',
     status: 'Conditions not met',
     offer: {
@@ -262,6 +266,7 @@ module.exports = {
     accreditingbody: "Somerset SCITT Consortium",
     provider: 'The Beach Teaching School',
     course: 'Primary (2YQN)',
+    locationname: 'Epsom Grinstead - training location',
     submittedDate: '2019-07-15',
     status: 'Rejected',
     rejectedDate: '2019-08-10',
@@ -361,6 +366,7 @@ module.exports = {
     accreditingbody: "Somerset SCITT Consortium",
     provider: 'The Beach Teaching School',
     course: 'Primary (2YQN)',
+    locationname: 'Camberley - training location',
     submittedDate: '2019-08-15',
     status: 'Declined',
     offer: {
@@ -420,6 +426,7 @@ module.exports = {
     accreditingbody: "Somerset SCITT Consortium",
     provider: 'Taunton Teaching Alliance',
     course: 'Primary (2RQM)',
+    locationname: 'Camberley - training location',
     submittedDate: '2019-09-15',
     withdrawnDate: '2019-09-16',
     status: 'Application withdrawn',
@@ -474,6 +481,7 @@ module.exports = {
     accreditingbody: "Somerset SCITT Consortium",
     provider: 'Taunton Teaching Alliance',
     course: 'Primary (2RQM)',
+    locationname: 'Main site',
 
     submittedDate: '2019-09-01',
     status: 'Offer withdrawn',
@@ -769,6 +777,7 @@ module.exports = {
     accreditingbody: "Somerset SCITT Consortium",
     provider: 'Taunton Teaching Alliance',
     course: 'Primary (2RQM)',
+    locationname: 'Main site',
     submittedDate: '2019-09-01',
     status: 'Offered',
     offer: {
@@ -874,7 +883,7 @@ module.exports = {
         missing: false,
         grade: 'B',
         year: '1997'
-      }      
+      }
     },
     'other-qualifications': {
       1: {
@@ -1016,6 +1025,7 @@ module.exports = {
     accreditingbody: "Somerset SCITT Consortium",
     provider: 'Ventrus Teaching School Alliance',
     course: 'Primary (32VP)',
+    locationname: 'Camberley - training location',
     submittedDate: '2019-09-16',
     status: 'Offered',
     offer: {
@@ -1279,6 +1289,7 @@ module.exports = {
     accreditingbody: "Somerset SCITT Consortium",
     provider: 'Ventrus Teaching School Alliance',
     course: 'Primary (32VP)',
+    locationname: 'Main site',
     submittedDate: '2019-09-18',
     status: 'New',
     'personal-details': {
@@ -1503,6 +1514,7 @@ module.exports = {
     accreditingbody: "Somerset SCITT Consortium",
     provider: 'Ventrus Teaching School Alliance',
     course: 'Primary (32VP)',
+    locationname: 'Main site',
     submittedDate: '2019-09-21',
     status: 'New',
     'personal-details': {
@@ -1689,6 +1701,7 @@ module.exports = {
     accreditingbody: "Somerset SCITT Consortium",
     provider: 'Taunton Teaching Alliance',
     course: 'Primary (2MKC)',
+    locationname: 'Main site',
     submittedDate: '2019-10-08',
     status: 'New',
     notes: {
@@ -1903,6 +1916,7 @@ module.exports = {
     accreditingbody: "Somerset SCITT Consortium",
     provider: 'Somerset SCITT Consortium',
     course: 'Primary (3-7) (X121)',
+    locationname: 'Main site',
     submittedDate: '2019-10-10',
     status: 'New',
     'personal-details': {

--- a/app/data/applications.js
+++ b/app/data/applications.js
@@ -4,7 +4,7 @@ module.exports = {
   "GH12354": {
     id: "GH12354",
     accreditingbody: "Somerset SCITT Consortium",
-    provider: 'Somerset SCITT Consortium',
+    provider: 'Growing Expert Teachers',
     course: 'Primary (3-7) (X121)',
     locationname: 'Lingfield - training location',
     submittedDate: '2019-07-15',
@@ -264,7 +264,7 @@ module.exports = {
   "PL098988": {
     id: "PL098988",
     accreditingbody: "Somerset SCITT Consortium",
-    provider: 'The Beach Teaching School',
+    provider: 'Growing Expert Teachers',
     course: 'Primary (2YQN)',
     locationname: 'Epsom Grinstead - training location',
     submittedDate: '2019-07-15',
@@ -364,7 +364,7 @@ module.exports = {
   "QW211115": {
     id: "QW211115",
     accreditingbody: "Somerset SCITT Consortium",
-    provider: 'The Beach Teaching School',
+    provider: 'Growing Expert Teachers',
     course: 'Primary (2YQN)',
     locationname: 'Camberley - training location',
     submittedDate: '2019-08-15',

--- a/app/routes/application-list.js
+++ b/app/routes/application-list.js
@@ -80,7 +80,7 @@ module.exports = router => {
 
       if(statuses && statuses.length) {
         selectedFilters.categories.push({
-          heading: { text: "Status" },
+          heading: { text: "Statuses" },
           items: statuses.map((status) => {
             return {
               text: status,
@@ -92,7 +92,7 @@ module.exports = router => {
 
       if(locationnames && locationnames.length) {
         selectedFilters.categories.push({
-          heading: { text: "Location" },
+          heading: { text: "Training locations for Growing Expert Teachers" },
           items: locationnames.map((locationname) => {
             return {
               text: locationname,
@@ -104,7 +104,7 @@ module.exports = router => {
 
       if(providers && providers.length) {
         selectedFilters.categories.push({
-          heading: { text: "Provider" },
+          heading: { text: "Providers" },
           items: providers.map((provider) => {
             return {
               text: provider,
@@ -116,7 +116,7 @@ module.exports = router => {
 
       if(accreditingbodies && accreditingbodies.length) {
         selectedFilters.categories.push({
-          heading: { text: "Accrediting bodies" },
+          heading: { text: "Courses ratified by" },
           items: accreditingbodies.map((accreditingbody) => {
             return {
               text: accreditingbody,

--- a/app/routes/application-list.js
+++ b/app/routes/application-list.js
@@ -6,7 +6,7 @@ module.exports = router => {
 
     // Clone and turn into an array
     let apps = Object.values(req.session.data.applications).reverse();
-    let { status, provider, accreditingbody, keywords } = req.query
+    let { status, provider, accreditingbody, keywords, locationname } = req.query
 
     keywords = keywords || req.session.data.keywords;
 
@@ -18,21 +18,30 @@ module.exports = router => {
       return provider !== '_unchecked'
     })) || req.session.data.provider;
 
+    let locationnames = locationname && (Array.isArray(locationname) ? locationname : [ locationname ].filter((locationname) => {
+      return locationname !== '_unchecked'
+    })) || req.session.data.locationname;
+
     let accreditingbodies = accreditingbody && (Array.isArray(accreditingbody) ? accreditingbody : [ accreditingbody ].filter((provider) => {
       return accreditingbody !== '_unchecked'
     })) || req.session.data.accreditingbody;
 
-    const hasFilters = !!( ( statuses && statuses.length > 0) || ( providers && providers.length > 0 ) || ( accreditingbodies && accreditingbodies.length > 0 ) || (keywords) )
+    const hasFilters = !!( ( statuses && statuses.length > 0) || ( locationnames && locationnames.length > 0 ) || ( providers && providers.length > 0 ) || ( accreditingbodies && accreditingbodies.length > 0 ) || (keywords) )
 
     if( hasFilters ){
       apps = apps.filter((app) => {
         let statusValid = true;
         let providerValid = true;
+        let locationnameValid = true;
         let accreditingbodyValid = true;
         let candidateNameValid = true;
 
         if( statuses && statuses.length ){
           statusValid = statuses.includes(app.status)
+        }
+
+        if( locationnames && locationnames.length ){
+          locationnameValid = locationnames.includes(app.locationname)
         }
 
         if( providers && providers.length ){
@@ -49,7 +58,7 @@ module.exports = router => {
           candidateNameValid = candidateName.toLowerCase().includes(keywords.toLowerCase());
         }
 
-        return statusValid && providerValid && candidateNameValid && accreditingbodyValid;
+        return statusValid && locationnameValid && providerValid && candidateNameValid && accreditingbodyValid;
       })
     }
 
@@ -76,6 +85,18 @@ module.exports = router => {
             return {
               text: status,
               href: `/remove-status-filter/${status}`
+            }
+          })
+        })
+      }
+
+      if(locationnames && locationnames.length) {
+        selectedFilters.categories.push({
+          heading: { text: "Location" },
+          items: locationnames.map((locationname) => {
+            return {
+              text: locationname,
+              href: `/remove-locationname-filter/${locationname}`
             }
           })
         })
@@ -127,6 +148,11 @@ module.exports = router => {
     res.redirect('/');
   })
 
+  router.get('/remove-locationname-filter/:locationname', (req, res) => {
+    req.session.data.locationname = req.session.data.locationname.filter(item => item !== req.params.locationname);
+    res.redirect('/');
+  })
+
   router.get('/remove-accreditingbody-filter/:accreditingbody', (req, res) => {
     // console.log(req.session.data.accreditingbody);
     req.session.data.accreditingbody = req.session.data.accreditingbody.filter(item => item !== req.params.accreditingbody);
@@ -138,6 +164,7 @@ module.exports = router => {
     req.session.data.provider = null;
     req.session.data.keywords = null;
     req.session.data.accreditingbody = null;
+    req.session.data.locationname = null;
     res.redirect('/');
   })
 

--- a/app/views/_includes/application-card.njk
+++ b/app/views/_includes/application-card.njk
@@ -6,8 +6,8 @@
         {{ [a["personal-details"]["given-name"], a["personal-details"]["family-name"]] | join(" ") }}
       </a>
     </h3>
-    <p class="govuk-!-font-size-16">{{ a.provider }} ({{a.locationname}})</p>
-    <p class="govuk-!-margin-bottom-0">{{ a.course }}</p>
+    <p class="govuk-!-font-size-16">{{ a.provider }}</p>
+    <p class="govuk-!-margin-bottom-0">{{ a.course }} at {{a.locationname}}</p>
     <p class="govuk-caption-m govuk-!-font-size-16">Ratified by {{a.accreditingbody}}</p>
   </div>
 

--- a/app/views/_includes/application-card.njk
+++ b/app/views/_includes/application-card.njk
@@ -6,7 +6,7 @@
         {{ [a["personal-details"]["given-name"], a["personal-details"]["family-name"]] | join(" ") }}
       </a>
     </h3>
-    <p class="govuk-!-font-size-16">{{ a.provider }}</p>
+    <p class="govuk-!-font-size-16">{{ a.provider }} ({{a.locationname}})</p>
     <p class="govuk-!-margin-bottom-0">{{ a.course }}</p>
     <p class="govuk-caption-m govuk-!-font-size-16">Ratified by {{a.accreditingbody}}</p>
   </div>

--- a/app/views/_includes/filter-panel.njk
+++ b/app/views/_includes/filter-panel.njk
@@ -108,38 +108,42 @@
       ]
     }) }}
 
-    {{ govukCheckboxes({
-      name: 'locationname',
-      classes: "govuk-checkboxes--small",
-      fieldset: {
-        legend: {
-          text: 'Location',
-          classes: 'govuk-fieldset__legend--m'
-        }
-      },
-      items: [
-        {
-          value: 'Main site',
-          text: 'Main site',
-          checked: checked("locationname", "Main site") == 'checked'
+    {% if checked("provider", "Growing Expert Teachers") %}
+
+
+      {{ govukCheckboxes({
+        name: 'locationname',
+        classes: "govuk-checkboxes--small",
+        fieldset: {
+          legend: {
+            text: 'Locations for Growing Expert Teachers',
+            classes: 'govuk-fieldset__legend--m'
+          }
         },
-        {
-          value: 'Camberley - training location',
-          text: 'Camberley - training location',
-          checked: checked("locationname", "Camberley - training location") == 'checked'
-        },
-        {
-          value: 'Epsom Grinstead - training location',
-          text: 'Epsom Grinstead - training location',
-          checked: checked("locationname", "Epsom Grinstead - training location") == 'checked'
-        },
-        {
-          value: 'Lingfield - training location',
-          text: 'Lingfield - training location',
-          checked: checked("locationname", "Lingfield - training location") == 'checked'
-        }
-      ]
-    }) }}
+        items: [
+          {
+            value: 'Main site',
+            text: 'Main site',
+            checked: checked("locationname", "Main site") == 'checked'
+          },
+          {
+            value: 'Camberley - training location',
+            text: 'Camberley - training location',
+            checked: checked("locationname", "Camberley - training location") == 'checked'
+          },
+          {
+            value: 'Epsom Grinstead - training location',
+            text: 'Epsom Grinstead - training location',
+            checked: checked("locationname", "Epsom Grinstead - training location") == 'checked'
+          },
+          {
+            value: 'Lingfield - training location',
+            text: 'Lingfield - training location',
+            checked: checked("locationname", "Lingfield - training location") == 'checked'
+          }
+        ]
+      }) }}
+    {% endif %}
 
     {{ govukCheckboxes({
       idPrefix: 'accreditingbody',

--- a/app/views/_includes/filter-panel.njk
+++ b/app/views/_includes/filter-panel.njk
@@ -116,7 +116,7 @@
         classes: "govuk-checkboxes--small",
         fieldset: {
           legend: {
-            text: 'Locations for Growing Expert Teachers',
+            text: 'Training locations for Growing Expert Teachers',
             classes: 'govuk-fieldset__legend--m'
           }
         },

--- a/app/views/_includes/filter-panel.njk
+++ b/app/views/_includes/filter-panel.njk
@@ -109,6 +109,39 @@
     }) }}
 
     {{ govukCheckboxes({
+      name: 'locationname',
+      classes: "govuk-checkboxes--small",
+      fieldset: {
+        legend: {
+          text: 'Location',
+          classes: 'govuk-fieldset__legend--m'
+        }
+      },
+      items: [
+        {
+          value: 'Main site',
+          text: 'Main site',
+          checked: checked("locationname", "Main site") == 'checked'
+        },
+        {
+          value: 'Camberley - training location',
+          text: 'Camberley - training location',
+          checked: checked("locationname", "Camberley - training location") == 'checked'
+        },
+        {
+          value: 'Epsom Grinstead - training location',
+          text: 'Epsom Grinstead - training location',
+          checked: checked("locationname", "Epsom Grinstead - training location") == 'checked'
+        },
+        {
+          value: 'Lingfield - training location',
+          text: 'Lingfield - training location',
+          checked: checked("locationname", "Lingfield - training location") == 'checked'
+        }
+      ]
+    }) }}
+
+    {{ govukCheckboxes({
       idPrefix: 'accreditingbody',
       name: 'accreditingbody',
       classes: "govuk-checkboxes--small",

--- a/app/views/application/index.njk
+++ b/app/views/application/index.njk
@@ -103,7 +103,7 @@
           }
         }, {
           key: {
-            text: "Preferred location"
+            text: "Training location"
           },
           value: {
             html: application["locationname"] + '<br> SCIL, Dillington House, Ilminster, Somerset, TA19 9DT '

--- a/app/views/application/index.njk
+++ b/app/views/application/index.njk
@@ -106,7 +106,7 @@
             text: "Preferred location"
           },
           value: {
-            text: '	SCIL, Dillington House, Ilminster, Somerset, TA19 9DT'
+            html: application["locationname"] + '<br> SCIL, Dillington House, Ilminster, Somerset, TA19 9DT '
           }
         }, {
           key: {

--- a/app/views/index.njk
+++ b/app/views/index.njk
@@ -16,44 +16,6 @@
       <div class="moj-action-bar">
         <div class="moj-action-bar__filter"></div>
       </div>
-      {# <div class="moj-scrollable-pane">
-        <div class="moj-scrollable-pane__wrapper">
-          {% if applications.length %}
-            <table class="govuk-table" data-module="sortable-table">
-              <thead class="govuk-table__head">
-                <tr class="govuk-table__row">
-                  <th class="govuk-table__header" scope="col" aria-sort="none">Name</th>
-                  <th class="govuk-table__header" scope="col" aria-sort="none">Course</th>
-                  <th class="govuk-table__header" scope="col" aria-sort="none">Status</th>
-                  <th class="govuk-table__header govuk-table__header--numeric" scope="col" aria-sort="descending">Last updated</th>
-                </tr>
-              </thead>
-              <tbody class="govuk-table__body">
-                {% for a in applications %}
-                  {% set rbd = a.status.submitted.date | addDays(40) %}
-                  {% set remaining = rbd | daysFromNow(rbd) %}
-                  {% set updated = a.rejectedDate or a.offer.declinedDate or a.offer.acceptedDate or a.offer.madeDate or a.submittedDate %}
-                  <tr class="govuk-table__row">
-                    <td class="govuk-table__cell">
-                      <a href="/application/{{ a.id }}">{{ [a["personal-details"]["given-name"], a["personal-details"]["family-name"]] | join(" ") }}</a>
-                    </td>
-                    <td class="govuk-table__cell">
-                    <span class="govuk-caption-m govuk-!-font-size-16">{{ a.provider }}</span> {{ a.course }}</td>
-                    <td class="govuk-table__cell">
-                      {{ govukTag({
-                        classes: a.status | statusClass,
-                        text: a.status
-                      })}}
-                    </td>
-                    <td class="govuk-table__cell govuk-table__cell--numeric" data-sort-value="{{ updated | date("yyyyMMdd") }}">{{ updated | date("d LLL yyyy") }}</td>
-                  </tr>
-                {% endfor %}
-              </tbody>
-            </table>
-          {% endif%}
-        </div>
-      </div> #}
-
       <div>
         <div class="app-application-cards">
           {% if applications.length %}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "node": "^10.0.0"
   },
   "scripts": {
-    "prestart": "npm install",
     "start": "node start.js",
     "s": "node start.js",
     "lint": "standard",


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/37163/80598671-9d8c6880-8a21-11ea-82be-009df734e89f.png)

![image](https://user-images.githubusercontent.com/37163/80598746-b85edd00-8a21-11ea-9547-9ffd926afc10.png)

![image](https://user-images.githubusercontent.com/37163/80683789-a1b99400-8abc-11ea-868e-6bb9b6c6370a.png)

Rules for how the filter will work:

The locations filter will only appear if there are multiple locations

If there are multiple locations, then the location filter will only show once the user has selected a provider filter. For example, the user will only see locations for Growing Expert Teachers once they select Growing Expert Teachers.

If a user removes an organisation then any selected location filters for that organisation will be automatically removed.

For (2) we know there is a risk that a user with low-digital literacy/a first time user may not spot the appearance of the additional filter, but we will solve this when we look at onboarding users generally.

The reason for this is because:
1. we have extremely limited space to work in so we can’t simply nest the location checkboxes within the provider checkboxes AND present back that relationship in the selected filters area at the top
2. It’s potentially a lot of data to load and so we want to load more options as they become relevant
