### PR TITLE
Make details text clearer

### DIFF
--- a/app/views/_includes/application/diversity-information.njk
+++ b/app/views/_includes/application/diversity-information.njk
@@ -86,7 +86,7 @@
 {% endset %}
 
 {{ govukDetails({
-  summaryText: "View candidate guidance",
+  summaryText: "View guidance given to candidate",
   html: diversityInformationGuidanceHtml
 }) }}
 

--- a/app/views/application/index.njk
+++ b/app/views/application/index.njk
@@ -92,7 +92,7 @@
         </ul>
       {% endset %}
       {{ govukDetails({
-        summaryText: "View candidate guidance",
+        summaryText: "View guidance given to candidate",
         html: disabilityGuidanceHtml
       }) }}
       <p class="govuk-body">{{application["reasonable-adjustments"] | nl2br or "No information shared"}}</p>
@@ -111,7 +111,7 @@
         <p class="govuk-body">It won’t necessarily stop you becoming a teacher.</p>
       {% endset %}
       {{ govukDetails({
-        summaryText: "View candidate guidance",
+        summaryText: "View guidance given to candidate",
         html: safeguardingGuidanceHtml
       }) }}
 
@@ -142,7 +142,7 @@
         </ul>
       {% endset %}
       {{ govukDetails({
-        summaryText: "View candidate guidance",
+        summaryText: "View guidance given to candidate",
         html: interviewGuidanceHtml
       }) }}
       <p class="govuk-body">{{ application.personalStatement.interview | nl2br or "No information shared" }}</p>
@@ -157,7 +157,7 @@
         <p class="govuk-body">Enter your other qualifications as completely as you can, including all your GCSEs and A levels (or equivalents), and any other qualifications where you showed skills that might help you as a teacher.</p>
       {% endset %}
       {{ govukDetails({
-        summaryText: "View candidate guidance",
+        summaryText: "View guidance given to candidate",
         html: qualificationsGuidanceHtml
       }) }}
       {% include "_includes/application/degrees.njk" %}
@@ -177,7 +177,7 @@
         <p class="govuk-body">Breaks in work history won’t impact your application if you have a reasonable explanation for them (for example, parenting responsibilities, redundancy, illness or personal reasons such as study or travel).</p>
       {% endset %}
       {{ govukDetails({
-        summaryText: "View candidate guidance",
+        summaryText: "View guidance given to candidate",
         html: workHistoryGuidanceHtml
       }) }}
       {% include "_includes/application/work-history.njk" %}
@@ -194,7 +194,7 @@
         <p class="govuk-body">You can also tell us about any other volunteering you’ve done, and how this supports your application to become a teacher.</p>
       {% endset %}
       {{ govukDetails({
-        summaryText: "View candidate guidance",
+        summaryText: "View guidance given to candidate",
         html: volunteeringGuidanceHtml
       }) }}
       {% include "_includes/application/school-experience.njk" %}
@@ -227,7 +227,7 @@
         </ul>
       {% endset %}
       {{ govukDetails({
-        summaryText: "View candidate guidance",
+        summaryText: "View guidance given to candidate",
         html: personalStatementGuidanceHtml
       }) }}
 
@@ -251,7 +251,7 @@
         </ul>
       {% endset %}
       {{ govukDetails({
-        summaryText: "View candidate guidance",
+        summaryText: "View guidance given to candidate",
         html: referencesGuidanceHtml
       }) }}
       <h3 class="govuk-heading-m govuk-!-margin-bottom-2">First referee</h2>


### PR DESCRIPTION
Make details text more explicit that it's the guidance given to candidates.

<img width="794" alt="Screenshot 2020-08-11 at 16 15 39" src="https://user-images.githubusercontent.com/2204224/89915769-aed33c80-dbee-11ea-9874-0e4bccc81dc2.png">
