### PR TITLE
Content check and confirm change of cycle

### DIFF
--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -26,7 +26,7 @@ module.exports = router => {
         'offer-made-to-new-provider': 'Offer successfully made',
         'offer-made-to-new-course': 'Offer successfully made',
         'offer-made-to-new-location': 'Offer successfully made',
-        'cycle-changed': 'Cycle successfully changed'
+        'cycle-changed': 'Offer successfully deferred'
       }
     })
 

--- a/app/views/_includes/application/details.njk
+++ b/app/views/_includes/application/details.njk
@@ -17,7 +17,7 @@
       items: [
         {
           href: '/application/' + application.id + '/cycle/edit',
-          text: "Change",
+          text: "Defer offer",
           visuallyHiddenText: "cycle"
         }
       ]

--- a/app/views/_includes/application/details.njk
+++ b/app/views/_includes/application/details.njk
@@ -17,7 +17,7 @@
       items: [
         {
           href: '/application/' + application.id + '/cycle/edit',
-          text: "Defer offer",
+          text: "Change",
           visuallyHiddenText: "cycle"
         }
       ]

--- a/app/views/application/cycle/edit/check.njk
+++ b/app/views/application/cycle/edit/check.njk
@@ -19,14 +19,12 @@
         {{name}}
       </span>
       <h1 class="govuk-heading-xl">
-        Check and confirm deferral to next cycle
+        Check and confirm deferral to next cycle (2020 to 2021)
       </h1>
 
-      <p>You are deferring this offer to the next cycle (2020 to 2021).</p>
+      <p>The course you are offering is not open for 2020 to 2021 yet. When the next cycle starts, we’ll prompt you to check and confirm the details of your offer.</p>
 
-      <p>The course you are offering is not open for that year yet. When the next cycle starts, we’ll prompt you to check and confirm the details of your offer.</p>
-
-      <p>You'll be able to change the course, location or provider if you need to.</p>
+      <p>You'll be able to change the conditions, course, location or provider if you need to.</p>
 
       <p>We’ll notify the candidate you’ve deferred their offer to the next cycle.</p>
 

--- a/app/views/application/cycle/edit/check.njk
+++ b/app/views/application/cycle/edit/check.njk
@@ -19,18 +19,20 @@
         {{name}}
       </span>
       <h1 class="govuk-heading-xl">
-        Check and confirm change of cycle
+        Check and confirm deferral to next cycle
       </h1>
 
-      <p>The course you have currently offered is not available yet in the next cycle.</p>
+      <p>You are deferring this offer to the next cycle (2020 to 2021).</p>
 
-      <p>This application will be marked as deferred. You must reinstate your offer at the start of the next cycle.</p>
+      <p>The course you are offering is not open for that year yet. When the next cycle starts, we’ll prompt you to check and confirm the details of your offer.</p>
 
-      <p>The candidate will be sent a confirmation by email of this action after you confirm the change of cycle.</p>
+      <p>You'll be able to change the course, location or provider if you need to.</p>
+
+      <p>We’ll notify the candidate you’ve deferred their offer to the next cycle.</p>
 
       <form method="post">
         {{ govukButton({
-          text: "Confirm change of cycle"
+          text: "Confirm deferral to next cycle"
         }) }}
       </form>
 

--- a/app/views/application/cycle/edit/cycle.njk
+++ b/app/views/application/cycle/edit/cycle.njk
@@ -28,12 +28,12 @@
           items: [
             {
               value: "Current cycle (2020 to 2021)",
-              text: "Offer for current cycle (2020 to 2021)",
+              text: "Keep offer in current cycle (2020 to 2021)",
               checked: checked("cycle", "Current cycle (2020 to 2021)", application)
             },
             {
               value: "Next cycle (2021 to 2022)",
-              text: "Offer for next cycle (2021 to 2022)",
+              text: "Defer offer to next cycle (2021 to 2022)",
               checked: checked("cycle", "Next cycle (2021 to 2022)", application)
             }
           ]

--- a/app/views/application/cycle/edit/cycle.njk
+++ b/app/views/application/cycle/edit/cycle.njk
@@ -20,7 +20,7 @@
           name: "applicatoncycle",
           fieldset: {
             legend: {
-              text: "Change cycle",
+              text: "Defer offer to next cycle",
               isPageHeading: true,
               classes: "govuk-fieldset__legend--xl"
             }
@@ -28,12 +28,12 @@
           items: [
             {
               value: "Current cycle (2020 to 2021)",
-              text: "Current cycle (2020 to 2021)",
+              text: "Offer for current cycle (2020 to 2021)",
               checked: checked("cycle", "Current cycle (2020 to 2021)", application)
             },
             {
               value: "Next cycle (2021 to 2022)",
-              text: "Next cycle (2021 to 2022)",
+              text: "Offer for next cycle (2021 to 2022)",
               checked: checked("cycle", "Next cycle (2021 to 2022)", application)
             }
           ]


### PR DESCRIPTION
Made some content changes to the explanation of what providers are doing when they change a cycle. 
Along the way, realised I don't totally understand the need for a radio button here as keeping the offer in the current cycle is the current situation (so not another option for them to choose from if that makes sense):
![Screenshot 2020-07-08 at 12 47 44](https://user-images.githubusercontent.com/38726669/86915168-6d480100-c119-11ea-938b-561744eb09bd.png)
