### PR TITLE
Add alert and info icons

### DIFF
--- a/app/views/_components/icon/template.njk
+++ b/app/views/_components/icon/template.njk
@@ -1,7 +1,11 @@
-<svg class="app-icon{%- if params.classes %} {{ params.classes }}{% endif %}" xmlns="http://www.w3.org/2000/svg" width="{{ params.size | default(16) }}" height="{{ params.size | default(16) }}" viewBox="0 0 200 200" focusable="false" fill="currentColor"{%- if params.label %} aria-label="{{ params.label }}"{% endif %}{%- if params.hidden %} aria-hidden="true"{% endif %}>
+<svg class="app-icon{%- if params.classes %} {{ params.classes }}{% endif %}" xmlns="http://www.w3.org/2000/svg" width="{{ params.size | default(16) }}" height="{{ params.size | default(16) }}" viewBox="0 0 228 200" focusable="false" fill="currentColor"{%- if params.label %} aria-label="{{ params.label }}"{% endif %}{%- if params.hidden %} aria-hidden="true"{% endif %}>
 {% if params.icon == "tick" %}
   <path d="M100 200a100 100 0 1 1 0-200 100 100 0 0 1 0 200zm-60-85l40 40 80-80-20-20-60 60-20-20-20 20z"/>
 {% elif params.icon == "cross" %}
   <path d="M100 0a100 100 0 110 200 100 100 0 010-200zm30 50l-30 30-30-30-20 20 30 30-30 30 20 20 30-30 30 30 20-20-30-30 30-30-20-20z"/>
+{% elif params.icon == "info" %}
+  <path d="M100 0a100 100 0 110 200 100 100 0 010-200zm16 90H88v72h28V90zm-14-52a16 16 0 100 32 16 16 0 000-32z"/>
+{% elif params.icon == "alert" %}
+  <path d="M109.1 2.3A16 16 0 01131 8.5l93 167.7a16 16 0 01-14 23.8H18.8A16 16 0 015 176L103 8.1a16 16 0 016.1-5.9zM114 146a16 16 0 100 32 16 16 0 000-32zm13-90h-26l2 72h22l2-72z"/>
 {% endif %}
 </svg>

--- a/app/views/_components/icon/template.njk
+++ b/app/views/_components/icon/template.njk
@@ -1,5 +1,5 @@
 <svg class="app-icon{%- if params.classes %} {{ params.classes }}{% endif %}" xmlns="http://www.w3.org/2000/svg" width="{{ params.size | default(16) }}" height="{{ params.size | default(16) }}" viewBox="0 0 228 200" focusable="false" fill="currentColor"{%- if params.label %} aria-label="{{ params.label }}"{% endif %}{%- if params.hidden %} aria-hidden="true"{% endif %}>
-{% if params.icon == "tick" %}
+{% if params.icon == "check" %}
   <path d="M100 200a100 100 0 1 1 0-200 100 100 0 0 1 0 200zm-60-85l40 40 80-80-20-20-60 60-20-20-20 20z"/>
 {% elif params.icon == "cross" %}
   <path d="M100 0a100 100 0 110 200 100 100 0 010-200zm30 50l-30 30-30-30-20 20 30 30-30 30 20 20 30-30 30 30 20-20-30-30 30-30-20-20z"/>

--- a/app/views/_includes/application/school-experience.njk
+++ b/app/views/_includes/application/school-experience.njk
@@ -15,7 +15,6 @@
       <p class="govuk-body">{{ item.timeCommitment or "—" }}</p>
       {%- if item.workedWithChildren == "Yes" %}
         <p class="govuk-body govuk-!-font-size-16">{{ appIcon({
-          classes: "govuk-!-margin-right-1",
           icon: "check",
           hidden: true
         }) }} Worked with children</p>

--- a/app/views/_includes/application/school-experience.njk
+++ b/app/views/_includes/application/school-experience.njk
@@ -16,7 +16,7 @@
       {%- if item.workedWithChildren == "Yes" %}
         <p class="govuk-body govuk-!-font-size-16">{{ appIcon({
           classes: "govuk-!-margin-right-1",
-          icon: "tick",
+          icon: "check",
           hidden: true
         }) }} Worked with children</p>
       {%- endif %}

--- a/app/views/_includes/application/work-history.njk
+++ b/app/views/_includes/application/work-history.njk
@@ -17,7 +17,7 @@
       {%- if item.workedWithChildren == "Yes" %}
         <p class="govuk-body govuk-!-font-size-16">{{ appIcon({
           classes: "govuk-!-margin-right-1",
-          icon: "tick",
+          icon: "check",
           hidden: true
         }) }} Worked with children</p>
       {%- endif %}

--- a/app/views/_includes/application/work-history.njk
+++ b/app/views/_includes/application/work-history.njk
@@ -16,7 +16,6 @@
       <p class="govuk-body">{{ item.description }}</p>
       {%- if item.workedWithChildren == "Yes" %}
         <p class="govuk-body govuk-!-font-size-16">{{ appIcon({
-          classes: "govuk-!-margin-right-1",
           icon: "check",
           hidden: true
         }) }} Worked with children</p>

--- a/app/views/_includes/permissions-guidance.njk
+++ b/app/views/_includes/permissions-guidance.njk
@@ -1,7 +1,7 @@
 {% set tick %}
   {{ appIcon({
     classes: "govuk-!-margin-right-1",
-    icon: "tick",
+    icon: "check",
     hidden: true
   }) }}
 {% endset %}

--- a/app/views/_includes/permissions-guidance.njk
+++ b/app/views/_includes/permissions-guidance.njk
@@ -1,6 +1,5 @@
 {% set tick %}
   {{ appIcon({
-    classes: "govuk-!-margin-right-1",
     icon: "check",
     hidden: true
   }) }}

--- a/app/views/account/notifications/index.njk
+++ b/app/views/account/notifications/index.njk
@@ -18,12 +18,12 @@
 {% block content %}
 
   {% set emailOnceADay %}
-    {{appIcon({ classes: "govuk-!-margin-right-1", icon: "tick", hidden: true})}}
+    {{appIcon({ classes: "govuk-!-margin-right-1", icon: "check", hidden: true})}}
     <span class="app-email-settings">Daily at 8am</span>
   {% endset %}
 
   {% set emailImmediately %}
-    {{appIcon({ classes: "govuk-!-margin-right-1", icon: "tick", hidden: true})}}
+    {{appIcon({ classes: "govuk-!-margin-right-1", icon: "check", hidden: true})}}
     <span class="app-email-settings">Immediately</span>
   {% endset %}
 
@@ -64,7 +64,7 @@
               html: emailImmediately
             },
             {
-              html: appIcon({ classes: "govuk-!-margin-right-1", icon: "tick", hidden: true})
+              html: appIcon({ classes: "govuk-!-margin-right-1", icon: "check", hidden: true})
             }
           ],
           [
@@ -86,7 +86,7 @@
               html: emailImmediately
             },
             {
-              html: appIcon({ classes: "govuk-!-margin-right-1", icon: "tick", hidden: true})
+              html: appIcon({ classes: "govuk-!-margin-right-1", icon: "check", hidden: true})
             }
           ],
           [
@@ -119,7 +119,7 @@
               html: emailOnceADay
             },
             {
-              html: appIcon({ classes: "govuk-!-margin-right-1", icon: "tick", hidden: true})
+              html: appIcon({ classes: "govuk-!-margin-right-1", icon: "check", hidden: true})
             }
           ],
           [
@@ -130,7 +130,7 @@
               html: emailOnceADay
             },
             {
-              html: appIcon({ classes: "govuk-!-margin-right-1", icon: "tick", hidden: true})
+              html: appIcon({ classes: "govuk-!-margin-right-1", icon: "check", hidden: true})
             }
           ],
           [
@@ -141,7 +141,7 @@
               html: ""
             },
             {
-              html: appIcon({ classes: "govuk-!-margin-right-1", icon: "tick", hidden: true})
+              html: appIcon({ classes: "govuk-!-margin-right-1", icon: "check", hidden: true})
             }
           ],
           [
@@ -192,7 +192,7 @@
               html: emailOnceADay
             },
             {
-              html: appIcon({ classes: "govuk-!-margin-right-1", icon: "tick", hidden: true})
+              html: appIcon({ classes: "govuk-!-margin-right-1", icon: "check", hidden: true})
             }
           ],
           [
@@ -214,7 +214,7 @@
               html: emailOnceADay
             },
             {
-              html: appIcon({ classes: "govuk-!-margin-right-1", icon: "tick", hidden: true})
+              html: appIcon({ classes: "govuk-!-margin-right-1", icon: "check", hidden: true})
             }
           ],
           [
@@ -247,7 +247,7 @@
               html: emailOnceADay
             },
             {
-              html: appIcon({ classes: "govuk-!-margin-right-1", icon: "tick", hidden: true})
+              html: appIcon({ classes: "govuk-!-margin-right-1", icon: "check", hidden: true})
             }
           ],
           [
@@ -258,7 +258,7 @@
               html: emailOnceADay
             },
             {
-              html: appIcon({ classes: "govuk-!-margin-right-1", icon: "tick", hidden: true})
+              html: appIcon({ classes: "govuk-!-margin-right-1", icon: "check", hidden: true})
             }
           ],
           [
@@ -269,7 +269,7 @@
               html: emailOnceADay
             },
             {
-              html: appIcon({ classes: "govuk-!-margin-right-1", icon: "tick", hidden: true})
+              html: appIcon({ classes: "govuk-!-margin-right-1", icon: "check", hidden: true})
             }
           ],
           [

--- a/app/views/account/notifications/index.njk
+++ b/app/views/account/notifications/index.njk
@@ -18,12 +18,12 @@
 {% block content %}
 
   {% set emailOnceADay %}
-    {{appIcon({ classes: "govuk-!-margin-right-1", icon: "check", hidden: true})}}
+    {{appIcon({ icon: "check", hidden: true})}}
     <span class="app-email-settings">Daily at 8am</span>
   {% endset %}
 
   {% set emailImmediately %}
-    {{appIcon({ classes: "govuk-!-margin-right-1", icon: "check", hidden: true})}}
+    {{appIcon({ icon: "check", hidden: true})}}
     <span class="app-email-settings">Immediately</span>
   {% endset %}
 
@@ -64,7 +64,7 @@
               html: emailImmediately
             },
             {
-              html: appIcon({ classes: "govuk-!-margin-right-1", icon: "check", hidden: true})
+              html: appIcon({ icon: "check", hidden: true})
             }
           ],
           [
@@ -86,7 +86,7 @@
               html: emailImmediately
             },
             {
-              html: appIcon({ classes: "govuk-!-margin-right-1", icon: "check", hidden: true})
+              html: appIcon({ icon: "check", hidden: true})
             }
           ],
           [
@@ -119,7 +119,7 @@
               html: emailOnceADay
             },
             {
-              html: appIcon({ classes: "govuk-!-margin-right-1", icon: "check", hidden: true})
+              html: appIcon({ icon: "check", hidden: true})
             }
           ],
           [
@@ -130,7 +130,7 @@
               html: emailOnceADay
             },
             {
-              html: appIcon({ classes: "govuk-!-margin-right-1", icon: "check", hidden: true})
+              html: appIcon({ icon: "check", hidden: true})
             }
           ],
           [
@@ -141,7 +141,7 @@
               html: ""
             },
             {
-              html: appIcon({ classes: "govuk-!-margin-right-1", icon: "check", hidden: true})
+              html: appIcon({ icon: "check", hidden: true})
             }
           ],
           [
@@ -192,7 +192,7 @@
               html: emailOnceADay
             },
             {
-              html: appIcon({ classes: "govuk-!-margin-right-1", icon: "check", hidden: true})
+              html: appIcon({ icon: "check", hidden: true})
             }
           ],
           [
@@ -214,7 +214,7 @@
               html: emailOnceADay
             },
             {
-              html: appIcon({ classes: "govuk-!-margin-right-1", icon: "check", hidden: true})
+              html: appIcon({ icon: "check", hidden: true})
             }
           ],
           [
@@ -247,7 +247,7 @@
               html: emailOnceADay
             },
             {
-              html: appIcon({ classes: "govuk-!-margin-right-1", icon: "check", hidden: true})
+              html: appIcon({ icon: "check", hidden: true})
             }
           ],
           [
@@ -258,7 +258,7 @@
               html: emailOnceADay
             },
             {
-              html: appIcon({ classes: "govuk-!-margin-right-1", icon: "check", hidden: true})
+              html: appIcon({ icon: "check", hidden: true})
             }
           ],
           [
@@ -269,7 +269,7 @@
               html: emailOnceADay
             },
             {
-              html: appIcon({ classes: "govuk-!-margin-right-1", icon: "check", hidden: true})
+              html: appIcon({ icon: "check", hidden: true})
             }
           ],
           [

--- a/app/views/account/organisational-permissions/show.njk
+++ b/app/views/account/organisational-permissions/show.njk
@@ -36,7 +36,7 @@
       {% set tick %}
         {{ appIcon({
           classes: "govuk-!-margin-right-1",
-          icon: "tick",
+          icon: "check",
           hidden: true
         }) }}
       {% endset %}

--- a/app/views/account/organisational-permissions/show.njk
+++ b/app/views/account/organisational-permissions/show.njk
@@ -35,7 +35,6 @@
 
       {% set tick %}
         {{ appIcon({
-          classes: "govuk-!-margin-right-1",
           icon: "check",
           hidden: true
         }) }}

--- a/app/views/account/profile.njk
+++ b/app/views/account/profile.njk
@@ -21,19 +21,19 @@
   {% set permissionsHtml %}
   <p class="govuk-!-font-weight-bold">{{ appIcon({
         classes: "govuk-!-margin-right-1",
-        icon: "tick",
+        icon: "check",
         hidden: true
       }) }} Manage organisation</p>
 
   <p class="govuk-!-font-weight-bold">{{ appIcon({
         classes: "govuk-!-margin-right-1",
-        icon: "tick",
+        icon: "check",
         hidden: true
       }) }} Manage users</p>
 
   <p class="govuk-!-font-weight-bold">{{ appIcon({
         classes: "govuk-!-margin-right-1",
-        icon: "tick",
+        icon: "check",
         hidden: true
       }) }} Make decisions</p>
   <div class="govuk-!-margin-left-5">
@@ -41,13 +41,13 @@
   <ul class="govuk-list">
     <li>{{ appIcon({
         classes: "govuk-!-margin-right-1",
-        icon: "tick",
+        icon: "check",
         hidden: true
       }) }} {{ data.accreditedBodies[0].name }}
     </li>
     <li>{{ appIcon({
         classes: "govuk-!-margin-right-1",
-        icon: "tick",
+        icon: "check",
         hidden: true
       }) }} {{ data.accreditedBodies[1].name }}
     </li>
@@ -56,7 +56,7 @@
 
     <p class="govuk-!-font-weight-bold">{{ appIcon({
           classes: "govuk-!-margin-right-1",
-          icon: "tick",
+          icon: "check",
           hidden: true
         }) }} View safeguarding information</p>
     <div class="govuk-!-margin-left-5">
@@ -64,13 +64,13 @@
         <ul class="govuk-list">
           <li>{{ appIcon({
             classes: "govuk-!-margin-right-1",
-            icon: "tick",
+            icon: "check",
             hidden: true
           }) }} {{ data.accreditedBodies[0].name }}
         </li>
         <li>{{ appIcon({
             classes: "govuk-!-margin-right-1",
-            icon: "tick",
+            icon: "check",
             hidden: true
           }) }} {{ data.accreditedBodies[1].name }}
         </li>
@@ -81,19 +81,19 @@
   {% set permissions2Html %}
     <p class="govuk-!-font-weight-bold">{{ appIcon({
           classes: "govuk-!-margin-right-1",
-          icon: "tick",
+          icon: "check",
           hidden: true
         }) }} Manage organisation</p>
 
     <p class="govuk-!-font-weight-bold">{{ appIcon({
           classes: "govuk-!-margin-right-1",
-          icon: "tick",
+          icon: "check",
           hidden: true
         }) }} Manage users</p>
 
     <p class="govuk-!-font-weight-bold">{{ appIcon({
           classes: "govuk-!-margin-right-1",
-          icon: "tick",
+          icon: "check",
           hidden: true
         }) }} Make decisions</p>
           <div class="govuk-!-margin-left-5">
@@ -101,7 +101,7 @@
     <ul class="govuk-list">
       <li>{{ appIcon({
           classes: "govuk-!-margin-right-1",
-          icon: "tick",
+          icon: "check",
           hidden: true
         }) }} {{ data.accreditedBodies[1].name }}
       </li>
@@ -109,7 +109,7 @@
     </div>
     <p class="govuk-!-font-weight-bold">{{ appIcon({
           classes: "govuk-!-margin-right-1",
-          icon: "tick",
+          icon: "check",
           hidden: true
         }) }} Access safeguarding information</p>
     <div class="govuk-!-margin-left-5">
@@ -117,7 +117,7 @@
     <ul class="govuk-list">
       <li>{{ appIcon({
           classes: "govuk-!-margin-right-1",
-          icon: "tick",
+          icon: "check",
           hidden: true
         }) }} {{ data.accreditedBodies[1].name }}
       </li>

--- a/app/views/account/profile.njk
+++ b/app/views/account/profile.njk
@@ -20,19 +20,16 @@
 
   {% set permissionsHtml %}
   <p class="govuk-!-font-weight-bold">{{ appIcon({
-        classes: "govuk-!-margin-right-1",
         icon: "check",
         hidden: true
       }) }} Manage organisation</p>
 
   <p class="govuk-!-font-weight-bold">{{ appIcon({
-        classes: "govuk-!-margin-right-1",
         icon: "check",
         hidden: true
       }) }} Manage users</p>
 
   <p class="govuk-!-font-weight-bold">{{ appIcon({
-        classes: "govuk-!-margin-right-1",
         icon: "check",
         hidden: true
       }) }} Make decisions</p>
@@ -40,13 +37,11 @@
     <p class="govuk-!-margin-bottom-1">Applies to courses run by:</p>
   <ul class="govuk-list">
     <li>{{ appIcon({
-        classes: "govuk-!-margin-right-1",
         icon: "check",
         hidden: true
       }) }} {{ data.accreditedBodies[0].name }}
     </li>
     <li>{{ appIcon({
-        classes: "govuk-!-margin-right-1",
         icon: "check",
         hidden: true
       }) }} {{ data.accreditedBodies[1].name }}
@@ -55,7 +50,6 @@
   </div>
 
     <p class="govuk-!-font-weight-bold">{{ appIcon({
-          classes: "govuk-!-margin-right-1",
           icon: "check",
           hidden: true
         }) }} View safeguarding information</p>
@@ -63,13 +57,11 @@
       <p class="govuk-!-margin-bottom-1">Applies to courses run by:</p>
         <ul class="govuk-list">
           <li>{{ appIcon({
-            classes: "govuk-!-margin-right-1",
             icon: "check",
             hidden: true
           }) }} {{ data.accreditedBodies[0].name }}
         </li>
         <li>{{ appIcon({
-            classes: "govuk-!-margin-right-1",
             icon: "check",
             hidden: true
           }) }} {{ data.accreditedBodies[1].name }}
@@ -80,19 +72,16 @@
 
   {% set permissions2Html %}
     <p class="govuk-!-font-weight-bold">{{ appIcon({
-          classes: "govuk-!-margin-right-1",
           icon: "check",
           hidden: true
         }) }} Manage organisation</p>
 
     <p class="govuk-!-font-weight-bold">{{ appIcon({
-          classes: "govuk-!-margin-right-1",
           icon: "check",
           hidden: true
         }) }} Manage users</p>
 
     <p class="govuk-!-font-weight-bold">{{ appIcon({
-          classes: "govuk-!-margin-right-1",
           icon: "check",
           hidden: true
         }) }} Make decisions</p>
@@ -100,7 +89,6 @@
       <p class="govuk-!-margin-bottom-1">Applies to courses ratified by:</p>
     <ul class="govuk-list">
       <li>{{ appIcon({
-          classes: "govuk-!-margin-right-1",
           icon: "check",
           hidden: true
         }) }} {{ data.accreditedBodies[1].name }}
@@ -108,7 +96,6 @@
     </ul>
     </div>
     <p class="govuk-!-font-weight-bold">{{ appIcon({
-          classes: "govuk-!-margin-right-1",
           icon: "check",
           hidden: true
         }) }} Access safeguarding information</p>
@@ -116,7 +103,6 @@
       <p class="govuk-!-margin-bottom-1">Applies to courses ratified by:</p>
     <ul class="govuk-list">
       <li>{{ appIcon({
-          classes: "govuk-!-margin-right-1",
           icon: "check",
           hidden: true
         }) }} {{ data.accreditedBodies[1].name }}

--- a/app/views/account/users/change-organisations/check.njk
+++ b/app/views/account/users/change-organisations/check.njk
@@ -22,19 +22,19 @@
       {% set permissionsHtml %}
         <p class="govuk-!-font-weight-bold">{{ appIcon({
               classes: "govuk-!-margin-right-1",
-              icon: "tick",
+              icon: "check",
               hidden: true
             }) }} Manage organisation</p>
 
         <p class="govuk-!-font-weight-bold">{{ appIcon({
               classes: "govuk-!-margin-right-1",
-              icon: "tick",
+              icon: "check",
               hidden: true
             }) }} Manage users</p>
 
         <p class="govuk-!-font-weight-bold">{{ appIcon({
               classes: "govuk-!-margin-right-1",
-              icon: "tick",
+              icon: "check",
               hidden: true
             }) }} Make decisions</p>
         <div class="govuk-!-margin-left-5">
@@ -42,13 +42,13 @@
         <ul class="govuk-list">
           <li>{{ appIcon({
               classes: "govuk-!-margin-right-1",
-              icon: "tick",
+              icon: "check",
               hidden: true
             }) }} {{ data.accreditedBodies[0].name }}
           </li>
           <li>{{ appIcon({
               classes: "govuk-!-margin-right-1",
-              icon: "tick",
+              icon: "check",
               hidden: true
             }) }} {{ data.accreditedBodies[1].name }}
           </li>
@@ -57,7 +57,7 @@
 
         <p class="govuk-!-font-weight-bold">{{ appIcon({
               classes: "govuk-!-margin-right-1",
-              icon: "tick",
+              icon: "check",
               hidden: true
             }) }} Access safeguarding information</p>
         <div class="govuk-!-margin-left-5">
@@ -65,13 +65,13 @@
         <ul class="govuk-list">
           <li>{{ appIcon({
               classes: "govuk-!-margin-right-1",
-              icon: "tick",
+              icon: "check",
               hidden: true
             }) }} {{ data.accreditedBodies[0].name }}
           </li>
           <li>{{ appIcon({
               classes: "govuk-!-margin-right-1",
-              icon: "tick",
+              icon: "check",
               hidden: true
             }) }} {{ data.accreditedBodies[1].name }}
           </li>
@@ -80,7 +80,7 @@
 
         <p class="govuk-!-font-weight-bold">{{ appIcon({
               classes: "govuk-!-margin-right-1",
-              icon: "tick",
+              icon: "check",
               hidden: true
             }) }} Access diversity information</p>
         <div class="govuk-!-margin-left-5">
@@ -88,13 +88,13 @@
         <ul class="govuk-list">
           <li>{{ appIcon({
               classes: "govuk-!-margin-right-1",
-              icon: "tick",
+              icon: "check",
               hidden: true
             }) }} {{ data.accreditedBodies[0].name }}
           </li>
           <li>{{ appIcon({
               classes: "govuk-!-margin-right-1",
-              icon: "tick",
+              icon: "check",
               hidden: true
             }) }} {{ data.accreditedBodies[1].name }}
           </li>
@@ -105,19 +105,19 @@
       {% set permissions2Html %}
         <p class="govuk-!-font-weight-bold">{{ appIcon({
               classes: "govuk-!-margin-right-1",
-              icon: "tick",
+              icon: "check",
               hidden: true
             }) }} Manage organisation</p>
 
         <p class="govuk-!-font-weight-bold">{{ appIcon({
               classes: "govuk-!-margin-right-1",
-              icon: "tick",
+              icon: "check",
               hidden: true
             }) }} Manage users</p>
 
         <p class="govuk-!-font-weight-bold">{{ appIcon({
               classes: "govuk-!-margin-right-1",
-              icon: "tick",
+              icon: "check",
               hidden: true
             }) }} Make decisions</p>
              <div class="govuk-!-margin-left-5">
@@ -125,7 +125,7 @@
         <ul class="govuk-list">
           <li>{{ appIcon({
               classes: "govuk-!-margin-right-1",
-              icon: "tick",
+              icon: "check",
               hidden: true
             }) }} {{ data.accreditedBodies[0].name }}
           </li>
@@ -133,7 +133,7 @@
         </div>
         <p class="govuk-!-font-weight-bold">{{ appIcon({
               classes: "govuk-!-margin-right-1",
-              icon: "tick",
+              icon: "check",
               hidden: true
             }) }} Access safeguarding information</p>
         <div class="govuk-!-margin-left-5">
@@ -141,7 +141,7 @@
         <ul class="govuk-list">
           <li>{{ appIcon({
               classes: "govuk-!-margin-right-1",
-              icon: "tick",
+              icon: "check",
               hidden: true
             }) }} {{ data.accreditedBodies[0].name }}
           </li>
@@ -149,7 +149,7 @@
         </div>
         <p class="govuk-!-font-weight-bold">{{ appIcon({
               classes: "govuk-!-margin-right-1",
-              icon: "tick",
+              icon: "check",
               hidden: true
             }) }} Access diversity information</p>
         <div class="govuk-!-margin-left-5">
@@ -157,7 +157,7 @@
         <ul class="govuk-list">
           <li>{{ appIcon({
               classes: "govuk-!-margin-right-1",
-              icon: "tick",
+              icon: "check",
               hidden: true
             }) }} {{ data.accreditedBodies[0].name }}
           </li>

--- a/app/views/account/users/change-organisations/permissions1.njk
+++ b/app/views/account/users/change-organisations/permissions1.njk
@@ -27,13 +27,13 @@
         <ul class="govuk-list">
           <li>{{ appIcon({
               classes: "govuk-!-margin-right-1",
-              icon: "tick",
+              icon: "check",
               hidden: true
             }) }} {{data.accreditedBodies[0].name}}
           </li>
           <li>{{ appIcon({
               classes: "govuk-!-margin-right-1",
-              icon: "tick",
+              icon: "check",
               hidden: true
             }) }} {{data.accreditedBodies[1].name}}
           </li>
@@ -46,13 +46,13 @@
         <ul class="govuk-list">
           <li>{{ appIcon({
               classes: "govuk-!-margin-right-1",
-              icon: "tick",
+              icon: "check",
               hidden: true
             }) }} {{data.accreditedBodies[0].name}}
           </li>
           <li>{{ appIcon({
               classes: "govuk-!-margin-right-1",
-              icon: "tick",
+              icon: "check",
               hidden: true
             }) }} {{data.accreditedBodies[1].name}}
           </li>
@@ -65,13 +65,13 @@
         <ul class="govuk-list">
           <li>{{ appIcon({
               classes: "govuk-!-margin-right-1",
-              icon: "tick",
+              icon: "check",
               hidden: true
             }) }} {{data.accreditedBodies[0].name}}
           </li>
           <li>{{ appIcon({
               classes: "govuk-!-margin-right-1",
-              icon: "tick",
+              icon: "check",
               hidden: true
             }) }} {{data.accreditedBodies[1].name}}
           </li>

--- a/app/views/account/users/change-permissions.njk
+++ b/app/views/account/users/change-permissions.njk
@@ -35,7 +35,7 @@
               {% for item in org.permissions.applicableOrgs.makeDecisions %}
                 <li>{{ appIcon({
                     classes: "govuk-!-margin-right-1",
-                    icon: "tick",
+                    icon: "check",
                     hidden: true
                   }) }} {{ item.name }}
                 </li>
@@ -78,7 +78,7 @@
               {% for item in org.permissions.applicableOrgs.viewSafeguardingInformation %}
                 <li>{{ appIcon({
                     classes: "govuk-!-margin-right-1",
-                    icon: "tick",
+                    icon: "check",
                     hidden: true
                   }) }} {{ item.name }}
                 </li>
@@ -121,7 +121,7 @@
               {% for item in org.permissions.applicableOrgs.viewDiversityInformation %}
                 <li>{{ appIcon({
                     classes: "govuk-!-margin-right-1",
-                    icon: "tick",
+                    icon: "check",
                     hidden: true
                   }) }} {{ item.name }}
                 </li>

--- a/app/views/account/users/change-permissions.njk
+++ b/app/views/account/users/change-permissions.njk
@@ -34,7 +34,6 @@
             <ul class="govuk-list">
               {% for item in org.permissions.applicableOrgs.makeDecisions %}
                 <li>{{ appIcon({
-                    classes: "govuk-!-margin-right-1",
                     icon: "check",
                     hidden: true
                   }) }} {{ item.name }}
@@ -54,7 +53,6 @@
             <ul class="govuk-list">
               {% for item in org.permissions.nonApplicableOrgs.makeDecisions %}
                 <li>{{ appIcon({
-                    classes: "govuk-!-margin-right-1",
                     icon: "cross",
                     hidden: true
                   }) }} {{ item.name }}
@@ -77,7 +75,6 @@
             <ul class="govuk-list">
               {% for item in org.permissions.applicableOrgs.viewSafeguardingInformation %}
                 <li>{{ appIcon({
-                    classes: "govuk-!-margin-right-1",
                     icon: "check",
                     hidden: true
                   }) }} {{ item.name }}
@@ -97,7 +94,6 @@
             <ul class="govuk-list">
               {% for item in org.permissions.nonApplicableOrgs.makeDecisions %}
                 <li>{{ appIcon({
-                    classes: "govuk-!-margin-right-1",
                     icon: "cross",
                     hidden: true
                   }) }} {{ item.name }}
@@ -120,7 +116,6 @@
             <ul class="govuk-list">
               {% for item in org.permissions.applicableOrgs.viewDiversityInformation %}
                 <li>{{ appIcon({
-                    classes: "govuk-!-margin-right-1",
                     icon: "check",
                     hidden: true
                   }) }} {{ item.name }}
@@ -140,7 +135,6 @@
             <ul class="govuk-list">
               {% for item in org.permissions.nonApplicableOrgs.viewDiversityInformation %}
                 <li>{{ appIcon({
-                    classes: "govuk-!-margin-right-1",
                     icon: "cross",
                     hidden: true
                   }) }} {{ item.name }}

--- a/app/views/account/users/new/check.njk
+++ b/app/views/account/users/new/check.njk
@@ -90,19 +90,19 @@
               {% endif %}
               {% if org.permissions.manageOrganisations %}
                 <p class="govuk-!-font-weight-bold">
-                  {{ appIcon({ classes: "govuk-!-margin-right-1", icon: "check", hidden: true }) }}
+                  {{ appIcon({ icon: "check", hidden: true }) }}
                   Manage organisational permissions
                 </p>
               {% endif %}
               {% if org.permissions.manageUsers %}
                 <p class="govuk-!-font-weight-bold">
-                  {{ appIcon({ classes: "govuk-!-margin-right-1", icon: "check", hidden: true }) }}
+                  {{ appIcon({ icon: "check", hidden: true }) }}
                   Manage users
                 </p>
               {% endif %}
               {% if org.permissions.makeDecisions %}
                 <p class="govuk-!-font-weight-bold">
-                  {{ appIcon({ classes: "govuk-!-margin-right-1", icon: "check", hidden: true }) }}
+                  {{ appIcon({ icon: "check", hidden: true }) }}
                   Make decisions
                 </p>
 
@@ -149,7 +149,7 @@
               {% endif %}
               {% if org.permissions.viewSafeguardingInformation %}
                 <p class="govuk-!-font-weight-bold">
-                  {{ appIcon({ classes: "govuk-!-margin-right-1", icon: "check", hidden: true }) }}
+                  {{ appIcon({ icon: "check", hidden: true }) }}
                   View safeguarding information
                 </p>
                 {% if org.permissions.applicableOrgs.viewSafeguardingInformation %}
@@ -195,7 +195,7 @@
 
               {% if org.permissions.viewDiversityInformation %}
                 <p class="govuk-!-font-weight-bold">
-                  {{ appIcon({ classes: "govuk-!-margin-right-1", icon: "check", hidden: true }) }}
+                  {{ appIcon({ icon: "check", hidden: true }) }}
                   View diversity information
                 </p>
                 {% if org.permissions.applicableOrgs.viewDiversityInformation %}
@@ -204,7 +204,6 @@
                   <ul class="govuk-list">
                     {% for item in org.permissions.applicableOrgs.viewDiversityInformation %}
                       <li>{{ appIcon({
-                          classes: "govuk-!-margin-right-1",
                           icon: "check",
                           hidden: true
                         }) }} {{ item.name }}
@@ -224,7 +223,6 @@
                     <ul class="govuk-list">
                       {% for item in org.permissions.nonApplicableOrgs.viewDiversityInformation %}
                         <li>{{ appIcon({
-                            classes: "govuk-!-margin-right-1",
                             icon: "cross",
                             hidden: true
                           }) }} {{ item.name }}

--- a/app/views/account/users/new/check.njk
+++ b/app/views/account/users/new/check.njk
@@ -90,19 +90,19 @@
               {% endif %}
               {% if org.permissions.manageOrganisations %}
                 <p class="govuk-!-font-weight-bold">
-                  {{ appIcon({ classes: "govuk-!-margin-right-1", icon: "tick", hidden: true }) }}
+                  {{ appIcon({ classes: "govuk-!-margin-right-1", icon: "check", hidden: true }) }}
                   Manage organisational permissions
                 </p>
               {% endif %}
               {% if org.permissions.manageUsers %}
                 <p class="govuk-!-font-weight-bold">
-                  {{ appIcon({ classes: "govuk-!-margin-right-1", icon: "tick", hidden: true }) }}
+                  {{ appIcon({ classes: "govuk-!-margin-right-1", icon: "check", hidden: true }) }}
                   Manage users
                 </p>
               {% endif %}
               {% if org.permissions.makeDecisions %}
                 <p class="govuk-!-font-weight-bold">
-                  {{ appIcon({ classes: "govuk-!-margin-right-1", icon: "tick", hidden: true }) }}
+                  {{ appIcon({ classes: "govuk-!-margin-right-1", icon: "check", hidden: true }) }}
                   Make decisions
                 </p>
 
@@ -117,7 +117,7 @@
                       {% for item in org.permissions.applicableOrgs.makeDecisions %}
                         <li>{{ appIcon({
                             classes: "govuk-!-margin-right-1",
-                            icon: "tick",
+                            icon: "check",
                             hidden: true
                           }) }} {{ item.name }}
                         </li>
@@ -149,7 +149,7 @@
               {% endif %}
               {% if org.permissions.viewSafeguardingInformation %}
                 <p class="govuk-!-font-weight-bold">
-                  {{ appIcon({ classes: "govuk-!-margin-right-1", icon: "tick", hidden: true }) }}
+                  {{ appIcon({ classes: "govuk-!-margin-right-1", icon: "check", hidden: true }) }}
                   View safeguarding information
                 </p>
                 {% if org.permissions.applicableOrgs.viewSafeguardingInformation %}
@@ -163,7 +163,7 @@
                       {% for item in org.permissions.applicableOrgs.viewSafeguardingInformation %}
                         <li>{{ appIcon({
                             classes: "govuk-!-margin-right-1",
-                            icon: "tick",
+                            icon: "check",
                             hidden: true
                           }) }} {{ item.name }}
                         </li>
@@ -195,7 +195,7 @@
 
               {% if org.permissions.viewDiversityInformation %}
                 <p class="govuk-!-font-weight-bold">
-                  {{ appIcon({ classes: "govuk-!-margin-right-1", icon: "tick", hidden: true }) }}
+                  {{ appIcon({ classes: "govuk-!-margin-right-1", icon: "check", hidden: true }) }}
                   View diversity information
                 </p>
                 {% if org.permissions.applicableOrgs.viewDiversityInformation %}
@@ -205,7 +205,7 @@
                     {% for item in org.permissions.applicableOrgs.viewDiversityInformation %}
                       <li>{{ appIcon({
                           classes: "govuk-!-margin-right-1",
-                          icon: "tick",
+                          icon: "check",
                           hidden: true
                         }) }} {{ item.name }}
                       </li>

--- a/app/views/account/users/new/permissions.njk
+++ b/app/views/account/users/new/permissions.njk
@@ -32,7 +32,6 @@
             <ul class="govuk-list">
               {% for item in org.permissions.applicableOrgs.makeDecisions %}
                 <li>{{ appIcon({
-                    classes: "govuk-!-margin-right-1",
                     icon: "check",
                     hidden: true
                   }) }} {{ item.name }}
@@ -52,7 +51,6 @@
             <ul class="govuk-list">
               {% for item in org.permissions.nonApplicableOrgs.makeDecisions %}
                 <li>{{ appIcon({
-                    classes: "govuk-!-margin-right-1",
                     icon: "cross",
                     hidden: true
                   }) }} {{ item.name }}
@@ -75,7 +73,6 @@
             <ul class="govuk-list">
               {% for item in org.permissions.applicableOrgs.viewSafeguardingInformation %}
                 <li>{{ appIcon({
-                    classes: "govuk-!-margin-right-1",
                     icon: "check",
                     hidden: true
                   }) }} {{ item.name }}
@@ -95,7 +92,6 @@
             <ul class="govuk-list">
               {% for item in org.permissions.nonApplicableOrgs.makeDecisions %}
                 <li>{{ appIcon({
-                    classes: "govuk-!-margin-right-1",
                     icon: "cross",
                     hidden: true
                   }) }} {{ item.name }}
@@ -118,7 +114,6 @@
             <ul class="govuk-list">
               {% for item in org.permissions.applicableOrgs.viewDiversityInformation %}
                 <li>{{ appIcon({
-                    classes: "govuk-!-margin-right-1",
                     icon: "check",
                     hidden: true
                   }) }} {{ item.name }}
@@ -138,7 +133,6 @@
             <ul class="govuk-list">
               {% for item in org.permissions.nonApplicableOrgs.viewDiversityInformation %}
                 <li>{{ appIcon({
-                    classes: "govuk-!-margin-right-1",
                     icon: "cross",
                     hidden: true
                   }) }} {{ item.name }}

--- a/app/views/account/users/new/permissions.njk
+++ b/app/views/account/users/new/permissions.njk
@@ -33,7 +33,7 @@
               {% for item in org.permissions.applicableOrgs.makeDecisions %}
                 <li>{{ appIcon({
                     classes: "govuk-!-margin-right-1",
-                    icon: "tick",
+                    icon: "check",
                     hidden: true
                   }) }} {{ item.name }}
                 </li>
@@ -76,7 +76,7 @@
               {% for item in org.permissions.applicableOrgs.viewSafeguardingInformation %}
                 <li>{{ appIcon({
                     classes: "govuk-!-margin-right-1",
-                    icon: "tick",
+                    icon: "check",
                     hidden: true
                   }) }} {{ item.name }}
                 </li>
@@ -119,7 +119,7 @@
               {% for item in org.permissions.applicableOrgs.viewDiversityInformation %}
                 <li>{{ appIcon({
                     classes: "govuk-!-margin-right-1",
-                    icon: "tick",
+                    icon: "check",
                     hidden: true
                   }) }} {{ item.name }}
                 </li>

--- a/app/views/account/users/show.njk
+++ b/app/views/account/users/show.njk
@@ -106,19 +106,19 @@
 
               {% if org.permissions.manageOrganisation %}
                 <p class="govuk-!-font-weight-bold">
-                  {{ appIcon({ classes: "govuk-!-margin-right-1", icon: "tick", hidden: true }) }}
+                  {{ appIcon({ classes: "govuk-!-margin-right-1", icon: "check", hidden: true }) }}
                   Manage organisational permissions
                 </p>
               {% endif %}
               {% if org.permissions.manageUsers %}
                 <p class="govuk-!-font-weight-bold">
-                  {{ appIcon({ classes: "govuk-!-margin-right-1", icon: "tick", hidden: true }) }}
+                  {{ appIcon({ classes: "govuk-!-margin-right-1", icon: "check", hidden: true }) }}
                   Manage users
                 </p>
               {% endif %}
               {% if org.permissions.makeDecisions %}
                 <p class="govuk-!-font-weight-bold">
-                  {{ appIcon({ classes: "govuk-!-margin-right-1", icon: "tick", hidden: true }) }}
+                  {{ appIcon({ classes: "govuk-!-margin-right-1", icon: "check", hidden: true }) }}
                   Make decisions
                 </p>
 
@@ -133,7 +133,7 @@
                       {% for item in org.permissions.applicableOrgs.makeDecisions %}
                         <li>{{ appIcon({
                             classes: "govuk-!-margin-right-1",
-                            icon: "tick",
+                            icon: "check",
                             hidden: true
                           }) }} {{ item.name }}
                         </li>
@@ -165,7 +165,7 @@
               {% endif %}
               {% if org.permissions.viewSafeguardingInformation %}
                 <p class="govuk-!-font-weight-bold">
-                  {{ appIcon({ classes: "govuk-!-margin-right-1", icon: "tick", hidden: true }) }}
+                  {{ appIcon({ classes: "govuk-!-margin-right-1", icon: "check", hidden: true }) }}
                   View safeguarding information
                 </p>
                 {% if org.permissions.applicableOrgs.viewSafeguardingInformation %}
@@ -179,7 +179,7 @@
                       {% for item in org.permissions.applicableOrgs.viewSafeguardingInformation %}
                         <li>{{ appIcon({
                             classes: "govuk-!-margin-right-1",
-                            icon: "tick",
+                            icon: "check",
                             hidden: true
                           }) }} {{ item.name }}
                         </li>
@@ -211,7 +211,7 @@
 
               {% if org.permissions.viewDiversityInformation %}
                 <p class="govuk-!-font-weight-bold">
-                  {{ appIcon({ classes: "govuk-!-margin-right-1", icon: "tick", hidden: true }) }}
+                  {{ appIcon({ classes: "govuk-!-margin-right-1", icon: "check", hidden: true }) }}
                   View diversity information
                 </p>
                 {% if org.permissions.applicableOrgs.viewDiversityInformation %}
@@ -221,7 +221,7 @@
                     {% for item in org.permissions.applicableOrgs.viewDiversityInformation %}
                       <li>{{ appIcon({
                           classes: "govuk-!-margin-right-1",
-                          icon: "tick",
+                          icon: "check",
                           hidden: true
                         }) }} {{ item.name }}
                       </li>

--- a/app/views/account/users/show.njk
+++ b/app/views/account/users/show.njk
@@ -106,19 +106,19 @@
 
               {% if org.permissions.manageOrganisation %}
                 <p class="govuk-!-font-weight-bold">
-                  {{ appIcon({ classes: "govuk-!-margin-right-1", icon: "check", hidden: true }) }}
+                  {{ appIcon({ icon: "check", hidden: true }) }}
                   Manage organisational permissions
                 </p>
               {% endif %}
               {% if org.permissions.manageUsers %}
                 <p class="govuk-!-font-weight-bold">
-                  {{ appIcon({ classes: "govuk-!-margin-right-1", icon: "check", hidden: true }) }}
+                  {{ appIcon({ icon: "check", hidden: true }) }}
                   Manage users
                 </p>
               {% endif %}
               {% if org.permissions.makeDecisions %}
                 <p class="govuk-!-font-weight-bold">
-                  {{ appIcon({ classes: "govuk-!-margin-right-1", icon: "check", hidden: true }) }}
+                  {{ appIcon({ icon: "check", hidden: true }) }}
                   Make decisions
                 </p>
 
@@ -165,7 +165,7 @@
               {% endif %}
               {% if org.permissions.viewSafeguardingInformation %}
                 <p class="govuk-!-font-weight-bold">
-                  {{ appIcon({ classes: "govuk-!-margin-right-1", icon: "check", hidden: true }) }}
+                  {{ appIcon({ icon: "check", hidden: true }) }}
                   View safeguarding information
                 </p>
                 {% if org.permissions.applicableOrgs.viewSafeguardingInformation %}
@@ -211,7 +211,7 @@
 
               {% if org.permissions.viewDiversityInformation %}
                 <p class="govuk-!-font-weight-bold">
-                  {{ appIcon({ classes: "govuk-!-margin-right-1", icon: "check", hidden: true }) }}
+                  {{ appIcon({ icon: "check", hidden: true }) }}
                   View diversity information
                 </p>
                 {% if org.permissions.applicableOrgs.viewDiversityInformation %}

--- a/app/views/interviews/index.njk
+++ b/app/views/interviews/index.njk
@@ -28,8 +28,7 @@
             {% if interview.app.interviewNeeds.length %}
               <p class="govuk-body govuk-!-font-size-16 govuk-!-margin-top-1">
               {{ appIcon({
-                classes: "govuk-!-margin-right-1",
-                icon: "tick",
+                icon: "alert",
                 hidden: true
               }) }}
               Has interview preferences</p>
@@ -68,8 +67,7 @@
             </a>
             {% if interview.app.interviewNeeds.length %}
               <p class="govuk-body govuk-!-font-size-16 govuk-!-margin-top-1">{{ appIcon({
-                classes: "govuk-!-margin-right-1",
-                icon: "tick",
+                icon: "alert",
                 hidden: true
               }) }} Interview preferences</p>
             {% endif %}

--- a/app/views/interviews/index.njk
+++ b/app/views/interviews/index.njk
@@ -28,7 +28,7 @@
             {% if interview.app.interviewNeeds.length %}
               <p class="govuk-body govuk-!-font-size-16 govuk-!-margin-top-1">
               {{ appIcon({
-                icon: "alert",
+                icon: "info",
                 hidden: true
               }) }}
               Has interview preferences</p>

--- a/app/views/interviews/index.njk
+++ b/app/views/interviews/index.njk
@@ -67,7 +67,7 @@
             </a>
             {% if interview.app.interviewNeeds.length %}
               <p class="govuk-body govuk-!-font-size-16 govuk-!-margin-top-1">{{ appIcon({
-                icon: "alert",
+                icon: "info",
                 hidden: true
               }) }} Interview preferences</p>
             {% endif %}

--- a/app/views/onboard-notifications/check.njk
+++ b/app/views/onboard-notifications/check.njk
@@ -12,12 +12,12 @@
 
 {% block content %}
   {% set emailOnceADay %}
-    {{appIcon({ classes: "govuk-!-margin-right-1", icon: "tick", hidden: true})}}
+    {{appIcon({ classes: "govuk-!-margin-right-1", icon: "check", hidden: true})}}
     <span class="app-email-settings">Daily at 8am</span>
   {% endset %}
 
   {% set emailImmediately %}
-    {{appIcon({ classes: "govuk-!-margin-right-1", icon: "tick", hidden: true})}}
+    {{appIcon({ classes: "govuk-!-margin-right-1", icon: "check", hidden: true})}}
     <span class="app-email-settings">Immediately</span>
   {% endset %}
 
@@ -55,7 +55,7 @@
               html: emailImmediately
             },
             {
-              html: appIcon({ classes: "govuk-!-margin-right-1", icon: "tick", hidden: true})
+              html: appIcon({ classes: "govuk-!-margin-right-1", icon: "check", hidden: true})
             }
           ],
           [
@@ -77,7 +77,7 @@
               html: emailImmediately
             },
             {
-              html: appIcon({ classes: "govuk-!-margin-right-1", icon: "tick", hidden: true})
+              html: appIcon({ classes: "govuk-!-margin-right-1", icon: "check", hidden: true})
             }
           ],
           [
@@ -110,7 +110,7 @@
               html: emailOnceADay
             },
             {
-              html: appIcon({ classes: "govuk-!-margin-right-1", icon: "tick", hidden: true})
+              html: appIcon({ classes: "govuk-!-margin-right-1", icon: "check", hidden: true})
             }
           ],
           [
@@ -121,7 +121,7 @@
               html: emailOnceADay
             },
             {
-              html: appIcon({ classes: "govuk-!-margin-right-1", icon: "tick", hidden: true})
+              html: appIcon({ classes: "govuk-!-margin-right-1", icon: "check", hidden: true})
             }
           ],
           [
@@ -132,7 +132,7 @@
               html: ""
             },
             {
-              html: appIcon({ classes: "govuk-!-margin-right-1", icon: "tick", hidden: true})
+              html: appIcon({ classes: "govuk-!-margin-right-1", icon: "check", hidden: true})
             }
           ],
           [
@@ -179,7 +179,7 @@
               html: emailOnceADay
             },
             {
-              html: appIcon({ classes: "govuk-!-margin-right-1", icon: "tick", hidden: true})
+              html: appIcon({ classes: "govuk-!-margin-right-1", icon: "check", hidden: true})
             }
           ],
           [
@@ -201,7 +201,7 @@
               html: emailOnceADay
             },
             {
-              html: appIcon({ classes: "govuk-!-margin-right-1", icon: "tick", hidden: true})
+              html: appIcon({ classes: "govuk-!-margin-right-1", icon: "check", hidden: true})
             }
           ],
           [
@@ -234,7 +234,7 @@
               html: emailOnceADay
             },
             {
-              html: appIcon({ classes: "govuk-!-margin-right-1", icon: "tick", hidden: true})
+              html: appIcon({ classes: "govuk-!-margin-right-1", icon: "check", hidden: true})
             }
           ],
           [
@@ -245,7 +245,7 @@
               html: emailOnceADay
             },
             {
-              html: appIcon({ classes: "govuk-!-margin-right-1", icon: "tick", hidden: true})
+              html: appIcon({ classes: "govuk-!-margin-right-1", icon: "check", hidden: true})
             }
           ],
           [
@@ -256,7 +256,7 @@
               html: emailOnceADay
             },
             {
-              html: appIcon({ classes: "govuk-!-margin-right-1", icon: "tick", hidden: true})
+              html: appIcon({ classes: "govuk-!-margin-right-1", icon: "check", hidden: true})
             }
           ],
           [

--- a/app/views/onboard-notifications/check.njk
+++ b/app/views/onboard-notifications/check.njk
@@ -12,12 +12,12 @@
 
 {% block content %}
   {% set emailOnceADay %}
-    {{appIcon({ classes: "govuk-!-margin-right-1", icon: "check", hidden: true})}}
+    {{appIcon({ icon: "check", hidden: true})}}
     <span class="app-email-settings">Daily at 8am</span>
   {% endset %}
 
   {% set emailImmediately %}
-    {{appIcon({ classes: "govuk-!-margin-right-1", icon: "check", hidden: true})}}
+    {{appIcon({ icon: "check", hidden: true})}}
     <span class="app-email-settings">Immediately</span>
   {% endset %}
 
@@ -55,7 +55,7 @@
               html: emailImmediately
             },
             {
-              html: appIcon({ classes: "govuk-!-margin-right-1", icon: "check", hidden: true})
+              html: appIcon({ icon: "check", hidden: true})
             }
           ],
           [
@@ -77,7 +77,7 @@
               html: emailImmediately
             },
             {
-              html: appIcon({ classes: "govuk-!-margin-right-1", icon: "check", hidden: true})
+              html: appIcon({ icon: "check", hidden: true})
             }
           ],
           [
@@ -110,7 +110,7 @@
               html: emailOnceADay
             },
             {
-              html: appIcon({ classes: "govuk-!-margin-right-1", icon: "check", hidden: true})
+              html: appIcon({ icon: "check", hidden: true})
             }
           ],
           [
@@ -121,7 +121,7 @@
               html: emailOnceADay
             },
             {
-              html: appIcon({ classes: "govuk-!-margin-right-1", icon: "check", hidden: true})
+              html: appIcon({ icon: "check", hidden: true})
             }
           ],
           [
@@ -132,7 +132,7 @@
               html: ""
             },
             {
-              html: appIcon({ classes: "govuk-!-margin-right-1", icon: "check", hidden: true})
+              html: appIcon({ icon: "check", hidden: true})
             }
           ],
           [
@@ -179,7 +179,7 @@
               html: emailOnceADay
             },
             {
-              html: appIcon({ classes: "govuk-!-margin-right-1", icon: "check", hidden: true})
+              html: appIcon({ icon: "check", hidden: true})
             }
           ],
           [
@@ -201,7 +201,7 @@
               html: emailOnceADay
             },
             {
-              html: appIcon({ classes: "govuk-!-margin-right-1", icon: "check", hidden: true})
+              html: appIcon({ icon: "check", hidden: true})
             }
           ],
           [
@@ -234,7 +234,7 @@
               html: emailOnceADay
             },
             {
-              html: appIcon({ classes: "govuk-!-margin-right-1", icon: "check", hidden: true})
+              html: appIcon({ icon: "check", hidden: true})
             }
           ],
           [
@@ -245,7 +245,7 @@
               html: emailOnceADay
             },
             {
-              html: appIcon({ classes: "govuk-!-margin-right-1", icon: "check", hidden: true})
+              html: appIcon({ icon: "check", hidden: true})
             }
           ],
           [
@@ -256,7 +256,7 @@
               html: emailOnceADay
             },
             {
-              html: appIcon({ classes: "govuk-!-margin-right-1", icon: "check", hidden: true})
+              html: appIcon({ icon: "check", hidden: true})
             }
           ],
           [

--- a/app/views/onboard/check.njk
+++ b/app/views/onboard/check.njk
@@ -11,7 +11,7 @@
   {% set tick %}
     {{ appIcon({
       classes: "govuk-!-margin-right-1",
-      icon: "tick",
+      icon: "check",
       hidden: true
     }) }}
   {% endset %}

--- a/app/views/onboard/check.njk
+++ b/app/views/onboard/check.njk
@@ -10,7 +10,6 @@
 
   {% set tick %}
     {{ appIcon({
-      classes: "govuk-!-margin-right-1",
       icon: "check",
       hidden: true
     }) }}


### PR DESCRIPTION
* Adds `alert` and `info` icon types to `appIcon` component
* Replaces tick icon on interviews page with alert icon
* Renames `tick` to `check` to match name used on production
* Alert icon is wider, meaning icon SVG viewport needs to be wider… nice side effect of this meaning we don’t need to add a right margin (potentially controversial change) 