### PR TITLE
Remove the need to set up permissions for courses you run AND ratify

### DIFF
--- a/app/views/onboard/check.njk
+++ b/app/views/onboard/check.njk
@@ -16,7 +16,7 @@
 
       <form novalidate action="/onboard/confirmation">
 
-        <h2 class="govuk-heading-m">
+        {# <h2 class="govuk-heading-m">
           For courses run and ratified by Somerset SCITT Consortium
         </h2>
 
@@ -34,7 +34,7 @@
             }) }} see safeguarding information</li>
         </ul>
 
-        <p><a href="/onboard/step2">Change</a></p>
+        <p><a href="/onboard/step2">Change</a></p> #}
 
         <h2 class="govuk-heading-m">
           For courses run by Ventrus Teaching School Alliance and ratified by Somerset SCITT Consortium

--- a/app/views/onboard/step1-part2.njk
+++ b/app/views/onboard/step1-part2.njk
@@ -24,7 +24,7 @@
         <li>the ‘equality and diversity’ section of the application form</li>
       </ul>
 
-      <form novalidate action="/onboard/step2">
+      <form novalidate action="/onboard/step3">
         {{govukButton({
           text: "Continue"
         })}}

--- a/app/views/onboard/step1.njk
+++ b/app/views/onboard/step1.njk
@@ -19,13 +19,13 @@
 
       <p>You can change these settings at any time.</p>
 
-      <h2 class="govuk-heading-l">Your organisations</h2>
+      <h2 class="govuk-heading-m">Your organisations that need setting up</h2>
 
-      <div class="app-application-card">
+      {# <div class="app-application-card">
         <div>
           <h2 class="govuk-heading-s govuk-!-margin-bottom-0">Somerset SCITT Consortium</h2>
         </div>
-      </div>
+      </div> #}
 
       <div class="app-application-card govuk-!-margin-bottom-7">
         <div>

--- a/app/views/organisations/show.njk
+++ b/app/views/organisations/show.njk
@@ -35,18 +35,6 @@
       {% endset %}
 
       <h2 class="govuk-heading-m">
-      For courses Somerset SCITT Consortium run and ratify
-      </h2>
-
-      <p class="govuk-!-margin-bottom-1">Somerset SCITT Consortium can:</p>
-      <ul class="govuk-list">
-        <li>{{tick | safe }} make decisions</li>
-        <li>{{tick | safe }} see safeguarding information</li>
-      </ul>
-
-      <p><a href="/organisations/edit">Change <span class="govuk-visually-hidden">permissions for courses Somerset SCITT run and ratify</span></a></p>
-
-      <h2 class="govuk-heading-m">
       For courses ratified by Somerset SCITT Consortium and run by Growing Expert Teachers
       </h2>
 


### PR DESCRIPTION
Screenshots: https://trello.com/c/VFw3VKTj/2112-design-dont-ask-users-to-setup-permissions-for-an-organisation-that-ratifies-and-runs-their-own-courses