### PR TITLE
Reduce heading sizes

### DIFF
--- a/app/views/404.njk
+++ b/app/views/404.njk
@@ -3,7 +3,7 @@
 {% set title = "Page not found" %}
 
 {% block content %}
-  <h1 class="govuk-heading-xl">
+  <h1 class="govuk-heading-l">
     {{title}}
   </h1>
   <p class="govuk-body">If you entered a web address please check it was correct.</p>

--- a/app/views/_content-wide.njk
+++ b/app/views/_content-wide.njk
@@ -6,8 +6,8 @@
   {% if title %}
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        <h1 class="govuk-heading-xl">
-          {% if parent %}<span class="govuk-caption-xl">{{ parent }}</span>{% endif %}
+        <h1 class="govuk-heading-l">
+          {% if parent %}<span class="govuk-caption-l">{{ parent }}</span>{% endif %}
           {{ title | safe }}
         </h1>
       </div>

--- a/app/views/_content.njk
+++ b/app/views/_content.njk
@@ -4,8 +4,8 @@
   {% block beforePageTitle %}{% endblock %}
 
   {% if title %}
-    <h1 class="govuk-heading-xl">
-      {% if parent %}<span class="govuk-caption-xl">{{ parent }}</span>{% endif %}
+    <h1 class="govuk-heading-l">
+      {% if parent %}<span class="govuk-caption-l">{{ parent }}</span>{% endif %}
       {{ title | safe }}
     </h1>
   {% endif %}

--- a/app/views/_form.njk
+++ b/app/views/_form.njk
@@ -7,13 +7,13 @@
     <div class="govuk-grid-column-two-thirds">
       <form action="{{ formaction | default('#') }}" method="post">
       {% set legendHtml %}
-        {% if parent %}<span class="govuk-caption-xl">{{ parent }}</span>{% endif %}
+        {% if parent %}<span class="govuk-caption-l">{{ parent }}</span>{% endif %}
         {{ title | safe }}
       {% endset %}
       {% call govukFieldset({
         legend: {
           html: legendHtml,
-          classes: "govuk-fieldset__legend--xl govuk-!-margin-bottom-8",
+          classes: "govuk-fieldset__legend--l govuk-!-margin-bottom-8",
           isPageHeading: true
         }
       }) %}

--- a/app/views/_includes/application/details.njk
+++ b/app/views/_includes/application/details.njk
@@ -32,7 +32,7 @@
 
 <p class="govuk-body"><a href="#" download>Download application (PDF)</a></p>
 
-<h2 class="govuk-heading-l govuk-!-margin-top-6">Applicant details</h2>
+<h2 class="govuk-heading-m govuk-!-margin-top-6">Applicant details</h2>
 
 {{ govukSummaryList({
   rows: [{

--- a/app/views/_includes/offer/change-condition-status/confirm-met.njk
+++ b/app/views/_includes/offer/change-condition-status/confirm-met.njk
@@ -15,8 +15,8 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      <span class="govuk-caption-xl">{{name}}</span>
-      <h1 class="govuk-heading-xl">{{title}}</h1>
+      <span class="govuk-caption-l">{{name}}</span>
+      <h1 class="govuk-heading-l">{{title}}</h1>
 
       <div class="app-offer-panel govuk-!-margin-bottom-6">
         <p class="govuk-!-margin-bottom-0">Condition: {{condition.description}}</p>

--- a/app/views/_includes/offer/change-condition-status/confirm-not-met.njk
+++ b/app/views/_includes/offer/change-condition-status/confirm-not-met.njk
@@ -15,8 +15,8 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      <span class="govuk-caption-xl">{{name}}</span>
-      <h1 class="govuk-heading-xl">{{title}}</h1>
+      <span class="govuk-caption-l">{{name}}</span>
+      <h1 class="govuk-heading-l">{{title}}</h1>
 
       <div class="app-offer-panel">
         <p class="govuk-!-margin-bottom-0">Condition: {{condition.description}}</p>

--- a/app/views/_includes/offer/change-condition-status/status.njk
+++ b/app/views/_includes/offer/change-condition-status/status.njk
@@ -15,7 +15,7 @@
     <div class="govuk-grid-column-two-thirds">
 
       {% set h1 %}
-        <span class="govuk-caption-xl">{{name}}</span>
+        <span class="govuk-caption-l">{{name}}</span>
         {{title}}
       {% endset %}
 

--- a/app/views/_includes/offer/new/conditions.njk
+++ b/app/views/_includes/offer/new/conditions.njk
@@ -14,8 +14,8 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <span class="govuk-caption-xl">{{name}}</span>
-      <h1 class="govuk-heading-xl govuk-!-margin-bottom-4">{{title}}</h1>
+      <span class="govuk-caption-l">{{name}}</span>
+      <h1 class="govuk-heading-l govuk-!-margin-bottom-4">{{title}}</h1>
 
       {% include "_includes/offer/details-of-offer-without-conditions.njk" %}
 

--- a/app/views/_includes/offer/reconfirm/conditions.njk
+++ b/app/views/_includes/offer/reconfirm/conditions.njk
@@ -14,8 +14,8 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <span class="govuk-caption-xl">{{name}}</span>
-      <h1 class="govuk-heading-xl">{{title}}</h1>
+      <span class="govuk-caption-l">{{name}}</span>
+      <h1 class="govuk-heading-l">{{title}}</h1>
 
       {% include "_includes/offer/details-of-offer-without-conditions.njk" %}
 

--- a/app/views/_includes/offer/reconfirm/statuses.njk
+++ b/app/views/_includes/offer/reconfirm/statuses.njk
@@ -14,8 +14,8 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <span class="govuk-caption-xl">{{name}}</span>
-      <h1 class="govuk-heading-xl">{{title}}</h1>
+      <span class="govuk-caption-l">{{name}}</span>
+      <h1 class="govuk-heading-l">{{title}}</h1>
 
 
 

--- a/app/views/account/index.njk
+++ b/app/views/account/index.njk
@@ -7,7 +7,7 @@
 
 {% block content %}
 
-    <h1 class="govuk-heading-xl">
+    <h1 class="govuk-heading-l">
       Your account
     </h1>
 

--- a/app/views/account/notifications/edit/1.njk
+++ b/app/views/account/notifications/edit/1.njk
@@ -19,8 +19,8 @@
     <div class="govuk-grid-column-two-thirds">
 
 
-        <span class="govuk-caption-xl">Change notification settings</span>
-        <h1 class="govuk-heading-xl">For applications to courses run by {{ data.user.organisations[1].name }} and ratified by {{ data.accreditedBodies[0].name }}</h1>
+        <span class="govuk-caption-l">Change notification settings</span>
+        <h1 class="govuk-heading-l">For applications to courses run by {{ data.user.organisations[1].name }} and ratified by {{ data.accreditedBodies[0].name }}</h1>
 
       {% macro notificationField(params) %}
         {% set applicationSubmittedFrequencyHtml %}

--- a/app/views/account/notifications/edit/2.njk
+++ b/app/views/account/notifications/edit/2.njk
@@ -14,8 +14,8 @@
     <div class="govuk-grid-column-two-thirds">
 
 
-        <span class="govuk-caption-xl">Change notification settings</span>
-        <h1 class="govuk-heading-xl">For applications to courses run by {{ data.user.organisations[1].name }} and ratified by Teaching Brilliance University</h1>
+        <span class="govuk-caption-l">Change notification settings</span>
+        <h1 class="govuk-heading-l">For applications to courses run by {{ data.user.organisations[1].name }} and ratified by Teaching Brilliance University</h1>
 
       {% macro notificationField(params) %}
         {% set applicationSubmittedFrequencyHtml %}

--- a/app/views/account/notifications/index.njk
+++ b/app/views/account/notifications/index.njk
@@ -29,7 +29,7 @@
 
   <div class="govuk-grid-ro">
     <div class="govuk-grid-column-two-third">
-      <h1 class="govuk-heading-xl">{{title}}</h1>
+      <h1 class="govuk-heading-l">{{title}}</h1>
 
       <h2 class="govuk-heading-m govuk-!-margin-bottom-3">
         For applications to courses run by {{ data.user.organisations[1].name }} and ratified by {{ data.accreditedBodies[0].name }}

--- a/app/views/account/profile.njk
+++ b/app/views/account/profile.njk
@@ -16,7 +16,7 @@
 
 {% block content %}
 
-  <h1 class="govuk-heading-xl">{{title}}</h1>
+  <h1 class="govuk-heading-l">{{title}}</h1>
 
   {% set permissionsHtml %}
   <p class="govuk-!-font-weight-bold">{{ appIcon({

--- a/app/views/activity/index.njk
+++ b/app/views/activity/index.njk
@@ -4,7 +4,7 @@
 {% set title = "Activity log" %}
 
 {% block content %}
-  <h1 class="govuk-heading-xl">{{title}}</h1>
+  <h1 class="govuk-heading-l">{{title}}</h1>
 
 
 

--- a/app/views/admin/clear-data-success.njk
+++ b/app/views/admin/clear-data-success.njk
@@ -3,7 +3,7 @@
 {% set title = "Data cleared" %}
 
 {% block content %}
-  <h1 class="govuk-heading-xl">
+  <h1 class="govuk-heading-l">
     {{title}}
   </h1>
   <p>The session data has been cleared.</p>

--- a/app/views/admin/clear-data.njk
+++ b/app/views/admin/clear-data.njk
@@ -11,7 +11,7 @@
 
 {% block content %}
 
-  <h1 class="govuk-heading-xl">
+  <h1 class="govuk-heading-l">
     {{title}}
   </h1>
 

--- a/app/views/admin/settings.njk
+++ b/app/views/admin/settings.njk
@@ -2,7 +2,7 @@
 
 {% block content %}
 
-  <h1 class="govuk-heading-xl">
+  <h1 class="govuk-heading-l">
     Settings
   </h1>
 

--- a/app/views/application/decision.njk
+++ b/app/views/application/decision.njk
@@ -13,7 +13,7 @@
 {% block content %}
 
   {% set h1 %}
-    <span class="govuk-caption-xl">{{name}}</span>
+    <span class="govuk-caption-l">{{name}}</span>
     {{title}}
   {% endset %}
 
@@ -22,7 +22,7 @@
       fieldset: {
         legend: {
           html: h1,
-          classes: "govuk-fieldset__legend--xl",
+          classes: "govuk-fieldset__legend--l",
           isPageHeading: true
         }
       },

--- a/app/views/application/feedback/check.njk
+++ b/app/views/application/feedback/check.njk
@@ -13,8 +13,8 @@
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <span class="govuk-caption-xl">{{name}}</span>
-      <h1 class="govuk-heading-xl">{{title}}</h1>
+      <span class="govuk-caption-l">{{name}}</span>
+      <h1 class="govuk-heading-l">{{title}}</h1>
 
       <p>The candidate will see your feedback in the format below.</p>
 

--- a/app/views/application/feedback/index.njk
+++ b/app/views/application/feedback/index.njk
@@ -15,7 +15,7 @@
     <div class="govuk-grid-column-two-thirds">
 
       {% set h1 %}
-        <span class="govuk-caption-xl">{{name}}</span>
+        <span class="govuk-caption-l">{{name}}</span>
         {{title}}
       {% endset %}
 
@@ -25,7 +25,7 @@
           maxwords: 200,
          label: {
             html: h1,
-            classes: "govuk-label--xl",
+            classes: "govuk-label--l",
             isPageHeading: true
           },
           id: "rejection-why",

--- a/app/views/application/index.njk
+++ b/app/views/application/index.njk
@@ -13,7 +13,7 @@
     icon: false
   }) if flash | falsify }}
 
-  <h1 class="govuk-heading-xl govuk-!-margin-bottom-6">{{title}}
+  <h1 class="govuk-heading-l govuk-!-margin-bottom-6">{{title}}
   {{ govukTag({ classes: statusText | statusClass, text: statusText }) }}</h1>
 
   {% include "_includes/application/respond-prompt.njk" %}
@@ -33,11 +33,9 @@
         {% include "_includes/candidate-feedback.njk" %}
       {% endif %}
 
-      {# <h1 class="govuk-heading-l">Application</h1> #}
-      {# <h2 class="govuk-heading-l">Personal details</h2> #}
       {% include "_includes/application/details.njk" %}
 
-      <h2 class="govuk-heading-l govuk-!-margin-top-8 govuk-!-margin-bottom-2">Course details</h2>
+      <h2 class="govuk-heading-m govuk-!-margin-top-8 govuk-!-margin-bottom-2">Course details</h2>
       {{ govukSummaryList({
         rows: [{
           key: {
@@ -70,7 +68,7 @@
         }]
       }) }}
 
-      <h2 class="govuk-heading-l govuk-!-margin-top-8 govuk-!-margin-bottom-2">Disability, access and other needs</h2>
+      <h2 class="govuk-heading-m govuk-!-margin-top-8 govuk-!-margin-bottom-2">Disability, access and other needs</h2>
       {% set disabilityGuidanceHtml %}
         <h2 class="govuk-heading-m">Asking for support if you have a disability or other needs</h2>
         <p class="govuk-body">You might benefit from extra support if you’re disabled, have a mental health condition or educational needs.</p>
@@ -95,7 +93,7 @@
       }) }}
       <p class="govuk-body">{{application["reasonable-adjustments"] | nl2br or "No information shared"}}</p>
 
-      <h2 class="govuk-heading-l govuk-!-margin-top-8 govuk-!-margin-bottom-2">Criminal convictions and professional misconduct</h2>
+      <h2 class="govuk-heading-m govuk-!-margin-top-8 govuk-!-margin-bottom-2">Criminal convictions and professional misconduct</h2>
       {% set safeguardingGuidanceHtml %}
         <h2 class="govuk-heading-m">Declaring any safeguarding issues</h2>
         <p class="govuk-body">Teacher training providers need to check that it’s safe for you to work with children and young people.</p>
@@ -126,7 +124,7 @@
         <p class="govuk-body">No information shared</p>
       {% endif %}
 
-      <h2 class="govuk-heading-l govuk-!-margin-top-8 govuk-!-margin-bottom-2">Interview</h2>
+      <h2 class="govuk-heading-m govuk-!-margin-top-8 govuk-!-margin-bottom-2">Interview</h2>
       {% set interviewGuidanceHtml %}
         <h2 class="govuk-heading-m">Interview needs</h2>
         <p class="govuk-body">Interviews usually take place over the course of a day. You'll need to attend in person.</p>
@@ -152,7 +150,7 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
-      <h2 class="govuk-heading-l govuk-!-margin-top-8 govuk-!-margin-bottom-2">Qualifications</h2>
+      <h2 class="govuk-heading-m govuk-!-margin-top-8 govuk-!-margin-bottom-2">Qualifications</h2>
       {% set qualificationsGuidanceHtml %}
         <h2 class="govuk-heading-m">Academic and other relevant qualifications</h2>
         <p class="govuk-body">Your undergraduate degree confirms your eligibility to teach. Enter the details of your degree as they appear on your certificate, translating them into English if necessary.</p>
@@ -175,7 +173,7 @@
     <div class="govuk-grid-column-two-thirds">
       {% include "_includes/application/other-qualifications.njk" %}
 
-      <h2 class="govuk-heading-l govuk-!-margin-top-8 govuk-!-margin-bottom-2">Work history</h2>
+      <h2 class="govuk-heading-m govuk-!-margin-top-8 govuk-!-margin-bottom-2">Work history</h2>
       {% set workHistoryGuidanceHtml %}
         <h2 class="govuk-heading-m">Work history</h2>
         <p class="govuk-body">Training providers need a complete picture of the last 5 years of of your work history, including time out of the workplace, to safeguard children.</p>
@@ -187,7 +185,7 @@
       }) }}
       {% include "_includes/application/work-history.njk" %}
 
-      <h2 class="govuk-heading-l govuk-!-margin-top-8 govuk-!-margin-bottom-2">Unpaid experience and volunteering</h2>
+      <h2 class="govuk-heading-m govuk-!-margin-top-8 govuk-!-margin-bottom-2">Unpaid experience and volunteering</h2>
       {% set volunteeringGuidanceHtml %}
         <h2 class="govuk-heading-m">Unpaid experience working with children and other volunteering</h2>
         <p class="govuk-body">Tell us about any unpaid experience you have working with children or in a school. For example:</p>
@@ -204,7 +202,7 @@
       }) }}
       {% include "_includes/application/school-experience.njk" %}
 
-      <h2 class="govuk-heading-l govuk-!-margin-top-8 govuk-!-margin-bottom-2">Personal statement</h2>
+      <h2 class="govuk-heading-m govuk-!-margin-top-8 govuk-!-margin-bottom-2">Personal statement</h2>
       {% set personalStatementGuidanceHtml %}
         <h2 class="govuk-heading-m">Why do you want to be a teacher?</h2>
         <p class="govuk-body">Use this section to showcase your motivation, commitment and teaching potential, backing up your answer with specific examples.</p>
@@ -242,7 +240,7 @@
       <h3 class="govuk-heading-s govuk-!-margin-bottom-0">Subject knowledge</h3>
       <p>{{ application.personalStatement.subjectKnowledge | safe | nl2br or "—" }}</p>
 
-      <h2 class="govuk-heading-l govuk-!-margin-top-8 govuk-!-margin-bottom-2">References</h2>
+      <h2 class="govuk-heading-m govuk-!-margin-top-8 govuk-!-margin-bottom-2">References</h2>
       {% set referencesGuidanceHtml %}
         <h2 class="govuk-heading-m">Choosing referees</h2>
         <p class="govuk-body">Referees should not be family members, partners or friends.</p>
@@ -259,15 +257,15 @@
         summaryText: "View guidance given to candidate",
         html: referencesGuidanceHtml
       }) }}
-      <h3 class="govuk-heading-m govuk-!-margin-bottom-2">First referee</h2>
+      <h3 class="govuk-heading-s govuk-!-margin-bottom-2">First referee</h2>
       {% set referenceId = "first" %}
       {% include "_includes/application/reference.njk" %}
 
-      <h3 class="govuk-heading-m govuk-!-margin-top-8 govuk-!-margin-bottom-2">Second referee</h2>
+      <h3 class="govuk-heading-s govuk-!-margin-top-8 govuk-!-margin-bottom-2">Second referee</h2>
       {% set referenceId = "second" %}
       {% include "_includes/application/reference.njk" %}
 
-      <h2 class="govuk-heading-l govuk-!-margin-top-8 govuk-!-margin-bottom-2">Diversity information</h2>
+      <h2 class="govuk-heading-m govuk-!-margin-top-8 govuk-!-margin-bottom-2">Diversity information</h2>
       {% include "_includes/application/diversity-information.njk" %}
     </div>
   </div>

--- a/app/views/application/interviews/delete/check.njk
+++ b/app/views/application/interviews/delete/check.njk
@@ -17,8 +17,8 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      <span class="govuk-caption-xl"> {{name}} </span>
-      <h1 class="govuk-heading-xl">{{title}}</h1>
+      <span class="govuk-caption-l"> {{name}} </span>
+      <h1 class="govuk-heading-l">{{title}}</h1>
 
       <form method="post">
 

--- a/app/views/application/interviews/delete/index.njk
+++ b/app/views/application/interviews/delete/index.njk
@@ -15,7 +15,7 @@
 {% block content %}
 
   {% set h1 %}
-    <span class="govuk-caption-xl"> {{name}} </span>
+    <span class="govuk-caption-l"> {{name}} </span>
     {{title}}
   {% endset %}
 
@@ -30,7 +30,7 @@
           label: {
             html: h1,
             isPageHeading: true,
-            classes: "govuk-label--xl"
+            classes: "govuk-label--l"
           },
           value: data.cancelInterview.reason
         }) }}

--- a/app/views/application/interviews/edit/check.njk
+++ b/app/views/application/interviews/edit/check.njk
@@ -14,8 +14,8 @@
 
 {% block content %}
 
-  <span class="govuk-caption-xl"> {{name}} </span>
-  <h1 class="govuk-heading-xl">{{title}}</h1>
+  <span class="govuk-caption-l"> {{name}} </span>
+  <h1 class="govuk-heading-l">{{title}}</h1>
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/app/views/application/interviews/edit/index.njk
+++ b/app/views/application/interviews/edit/index.njk
@@ -14,8 +14,8 @@
 
 {% block content %}
 
-  <span class="govuk-caption-xl"> {{name}} </span>
-  <h1 class="govuk-heading-xl">{{title}}</h1>
+  <span class="govuk-caption-l"> {{name}} </span>
+  <h1 class="govuk-heading-l">{{title}}</h1>
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/app/views/application/interviews/index.njk
+++ b/app/views/application/interviews/index.njk
@@ -12,7 +12,7 @@
     icon: false
   }) if flash | falsify }}
 
-  <h1 class="govuk-heading-xl govuk-!-margin-bottom-6">{{name}}
+  <h1 class="govuk-heading-l govuk-!-margin-bottom-6">{{name}}
   {{ govukTag({ classes: statusText | statusClass, text: statusText }) }}</h1>
 
   {% include "_includes/application/respond-prompt.njk" %}

--- a/app/views/application/interviews/new/check.njk
+++ b/app/views/application/interviews/new/check.njk
@@ -14,8 +14,8 @@
 
 {% block content %}
 
-  <span class="govuk-caption-xl"> {{name}} </span>
-  <h1 class="govuk-heading-xl">Check and confirm interview</h1>
+  <span class="govuk-caption-l"> {{name}} </span>
+  <h1 class="govuk-heading-l">Check and confirm interview</h1>
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/app/views/application/interviews/new/index.njk
+++ b/app/views/application/interviews/new/index.njk
@@ -14,8 +14,8 @@
 
 {% block content %}
 
-  <span class="govuk-caption-xl"> {{name}} </span>
-  <h1 class="govuk-heading-xl">Set up an interview</h1>
+  <span class="govuk-caption-l"> {{name}} </span>
+  <h1 class="govuk-heading-l">Set up an interview</h1>
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/app/views/application/notes/index.njk
+++ b/app/views/application/notes/index.njk
@@ -15,7 +15,7 @@
   {% set rbd = application.submittedDate | addDays(40) %}
   {% set remaining = rbd | daysFromNow(rbd) %}
 
-  <h1 class="govuk-heading-xl govuk-!-margin-bottom-6">{{name}}
+  <h1 class="govuk-heading-l govuk-!-margin-bottom-6">{{name}}
   {{ govukTag({ classes: statusText | statusClass, text: statusText }) }}</h1>
 
   {% include "_includes/application/respond-prompt.njk" %}

--- a/app/views/application/notes/new.njk
+++ b/app/views/application/notes/new.njk
@@ -17,7 +17,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      <h1 class="govuk-heading-xl">Add note</h1>
+      <h1 class="govuk-heading-l">Add note</h1>
 
       <form method="post">
         {{ govukCharacterCount({

--- a/app/views/application/notes/show.njk
+++ b/app/views/application/notes/show.njk
@@ -17,7 +17,7 @@
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        <h1 class="govuk-heading-xl govuk-!-margin-bottom-5">{{note.subject}}</h1>
+        <h1 class="govuk-heading-l govuk-!-margin-bottom-5">{{note.subject}}</h1>
         <p>{{note.body}}</p>
         <p class="govuk-hint govuk-!-font-size-16 govuk-!-margin-bottom-0">{{note.sender}}, {{note.date | govukDateAtTime }}</p>
       </div>

--- a/app/views/application/offer/defer/check.njk
+++ b/app/views/application/offer/defer/check.njk
@@ -16,10 +16,10 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      <span class="govuk-caption-xl">
+      <span class="govuk-caption-l">
         {{name}}
       </span>
-      <h1 class="govuk-heading-xl">
+      <h1 class="govuk-heading-l">
         {{title}}
       </h1>
 

--- a/app/views/application/offer/delete-condition/index.njk
+++ b/app/views/application/offer/delete-condition/index.njk
@@ -14,8 +14,8 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <span class="govuk-caption-xl">{{name}}</span>
-      <h1 class="govuk-heading-xl">{{title}}</h1>
+      <span class="govuk-caption-l">{{name}}</span>
+      <h1 class="govuk-heading-l">{{title}}</h1>
 
       <div class="app-offer-panel govuk-!-margin-bottom-6">
         <p class="govuk-!-margin-bottom-0">Condition: {{condition.description}}</p>

--- a/app/views/application/offer/delete-conditions/check.njk
+++ b/app/views/application/offer/delete-conditions/check.njk
@@ -14,8 +14,8 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <span class="govuk-caption-xl">{{name}}</span>
-      <h1 class="govuk-heading-xl">{{title}}</h1>
+      <span class="govuk-caption-l">{{name}}</span>
+      <h1 class="govuk-heading-l">{{title}}</h1>
 
       {% set conditionsHtml %}
         {% for item in data['delete-conditions'].conditions %}

--- a/app/views/application/offer/delete-conditions/index.njk
+++ b/app/views/application/offer/delete-conditions/index.njk
@@ -15,7 +15,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       {% set h1 %}
-        <span class="govuk-caption-xl">{{name}}</span>
+        <span class="govuk-caption-l">{{name}}</span>
         {{title}}
       {% endset %}
 
@@ -26,7 +26,7 @@
             legend: {
               html: h1,
               isPageHeading: true,
-              classes: "govuk-fieldset__legend--xl"
+              classes: "govuk-fieldset__legend--l"
             }
           },
           items: conditionItems

--- a/app/views/application/offer/edit-condition-statuses/check.njk
+++ b/app/views/application/offer/edit-condition-statuses/check.njk
@@ -14,8 +14,8 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <span class="govuk-caption-xl">{{name}}</span>
-      <h1 class="govuk-heading-xl">{{title}}</h1>
+      <span class="govuk-caption-l">{{name}}</span>
+      <h1 class="govuk-heading-l">{{title}}</h1>
 
       <div class="app-offer-panel">
         <h2 class="govuk-heading-m">

--- a/app/views/application/offer/edit-condition-statuses/index.njk
+++ b/app/views/application/offer/edit-condition-statuses/index.njk
@@ -14,8 +14,8 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <span class="govuk-caption-xl">{{name}}</span>
-      <h1 class="govuk-heading-xl">{{title}}</h1>
+      <span class="govuk-caption-l">{{name}}</span>
+      <h1 class="govuk-heading-l">{{title}}</h1>
 
       <div class="app-offer-panel govuk-!-margin-bottom-7">
         <dl class="govuk-summary-list app-conditions-list govuk-!-margin-bottom-0 {% if checked(data.settings, "hasCombinedConditions") %}app-condition-list--combined {% endif %}">

--- a/app/views/application/offer/edit-conditions/check.njk
+++ b/app/views/application/offer/edit-conditions/check.njk
@@ -14,8 +14,8 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <span class="govuk-caption-xl">{{name}}</span>
-      <h1 class="govuk-heading-xl">{{title}}</h1>
+      <span class="govuk-caption-l">{{name}}</span>
+      <h1 class="govuk-heading-l">{{title}}</h1>
 
       <div class="app-offer-panel">
         <h2 class="govuk-heading-m">

--- a/app/views/application/offer/edit-conditions/index.njk
+++ b/app/views/application/offer/edit-conditions/index.njk
@@ -14,8 +14,8 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <span class="govuk-caption-xl">{{name}}</span>
-      <h1 class="govuk-heading-xl">{{title}}</h1>
+      <span class="govuk-caption-l">{{name}}</span>
+      <h1 class="govuk-heading-l">{{title}}</h1>
 
       {% include "_includes/offer/details-of-offer-without-conditions.njk" %}
 

--- a/app/views/application/offer/index.njk
+++ b/app/views/application/offer/index.njk
@@ -16,7 +16,7 @@
   {% set rbd = application.submittedDate | addDays(40) %}
   {% set remaining = rbd | daysFromNow(rbd) %}
 
-  <h1 class="govuk-heading-xl govuk-!-margin-bottom-6">{{title}} {{ govukTag({ classes: status | statusClass, text: status })}}</h1>
+  <h1 class="govuk-heading-l govuk-!-margin-bottom-6">{{title}} {{ govukTag({ classes: status | statusClass, text: status })}}</h1>
 
   {% include "_includes/application/respond-prompt.njk" %}
   {% include "_includes/application/defer-prompt.njk" %}

--- a/app/views/application/reject/check.njk
+++ b/app/views/application/reject/check.njk
@@ -13,8 +13,8 @@
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <span class="govuk-caption-xl">{{name}}</span>
-      <h1 class="govuk-heading-xl">{{title}}</h1>
+      <span class="govuk-caption-l">{{name}}</span>
+      <h1 class="govuk-heading-l">{{title}}</h1>
 
       <p>Your feedback will be given to the candidate in the format below.</p>
 

--- a/app/views/application/reject/course-choice-and-safeguarding.njk
+++ b/app/views/application/reject/course-choice-and-safeguarding.njk
@@ -13,8 +13,8 @@
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <span class="govuk-caption-xl">{{name}}</span>
-      <h1 class="govuk-heading-xl">Course choice and safeguarding</h1>
+      <span class="govuk-caption-l">{{name}}</span>
+      <h1 class="govuk-heading-l">Course choice and safeguarding</h1>
       <p>When giving details or advice, bear in mind the candidate will see this feedback. </p>
       <form method="post">
         {% include "_includes/reject-form-fields-2.njk" %}

--- a/app/views/application/reject/index.njk
+++ b/app/views/application/reject/index.njk
@@ -13,8 +13,8 @@
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <span class="govuk-caption-xl">{{name}}</span>
-      <h1 class="govuk-heading-xl">{{title}}</h1>
+      <span class="govuk-caption-l">{{name}}</span>
+      <h1 class="govuk-heading-l">{{title}}</h1>
       <p>When giving details or advice, bear in mind the candidate will see this feedback. </p>
 
       <form method="post">

--- a/app/views/application/reject/other-reasons-for-rejection.njk
+++ b/app/views/application/reject/other-reasons-for-rejection.njk
@@ -13,8 +13,8 @@
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <span class="govuk-caption-xl">{{name}}</span>
-      <h1 class="govuk-heading-xl">{{title}}</h1>
+      <span class="govuk-caption-l">{{name}}</span>
+      <h1 class="govuk-heading-l">{{title}}</h1>
       <p>When giving details or advice, bear in mind the candidate will see this feedback. </p>
 
       <form method="post">

--- a/app/views/application/timeline.njk
+++ b/app/views/application/timeline.njk
@@ -9,7 +9,7 @@
   {% set rbd = application.submittedDate | addDays(40) %}
   {% set remaining = rbd | daysFromNow(rbd) %}
 
-  <h1 class="govuk-heading-xl govuk-!-margin-bottom-6">{{title}}
+  <h1 class="govuk-heading-l govuk-!-margin-bottom-6">{{title}}
   {{ govukTag({ classes: statusText | statusClass, text: statusText }) }}</h1>
 
   {% include "_includes/application/respond-prompt.njk" %}

--- a/app/views/dsa/index.njk
+++ b/app/views/dsa/index.njk
@@ -5,7 +5,7 @@
 {% block content %}
   <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">Data sharing agreement</h1>
+    <h1 class="govuk-heading-l govuk-!-margin-bottom-3">Data sharing agreement</h1>
     <p class="govuk-body-l">This agreement applies to personal data shared between the Department for Education (DfE) and {{ data.user.organisations[0].name }}, ‘the providers’, as part of Apply for teacher training.</p>
 
       <p class="govuk-body">Our data sharing agreement sets out how you should use and look after the data we share with you. Please read the data sharing agreement below in full to check you can meet your responsibilities.</p>

--- a/app/views/export/index.njk
+++ b/app/views/export/index.njk
@@ -4,7 +4,7 @@
 {% set title = "Export data" %}
 
 {% block content %}
-  <h1 class="govuk-heading-xl">{{title}}</h1>
+  <h1 class="govuk-heading-l">{{title}}</h1>
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/app/views/index.njk
+++ b/app/views/index.njk
@@ -4,10 +4,7 @@
 
 {% block content %}
 
-  {# <span class="govuk-caption-xl">
-    {{data.cycle}} <a href="/switch-cycle" class="govuk-link govuk-!-font-size-19">Switch cycle</a>
-  </span> #}
-  <h1 class="govuk-heading-xl">
+  <h1 class="govuk-heading-l">
     Applications
   </h1>
 

--- a/app/views/interviews/index.njk
+++ b/app/views/interviews/index.njk
@@ -4,7 +4,7 @@
 {% set title = "Interviews" %}
 
 {% block content %}
-  <h1 class="govuk-heading-xl">{{title}}</h1>
+  <h1 class="govuk-heading-l">{{title}}</h1>
 
   <table class="govuk-table">
     <thead class="govuk-table__head">

--- a/app/views/notifications/index.njk
+++ b/app/views/notifications/index.njk
@@ -7,7 +7,7 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">{{title}}</h1>
+      <h1 class="govuk-heading-l govuk-!-margin-bottom-3">{{title}}</h1>
 
       <p class="govuk-!-margin-bottom-8"><a href="/account/notifications">Change your notification settings</a></p>
 

--- a/app/views/offer/change-course/confirm.njk
+++ b/app/views/offer/change-course/confirm.njk
@@ -14,8 +14,8 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <span class="govuk-caption-xl">{{name}}</span>
-      <h1 class="govuk-heading-xl">{{title}}</h1>
+      <span class="govuk-caption-l">{{name}}</span>
+      <h1 class="govuk-heading-l">{{title}}</h1>
 
       <h2 class="govuk-heading-l">Your existing offer</h2>
 

--- a/app/views/offer/change-course/course.njk
+++ b/app/views/offer/change-course/course.njk
@@ -13,7 +13,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       {% set h1 %}
-        <span class="govuk-caption-xl">{{name}}</span>
+        <span class="govuk-caption-l">{{name}}</span>
         {{title}}
       {% endset %}
       <form method="post">
@@ -23,7 +23,7 @@
             legend: {
               html: h1,
               isPageheading: true,
-              classes: "govuk-fieldset__legend--xl"
+              classes: "govuk-fieldset__legend--l"
             }
           },
           idPrefix: "course",

--- a/app/views/offer/change-course/location.njk
+++ b/app/views/offer/change-course/location.njk
@@ -13,7 +13,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       {% set h1 %}
-        <span class="govuk-caption-xl">{{name}}</span>
+        <span class="govuk-caption-l">{{name}}</span>
         {{title}}
       {% endset %}
       <form method="post">
@@ -23,7 +23,7 @@
             legend: {
               html: h1,
               isPageHeading: true,
-              classes: "govuk-fieldset__legend--xl"
+              classes: "govuk-fieldset__legend--l"
             }
           },
           idPrefix: "location",

--- a/app/views/offer/change-location/confirm.njk
+++ b/app/views/offer/change-location/confirm.njk
@@ -14,8 +14,8 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <span class="govuk-caption-xl">{{name}}</span>
-      <h1 class="govuk-heading-xl">{{title}}</h1>
+      <span class="govuk-caption-l">{{name}}</span>
+      <h1 class="govuk-heading-l">{{title}}</h1>
 
       <h2 class="govuk-heading-l">Your existing offer</h2>
 

--- a/app/views/offer/change-location/location.njk
+++ b/app/views/offer/change-location/location.njk
@@ -13,7 +13,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       {% set h1 %}
-        <span class="govuk-caption-xl">{{name}}</span>
+        <span class="govuk-caption-l">{{name}}</span>
         {{title}}
       {% endset %}
       <form method="post">
@@ -23,7 +23,7 @@
             legend: {
               html: h1,
               isPageHeading: true,
-              classes: "govuk-fieldset__legend--xl"
+              classes: "govuk-fieldset__legend--l"
             }
           },
           idPrefix: "location",

--- a/app/views/offer/change-provider/confirm.njk
+++ b/app/views/offer/change-provider/confirm.njk
@@ -14,8 +14,8 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <span class="govuk-caption-xl">{{name}}</span>
-      <h1 class="govuk-heading-xl">{{title}}</h1>
+      <span class="govuk-caption-l">{{name}}</span>
+      <h1 class="govuk-heading-l">{{title}}</h1>
 
       <h2 class="govuk-heading-l">Your existing offer</h2>
 

--- a/app/views/offer/change-provider/course.njk
+++ b/app/views/offer/change-provider/course.njk
@@ -13,7 +13,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       {% set h1 %}
-        <span class="govuk-caption-xl">{{name}}</span>
+        <span class="govuk-caption-l">{{name}}</span>
         {{title}}
       {% endset %}
 
@@ -24,7 +24,7 @@
             legend: {
               html: h1,
               isPageHeading: true,
-              classes: "govuk-fieldset__legend--xl"
+              classes: "govuk-fieldset__legend--l"
             }
           },
           idPrefix: "course",

--- a/app/views/offer/change-provider/location.njk
+++ b/app/views/offer/change-provider/location.njk
@@ -14,7 +14,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       {% set h1 %}
-        <span class="govuk-caption-xl">{{name}}</span>
+        <span class="govuk-caption-l">{{name}}</span>
         {{title}}
       {% endset %}
       <form method="post">
@@ -24,7 +24,7 @@
             legend: {
               html: h1,
               isPageHeading: true,
-              classes: "govuk-fieldset__legend--xl"
+              classes: "govuk-fieldset__legend--l"
             }
           },
           idPrefix: "location",

--- a/app/views/offer/change-provider/provider.njk
+++ b/app/views/offer/change-provider/provider.njk
@@ -13,7 +13,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       {% set h1 %}
-        <span class="govuk-caption-xl">{{name}}</span>
+        <span class="govuk-caption-l">{{name}}</span>
         {{title}}
       {% endset %}
       <form method="post">
@@ -23,7 +23,7 @@
             legend: {
               html: h1,
               isPageHeading: true,
-              classes: "govuk-fieldset__legend--xl"
+              classes: "govuk-fieldset__legend--l"
             }
           },
           idPrefix: "trainingprovider",

--- a/app/views/offer/new/change-course/confirm.njk
+++ b/app/views/offer/new/change-course/confirm.njk
@@ -15,8 +15,8 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      <span class="govuk-caption-xl">{{name}}</span>
-      <h1 class="govuk-heading-xl">{{title}}</h1>
+      <span class="govuk-caption-l">{{name}}</span>
+      <h1 class="govuk-heading-l">{{title}}</h1>
 
       <div class="app-offer-panel">
 

--- a/app/views/offer/new/change-course/course.njk
+++ b/app/views/offer/new/change-course/course.njk
@@ -14,7 +14,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       {% set h1 %}
-        <span class="govuk-caption-xl">{{name}}</span>
+        <span class="govuk-caption-l">{{name}}</span>
         {{title}}
       {% endset %}
       <form method="post">
@@ -23,7 +23,7 @@
           fieldset: {
             legend: {
               html: h1,
-              classes: "govuk-fieldset__legend--xl",
+              classes: "govuk-fieldset__legend--l",
               isPageHeading: true
             }
           },

--- a/app/views/offer/new/change-course/location.njk
+++ b/app/views/offer/new/change-course/location.njk
@@ -14,7 +14,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       {% set h1 %}
-        <span class="govuk-caption-xl">{{name}}</span>
+        <span class="govuk-caption-l">{{name}}</span>
         {{title}}
       {% endset %}
       <form method="post">
@@ -23,7 +23,7 @@
           fieldset: {
             legend: {
               html: h1,
-              classes: "govuk-fieldset__legend--xl",
+              classes: "govuk-fieldset__legend--l",
               isPageHeading: true
             }
           },

--- a/app/views/offer/new/change-location/confirm.njk
+++ b/app/views/offer/new/change-location/confirm.njk
@@ -15,8 +15,8 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      <span class="govuk-caption-xl">{{name}}</span>
-      <h1 class="govuk-heading-xl">{{title}}</h1>
+      <span class="govuk-caption-l">{{name}}</span>
+      <h1 class="govuk-heading-l">{{title}}</h1>
 
       <div class="app-offer-panel">
 

--- a/app/views/offer/new/change-location/location.njk
+++ b/app/views/offer/new/change-location/location.njk
@@ -14,7 +14,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       {% set h1 %}
-        <span class="govuk-caption-xl">{{name}}</span>
+        <span class="govuk-caption-l">{{name}}</span>
         {{title}}
       {% endset %}
       <form method="post">
@@ -24,7 +24,7 @@
             legend: {
               html: h1,
               isPageHeading: true,
-              classes: "govuk-fieldset__legend--xl"
+              classes: "govuk-fieldset__legend--l"
             }
           },
           idPrefix: "location",

--- a/app/views/offer/new/change-provider/confirm.njk
+++ b/app/views/offer/new/change-provider/confirm.njk
@@ -15,8 +15,8 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      <span class="govuk-caption-xl">{{name}}</span>
-      <h1 class="govuk-heading-xl">{{title}}</h1>
+      <span class="govuk-caption-l">{{name}}</span>
+      <h1 class="govuk-heading-l">{{title}}</h1>
 
       <div class="app-offer-panel">
 

--- a/app/views/offer/new/change-provider/course.njk
+++ b/app/views/offer/new/change-provider/course.njk
@@ -14,7 +14,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       {% set h1 %}
-        <span class="govuk-caption-xl">{{name}}</span>
+        <span class="govuk-caption-l">{{name}}</span>
         {{title}}
       {% endset %}
       <form method="post">
@@ -24,7 +24,7 @@
             legend: {
               html: h1,
               isPageHeading: true,
-              classes: "govuk-fieldset__legend--xl"
+              classes: "govuk-fieldset__legend--l"
             }
           },
           idPrefix: "course",

--- a/app/views/offer/new/change-provider/location.njk
+++ b/app/views/offer/new/change-provider/location.njk
@@ -14,7 +14,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       {% set h1 %}
-        <span class="govuk-caption-xl">{{name}}</span>
+        <span class="govuk-caption-l">{{name}}</span>
         {{title}}
       {% endset %}
       <form method="post">
@@ -24,7 +24,7 @@
             legend: {
               html: h1,
               isPageHeading: true,
-              classes: "govuk-fieldset__legend--xl"
+              classes: "govuk-fieldset__legend--l"
             }
           },
           idPrefix: "location",

--- a/app/views/offer/new/change-provider/provider.njk
+++ b/app/views/offer/new/change-provider/provider.njk
@@ -14,7 +14,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       {% set h1 %}
-        <span class="govuk-caption-xl">{{name}}</span>
+        <span class="govuk-caption-l">{{name}}</span>
         {{title}}
       {% endset %}
 
@@ -25,7 +25,7 @@
             legend: {
               html: h1,
               isPageHeading: true,
-              classes: "govuk-fieldset__legend--xl"
+              classes: "govuk-fieldset__legend--l"
             }
           },
           idPrefix: "providerx",

--- a/app/views/offer/new/standard/confirm.njk
+++ b/app/views/offer/new/standard/confirm.njk
@@ -28,8 +28,8 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <span class="govuk-caption-xl">{{name}}</span>
-      <h1 class="govuk-heading-xl">{{title}}</h1>
+      <span class="govuk-caption-l">{{name}}</span>
+      <h1 class="govuk-heading-l">{{title}}</h1>
 
       <div class="app-offer-panel ">
 

--- a/app/views/offer/reconfirm/action.njk
+++ b/app/views/offer/reconfirm/action.njk
@@ -36,8 +36,8 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <span class="govuk-caption-xl">{{name}}</span>
-      <h1 class="govuk-heading-xl">{{title}}</h1>
+      <span class="govuk-caption-l">{{name}}</span>
+      <h1 class="govuk-heading-l">{{title}}</h1>
 
       <div class="app-offer-pane govuk-!-margin-bottom-7">
         <p>The course offered to the candidate in the previous cycle is available in the current cycle. On the next screen, you can change the status of the conditions of the offer.</p>

--- a/app/views/offer/reconfirm/check.njk
+++ b/app/views/offer/reconfirm/check.njk
@@ -37,8 +37,8 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
 
-      <span class="govuk-caption-xl">{{name}}</span>
-      <h1 class="govuk-heading-xl">{{title}}</h1>
+      <span class="govuk-caption-l">{{name}}</span>
+      <h1 class="govuk-heading-l">{{title}}</h1>
 
       <div class="app-offer-panel">
         <h2 class="govuk-heading-m">

--- a/app/views/offer/reconfirm/course.njk
+++ b/app/views/offer/reconfirm/course.njk
@@ -13,7 +13,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       {% set h1 %}
-        <span class="govuk-caption-xl">{{name}}</span>
+        <span class="govuk-caption-l">{{name}}</span>
         {{title}}
       {% endset %}
 
@@ -24,7 +24,7 @@
             legend: {
               html: h1,
               isPageHeading: true,
-              classes: "govuk-fieldset__legend--xl"
+              classes: "govuk-fieldset__legend--l"
             }
           },
           idPrefix: "course",

--- a/app/views/offer/reconfirm/location.njk
+++ b/app/views/offer/reconfirm/location.njk
@@ -14,7 +14,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       {% set h1 %}
-        <span class="govuk-caption-xl">{{name}}</span>
+        <span class="govuk-caption-l">{{name}}</span>
         {{title}}
       {% endset %}
       <form method="post">
@@ -24,7 +24,7 @@
             legend: {
               html: h1,
               isPageHeading: true,
-              classes: "govuk-fieldset__legend--xl"
+              classes: "govuk-fieldset__legend--l"
             }
           },
           idPrefix: "location",

--- a/app/views/offer/reconfirm/provider.njk
+++ b/app/views/offer/reconfirm/provider.njk
@@ -13,7 +13,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       {% set h1 %}
-        <span class="govuk-caption-xl">{{name}}</span>
+        <span class="govuk-caption-l">{{name}}</span>
         {{title}}
       {% endset %}
       <form method="post">
@@ -23,7 +23,7 @@
             legend: {
               html: h1,
               isPageHeading: true,
-              classes: "govuk-fieldset__legend--xl"
+              classes: "govuk-fieldset__legend--l"
             }
           },
           idPrefix: "trainingprovider",

--- a/app/views/offer/reconfirm/unavailable-course/action.njk
+++ b/app/views/offer/reconfirm/unavailable-course/action.njk
@@ -36,8 +36,8 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <span class="govuk-caption-xl">{{name}}</span>
-      <h1 class="govuk-heading-xl">Review deferred offer</h1>
+      <span class="govuk-caption-l">{{name}}</span>
+      <h1 class="govuk-heading-l">Review deferred offer</h1>
 
       <div class="app-offer-pane govuk-!-margin-bottom-7">
         {# <p>{{application.course}} at {{application.provider}} is no longer available. You need to choose a different course.</p> #}

--- a/app/views/offer/reconfirm/unavailable-course/check.njk
+++ b/app/views/offer/reconfirm/unavailable-course/check.njk
@@ -14,8 +14,8 @@
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <span class="govuk-caption-xl">{{name}}</span>
-      <h1 class="govuk-heading-xl">{{title}}</h1>
+      <span class="govuk-caption-l">{{name}}</span>
+      <h1 class="govuk-heading-l">{{title}}</h1>
 
       <div class="app-offer-panel">
         <h2 class="govuk-heading-m">

--- a/app/views/offer/reconfirm/unavailable-course/course.njk
+++ b/app/views/offer/reconfirm/unavailable-course/course.njk
@@ -12,8 +12,8 @@
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <span class="govuk-caption-xl">{{name}}</span>
-      <h1 class="govuk-heading-xl govuk-!-margin-bottom-4">
+      <span class="govuk-caption-l">{{name}}</span>
+      <h1 class="govuk-heading-l govuk-!-margin-bottom-4">
         {{title}}
       </h1>
 

--- a/app/views/offer/reconfirm/unavailable-course/location.njk
+++ b/app/views/offer/reconfirm/unavailable-course/location.njk
@@ -13,8 +13,8 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <span class="govuk-caption-xl">{{name}}</span>
-      <h1 class="govuk-heading-xl govuk-!-margin-bottom-4">
+      <span class="govuk-caption-l">{{name}}</span>
+      <h1 class="govuk-heading-l govuk-!-margin-bottom-4">
         {{title}}
       </h1>
 

--- a/app/views/offer/reconfirm/unavailable-course/provider.njk
+++ b/app/views/offer/reconfirm/unavailable-course/provider.njk
@@ -13,7 +13,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       {% set h1 %}
-        <span class="govuk-caption-xl">{{name}}</span>
+        <span class="govuk-caption-l">{{name}}</span>
         {{title}}
       {% endset %}
       <form method="post">
@@ -23,7 +23,7 @@
             legend: {
               html: h1,
               isPageHeading: true,
-              classes: "govuk-fieldset__legend--xl"
+              classes: "govuk-fieldset__legend--l"
             }
           },
           idPrefix: "trainingprovider",

--- a/app/views/offer/reconfirm/unavailable-location/action.njk
+++ b/app/views/offer/reconfirm/unavailable-location/action.njk
@@ -36,8 +36,8 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <span class="govuk-caption-xl">{{name}}</span>
-      <h1 class="govuk-heading-xl">{{title}}</h1>
+      <span class="govuk-caption-l">{{name}}</span>
+      <h1 class="govuk-heading-l">{{title}}</h1>
 
       <div class="app-offer-pane govuk-!-margin-bottom-7">
         {# <p>{{application.course}} is not available at Alliance Academy, Edgeware, Road Name, SW1 1AA. You need to choose another location or course.</p> #}

--- a/app/views/offer/reconfirm/unavailable-location/check.njk
+++ b/app/views/offer/reconfirm/unavailable-location/check.njk
@@ -36,8 +36,8 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <span class="govuk-caption-xl">{{name}}</span>
-      <h1 class="govuk-heading-xl">{{title}}</h1>
+      <span class="govuk-caption-l">{{name}}</span>
+      <h1 class="govuk-heading-l">{{title}}</h1>
 
       <div class="app-offer-panel">
         <h2 class="govuk-heading-m">

--- a/app/views/offer/reconfirm/unavailable-location/location.njk
+++ b/app/views/offer/reconfirm/unavailable-location/location.njk
@@ -13,8 +13,8 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <span class="govuk-caption-xl">{{name}}</span>
-      <h1 class="govuk-heading-xl govuk-!-margin-bottom-4">
+      <span class="govuk-caption-l">{{name}}</span>
+      <h1 class="govuk-heading-l govuk-!-margin-bottom-4">
         {{title}}
       </h1>
 

--- a/app/views/offer/withdraw/check.njk
+++ b/app/views/offer/withdraw/check.njk
@@ -13,8 +13,8 @@
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <span class="govuk-caption-xl">{{name}}</span>
-      <h1 class="govuk-heading-xl">{{title}}</h1>
+      <span class="govuk-caption-l">{{name}}</span>
+      <h1 class="govuk-heading-l">{{title}}</h1>
 
       <p>Your feedback will be given to the candidate in the format below.</p>
 

--- a/app/views/offer/withdraw/index.njk
+++ b/app/views/offer/withdraw/index.njk
@@ -13,8 +13,8 @@
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <span class="govuk-caption-xl">{{name}}</span>
-      <h1 class="govuk-heading-xl">{{title}}</h1>
+      <span class="govuk-caption-l">{{name}}</span>
+      <h1 class="govuk-heading-l">{{title}}</h1>
       <p>When giving details or advice, bear in mind the candidate will see this feedback. </p>
 
       <form method="post">

--- a/app/views/offer/withdraw/other-reasons-for-rejection.njk
+++ b/app/views/offer/withdraw/other-reasons-for-rejection.njk
@@ -13,8 +13,8 @@
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <span class="govuk-caption-xl">{{name}}</span>
-      <h1 class="govuk-heading-xl">{{title}}</h1>
+      <span class="govuk-caption-l">{{name}}</span>
+      <h1 class="govuk-heading-l">{{title}}</h1>
       <p>When giving details or advice, bear in mind the candidate will see this feedback. </p>
 
       <form method="post">

--- a/app/views/onboard-notifications/check.njk
+++ b/app/views/onboard-notifications/check.njk
@@ -23,7 +23,7 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-xl">{{title}}</h1>
+      <h1 class="govuk-heading-l">{{title}}</h1>
 
       <h2 class="govuk-heading-m govuk-!-margin-bottom-3">
         For applications to courses run by {{ data.user.organisations[1].name }} and ratified by {{ data.accreditedBodies[0].name }}

--- a/app/views/onboard-notifications/index.njk
+++ b/app/views/onboard-notifications/index.njk
@@ -7,7 +7,7 @@
 
       <div class="app-callout-car">
 
-        <h1 class="govuk-heading-xl">You can change your notification settings</h1>
+        <h1 class="govuk-heading-l">You can change your notification settings</h1>
 
         <p class="govuk-body">You’ll get notifications about your applications.</p>
 

--- a/app/views/onboard-notifications/setup-1.njk
+++ b/app/views/onboard-notifications/setup-1.njk
@@ -13,8 +13,8 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      <span class="govuk-caption-xl">{{title}}</span>
-      <h1 class="govuk-heading-xl">For applications to courses run by {{ data.user.organisations[1].name }} and ratified by {{ data.accreditedBodies[0].name }}</h1>
+      <span class="govuk-caption-l">{{title}}</span>
+      <h1 class="govuk-heading-l">For applications to courses run by {{ data.user.organisations[1].name }} and ratified by {{ data.accreditedBodies[0].name }}</h1>
 
       {% macro notificationField(params) %}
         {% set applicationSubmittedFrequencyHtml %}

--- a/app/views/onboard-notifications/setup-2.njk
+++ b/app/views/onboard-notifications/setup-2.njk
@@ -13,8 +13,8 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      <span class="govuk-caption-xl">{{title}}</span>
-      <h1 class="govuk-heading-xl">For applications to courses run by {{ data.user.organisations[1].name }} and ratified by Teaching Brilliance University</h1>
+      <span class="govuk-caption-l">{{title}}</span>
+      <h1 class="govuk-heading-l">For applications to courses run by {{ data.user.organisations[1].name }} and ratified by Teaching Brilliance University</h1>
 
       {% macro notificationField(params) %}
         {% set applicationSubmittedFrequencyHtml %}

--- a/app/views/onboard/check.njk
+++ b/app/views/onboard/check.njk
@@ -21,8 +21,8 @@
 
       {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 
-      <span class="govuk-caption-xl">Set up permissions</span>
-      <h1 class="govuk-heading-xl">Check permissions</h1>
+      <span class="govuk-caption-l">Set up permissions</span>
+      <h1 class="govuk-heading-l">Check permissions</h1>
 
       <form novalidate action="/onboard/confirmation">
 

--- a/app/views/onboard/relationship1.njk
+++ b/app/views/onboard/relationship1.njk
@@ -14,8 +14,8 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      <span class="govuk-caption-xl">Set up permissions</span>
-      <h1 class="govuk-heading-xl">{{org}} and {{partner}}</h1>
+      <span class="govuk-caption-l">Set up permissions</span>
+      <h1 class="govuk-heading-l">{{org}} and {{partner}}</h1>
 
       {% include "_includes/permissions-guidance.njk" %}
 

--- a/app/views/organisations/delete.njk
+++ b/app/views/organisations/delete.njk
@@ -14,8 +14,8 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      <span class="govuk-caption-xl">Harry Potter</span>
-      <h1 class="govuk-heading-xl">Are you sure you want to delete this user’s account?</h1>
+      <span class="govuk-caption-l">Harry Potter</span>
+      <h1 class="govuk-heading-l">Are you sure you want to delete this user’s account?</h1>
 
       <form novalidate method="post">
         {{ govukButton({

--- a/app/views/organisations/edit.njk
+++ b/app/views/organisations/edit.njk
@@ -13,8 +13,8 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <span class="govuk-caption-xl">Change permissions</span>
-      <h1 class="govuk-heading-xl">For courses run by {{ data.user.organisations[1].name }} and ratified by {{ data.user.organisations[0].name }}</h1>
+      <span class="govuk-caption-l">Change permissions</span>
+      <h1 class="govuk-heading-l">For courses run by {{ data.user.organisations[1].name }} and ratified by {{ data.user.organisations[0].name }}</h1>
 
       {% include "_includes/permissions-guidance.njk" %}
 

--- a/app/views/organisations/index.njk
+++ b/app/views/organisations/index.njk
@@ -18,7 +18,7 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-xl">{{title}}</h1>
+      <h1 class="govuk-heading-l">{{title}}</h1>
 
       <p>Use this section to change permissions between your own organisations and your partner organisations.</p>
 

--- a/app/views/organisations/show.njk
+++ b/app/views/organisations/show.njk
@@ -28,8 +28,8 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <span class="govuk-caption-xl">Organisational permissions</span>
-      <h1 class="govuk-heading-xl">{{title}}</h1>
+      <span class="govuk-caption-l">Organisational permissions</span>
+      <h1 class="govuk-heading-l">{{title}}</h1>
 
       {% set tick %}
         {{ appIcon({

--- a/app/views/users/change-email-address.njk
+++ b/app/views/users/change-email-address.njk
@@ -19,7 +19,7 @@
     <div class="govuk-grid-column-two-thirds">
 
       {% set h1 %}
-        <span class="govuk-caption-xl">{{name}}</span>
+        <span class="govuk-caption-l">{{name}}</span>
         {{title}}
       {% endset %}
 
@@ -27,7 +27,7 @@
         {{ govukInput({
           label: {
             html: h1,
-            classes: "govuk-label--xl",
+            classes: "govuk-label--l",
             isPageHeading: true
           },
           id: "new-email-address",

--- a/app/views/users/change-name.njk
+++ b/app/views/users/change-name.njk
@@ -17,8 +17,8 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      <span class="govuk-caption-xl">{{name}}</span>
-      <h1 class="govuk-heading-xl">{{title}}</h1>
+      <span class="govuk-caption-l">{{name}}</span>
+      <h1 class="govuk-heading-l">{{title}}</h1>
 
       <form novalidate method="post">
         {{ govukInput({

--- a/app/views/users/change-organisations.njk
+++ b/app/views/users/change-organisations.njk
@@ -17,7 +17,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       {% set h1 %}
-        <span class="govuk-caption-xl">{{name}}</span>
+        <span class="govuk-caption-l">{{name}}</span>
         {{title}}
       {% endset %}
 
@@ -27,7 +27,7 @@
             legend: {
               html: h1,
               isPageHeading: true,
-              classes: "govuk-fieldset__legend--xl"
+              classes: "govuk-fieldset__legend--l"
             }
           },
 

--- a/app/views/users/change-organisations/check.njk
+++ b/app/views/users/change-organisations/check.njk
@@ -15,8 +15,8 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-        <span class="govuk-caption-xl">{{name}}</span>
-        <h1 class="govuk-heading-xl">{{title}}</h1>
+        <span class="govuk-caption-l">{{name}}</span>
+        <h1 class="govuk-heading-l">{{title}}</h1>
 
 
       {% set permissionsHtml %}

--- a/app/views/users/change-organisations/index.njk
+++ b/app/views/users/change-organisations/index.njk
@@ -16,7 +16,7 @@
     <div class="govuk-grid-column-two-thirds">
 
       {% set h1 %}
-        <span class="govuk-caption-xl">{{name}}</span>
+        <span class="govuk-caption-l">{{name}}</span>
         {{title}}
       {% endset %}
 
@@ -28,7 +28,7 @@
             legend: {
               html: h1,
               isPageHeading: true,
-              classes: "govuk-fieldset__legend--xl"
+              classes: "govuk-fieldset__legend--l"
             }
           },
 

--- a/app/views/users/change-organisations/permissions1.njk
+++ b/app/views/users/change-organisations/permissions1.njk
@@ -17,7 +17,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       {% set h1 %}
-        <span class="govuk-caption-xl">{{name}}</span>
+        <span class="govuk-caption-l">{{name}}</span>
         {{title}}
       {% endset %}
 
@@ -87,7 +87,7 @@
               legend: {
                 html: h1,
                 isPageHeading: true,
-                classes: "govuk-fieldset__legend--xl"
+                classes: "govuk-fieldset__legend--l"
               }
             },
             hint: {

--- a/app/views/users/change-permissions.njk
+++ b/app/views/users/change-permissions.njk
@@ -17,7 +17,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       {% set h1 %}
-        <span class="govuk-caption-xl">{{name}}</span>
+        <span class="govuk-caption-l">{{name}}</span>
         {{title}}
       {% endset %}
 
@@ -226,7 +226,7 @@
             legend: {
               html: h1,
               isPageHeading: true,
-              classes: "govuk-fieldset__legend--xl"
+              classes: "govuk-fieldset__legend--l"
             }
           },
           items: [

--- a/app/views/users/delete.njk
+++ b/app/views/users/delete.njk
@@ -17,8 +17,8 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      <span class="govuk-caption-xl">{{name}}</span>
-      <h1 class="govuk-heading-xl">{{title}}</h1>
+      <span class="govuk-caption-l">{{name}}</span>
+      <h1 class="govuk-heading-l">{{title}}</h1>
 
       <form novalidate method="post">
         {{ govukButton({

--- a/app/views/users/index.njk
+++ b/app/views/users/index.njk
@@ -23,7 +23,7 @@
 
   <div class="govuk-grid">
     <div class="govuk-grid-column-two-third">
-      <h1 class="govuk-heading-xl">{{title}}</h1>
+      <h1 class="govuk-heading-l">{{title}}</h1>
       {{govukButton({
         text: 'Invite user',
         href: '/users/new'

--- a/app/views/users/new/check.njk
+++ b/app/views/users/new/check.njk
@@ -13,8 +13,8 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      <span class="govuk-caption-xl">Invite user</span>
-      <h1 class="govuk-heading-xl">{{title}}</h1>
+      <span class="govuk-caption-l">Invite user</span>
+      <h1 class="govuk-heading-l">{{title}}</h1>
 
       <dl class="govuk-summary-list">
         <div class="govuk-summary-list__row">

--- a/app/views/users/new/index.njk
+++ b/app/views/users/new/index.njk
@@ -13,8 +13,8 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <span class="govuk-caption-xl">Invite user</span>
-      <h1 class="govuk-heading-xl">Basic details</h1>
+      <span class="govuk-caption-l">Invite user</span>
+      <h1 class="govuk-heading-l">Basic details</h1>
 
       <form novalidate method="post">
         {{ govukInput({

--- a/app/views/users/new/organisations.njk
+++ b/app/views/users/new/organisations.njk
@@ -12,7 +12,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       {% set h1 %}
-        <span class="govuk-caption-xl">Invite user</span>
+        <span class="govuk-caption-l">Invite user</span>
         Select organisations this user will have access to
       {% endset %}
 
@@ -22,7 +22,7 @@
             legend: {
               html: h1,
               isPageHeading: true,
-              classes: "govuk-fieldset__legend--xl"
+              classes: "govuk-fieldset__legend--l"
             }
           },
           items: organisationItems

--- a/app/views/users/new/permissions.njk
+++ b/app/views/users/new/permissions.njk
@@ -13,7 +13,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       {% set h1 %}
-        <span class="govuk-caption-xl">Invite user</span>
+        <span class="govuk-caption-l">Invite user</span>
         Set permissions: {{ org.org.name }}
       {% endset %}
 
@@ -219,7 +219,7 @@
             legend: {
               html: h1,
               isPageHeading: true,
-              classes: "govuk-fieldset__legend--xl"
+              classes: "govuk-fieldset__legend--l"
             }
           },
           items: [

--- a/app/views/users/show.njk
+++ b/app/views/users/show.njk
@@ -30,7 +30,7 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-xl">{{title}}</h1>
+      <h1 class="govuk-heading-l">{{title}}</h1>
 
       <dl class="govuk-summary-list">
         <div class="govuk-summary-list__row">


### PR DESCRIPTION
Change all `xl` headings, labels, legends and captions to `l`

On application details page change `l` headings to `m` headings and `m` headings to `s` headings