### PR TITLE
WIP: Remove job descriptions from work history section

### DIFF
--- a/app/views/_includes/application/work-history.njk
+++ b/app/views/_includes/application/work-history.njk
@@ -13,7 +13,7 @@
       <h3 class="govuk-heading-s govuk-!-margin-bottom-1">{{ item.role + " – " + item.type if item.category == "job" else "Break (" + item.duration + ")" }}</h3>
       <p class="govuk-body govuk-!-margin-bottom-1">{{org}}</p>
       <p class="govuk-caption-m govuk-!-font-size-16">{{[startDate, endDate] | join(" - ")}}</p>
-      <p class="govuk-body">{{ item.description }}</p>
+      {% if item.category != "job" %}<p class="govuk-body">{{ item.description }}</p>{% endif %}
       {%- if item.workedWithChildren == "Yes" %}
         <p class="govuk-body govuk-!-font-size-16">{{ appIcon({
           icon: "check",

--- a/app/views/application/index.njk
+++ b/app/views/application/index.njk
@@ -246,8 +246,8 @@
       <h2 class="govuk-heading-m govuk-!-margin-top-8 govuk-!-margin-bottom-2 govuk-!-font-size-27">Work history</h2>
       {% set workHistoryGuidanceHtml %}
         <h2 class="govuk-heading-m">Work history</h2>
-        <p class="govuk-body">Training providers need a complete picture of the last 5 years of of your work history, including time out of the workplace, to safeguard children.</p>
-        <p class="govuk-body">Breaks in work history won’t impact your application if you have a reasonable explanation for them (for example, parenting responsibilities, redundancy, illness or personal reasons such as study or travel).</p>
+        <p class="govuk-body">Training providers need a complete picture of your work history (outside of full time education), including time out of the workplace, to safeguard children.</p>
+        <p class="govuk-body">Breaks in work history will not impact your application if you have a reasonable explanation for them (for example, parenting responsibilities, redundancy, illness or personal reasons such as study or travel).</p>
       {% endset %}
       {{ govukDetails({
         summaryText: "View guidance given to candidate",


### PR DESCRIPTION
This reflects a potential change candidate-side to no longer ask for a relevant skills and exprience for each job, and to ask for a complete work history instead of the past 5 years.