### PR TITLE
Move work history down the page

### DIFF
--- a/app/views/_includes/application/work-history.njk
+++ b/app/views/_includes/application/work-history.njk
@@ -13,7 +13,7 @@
       <h3 class="govuk-heading-s govuk-!-margin-bottom-1">{{ item.role + " – " + item.type if item.category == "job" else "Break (" + item.duration + ")" }}</h3>
       <p class="govuk-body govuk-!-margin-bottom-1">{{org}}</p>
       <p class="govuk-caption-m govuk-!-font-size-16">{{[startDate, endDate] | join(" - ")}}</p>
-      <p class="govuk-body">{{ item.description }}</p>
+      {% if item.category != "job" %}<p class="govuk-body">{{ item.description }}</p>{% endif %}
       {%- if item.workedWithChildren == "Yes" %}
         <p class="govuk-body govuk-!-font-size-16">{{ appIcon({
           icon: "check",

--- a/app/views/application/index.njk
+++ b/app/views/application/index.njk
@@ -309,7 +309,7 @@
       <h2 class="govuk-heading-m govuk-!-margin-top-8 govuk-!-margin-bottom-2 govuk-!-font-size-27">Work history</h2>
 
       {{ govukInsetText({
-        text: "On January 1 2021 we stopped asking candidates for their relevant skills and experience for each job."
+        text: "On 1 January 2021 we stopped asking candidates for their relevant skills and experience for each job."
       }) }}
 
       {% set workHistoryGuidanceHtml %}

--- a/app/views/application/index.njk
+++ b/app/views/application/index.njk
@@ -307,8 +307,12 @@
       {% include "_includes/application/reference.njk" %}
 
       <h2 class="govuk-heading-m govuk-!-margin-top-8 govuk-!-margin-bottom-2 govuk-!-font-size-27">Work history</h2>
+
+      {{ govukInsetText({
+        text: "Since 1 January 2021, candidates are no longer asked to describe relevant skills and experience for each job."
+      }) }}
+
       {% set workHistoryGuidanceHtml %}
-        <h2 class="govuk-heading-m">Work history</h2>
         <p class="govuk-body">Training providers need a complete picture of your work history (outside of full time education), including time out of the workplace, to safeguard children.</p>
         <p class="govuk-body">Breaks in work history will not impact your application if you have a reasonable explanation for them (for example, parenting responsibilities, redundancy, illness or personal reasons such as study or travel).</p>
       {% endset %}

--- a/app/views/application/index.njk
+++ b/app/views/application/index.njk
@@ -243,35 +243,6 @@
     <div class="govuk-grid-column-two-thirds">
       {% include "_includes/application/other-qualifications.njk" %}
 
-      <h2 class="govuk-heading-m govuk-!-margin-top-8 govuk-!-margin-bottom-2 govuk-!-font-size-27">Work history</h2>
-      {% set workHistoryGuidanceHtml %}
-        <h2 class="govuk-heading-m">Work history</h2>
-        <p class="govuk-body">Training providers need a complete picture of your work history (outside of full time education), including time out of the workplace, to safeguard children.</p>
-        <p class="govuk-body">Breaks in work history will not impact your application if you have a reasonable explanation for them (for example, parenting responsibilities, redundancy, illness or personal reasons such as study or travel).</p>
-      {% endset %}
-      {{ govukDetails({
-        summaryText: "View guidance given to candidate",
-        html: workHistoryGuidanceHtml
-      }) }}
-      {% include "_includes/application/work-history.njk" %}
-
-      <h2 class="govuk-heading-m govuk-!-margin-top-8 govuk-!-margin-bottom-2 govuk-!-font-size-27">Unpaid experience and volunteering</h2>
-      {% set volunteeringGuidanceHtml %}
-        <h2 class="govuk-heading-m">Unpaid experience working with children and other volunteering</h2>
-        <p class="govuk-body">Tell us about any unpaid experience you have working with children or in a school. For example:</p>
-        <ul class="govuk-list govuk-list--bullet">
-          <li>one-off observations in a school</li>
-          <li>volunteering at a children's club</li>
-          <li>being a governor</li>
-        </ul>
-        <p class="govuk-body">You can also tell us about any other volunteering you’ve done, and how this supports your application to become a teacher.</p>
-      {% endset %}
-      {{ govukDetails({
-        summaryText: "View guidance given to candidate",
-        html: volunteeringGuidanceHtml
-      }) }}
-      {% include "_includes/application/school-experience.njk" %}
-
       <h2 class="govuk-heading-m govuk-!-margin-top-8 govuk-!-margin-bottom-2 govuk-!-font-size-27">Personal statement</h2>
       {% set personalStatementGuidanceHtml %}
         <h2 class="govuk-heading-m">Why do you want to be a teacher?</h2>
@@ -334,6 +305,36 @@
       <h3 class="govuk-heading-m govuk-!-margin-top-8 govuk-!-margin-bottom-2">Second referee</h2>
       {% set referenceId = "second" %}
       {% include "_includes/application/reference.njk" %}
+
+      <h2 class="govuk-heading-m govuk-!-margin-top-8 govuk-!-margin-bottom-2 govuk-!-font-size-27">Work history</h2>
+      {% set workHistoryGuidanceHtml %}
+        <h2 class="govuk-heading-m">Work history</h2>
+        <p class="govuk-body">Training providers need a complete picture of your work history (outside of full time education), including time out of the workplace, to safeguard children.</p>
+        <p class="govuk-body">Breaks in work history will not impact your application if you have a reasonable explanation for them (for example, parenting responsibilities, redundancy, illness or personal reasons such as study or travel).</p>
+      {% endset %}
+      {{ govukDetails({
+        summaryText: "View guidance given to candidate",
+        html: workHistoryGuidanceHtml
+      }) }}
+      {% include "_includes/application/work-history.njk" %}
+
+      <h2 class="govuk-heading-m govuk-!-margin-top-8 govuk-!-margin-bottom-2 govuk-!-font-size-27">Unpaid experience and volunteering</h2>
+      {% set volunteeringGuidanceHtml %}
+        <h2 class="govuk-heading-m">Unpaid experience working with children and other volunteering</h2>
+        <p class="govuk-body">Tell us about any unpaid experience you have working with children or in a school. For example:</p>
+        <ul class="govuk-list govuk-list--bullet">
+          <li>one-off observations in a school</li>
+          <li>volunteering at a children's club</li>
+          <li>being a governor</li>
+        </ul>
+        <p class="govuk-body">You can also tell us about any other volunteering you’ve done, and how this supports your application to become a teacher.</p>
+      {% endset %}
+      {{ govukDetails({
+        summaryText: "View guidance given to candidate",
+        html: volunteeringGuidanceHtml
+      }) }}
+      {% include "_includes/application/school-experience.njk" %}
+
 
       <h2 class="govuk-heading-m govuk-!-margin-top-8 govuk-!-margin-bottom-2">Diversity information</h2>
       {% include "_includes/application/diversity-information.njk" %}

--- a/app/views/application/index.njk
+++ b/app/views/application/index.njk
@@ -309,7 +309,7 @@
       <h2 class="govuk-heading-m govuk-!-margin-top-8 govuk-!-margin-bottom-2 govuk-!-font-size-27">Work history</h2>
 
       {{ govukInsetText({
-        text: "Since 1 January 2021, candidates are no longer asked to describe relevant skills and experience for each job."
+        text: "On January 1 2021 we stopped asking candidates for their relevant skills and experience for each job."
       }) }}
 
       {% set workHistoryGuidanceHtml %}

--- a/app/views/application/index.njk
+++ b/app/views/application/index.njk
@@ -246,8 +246,8 @@
       <h2 class="govuk-heading-m govuk-!-margin-top-8 govuk-!-margin-bottom-2 govuk-!-font-size-27">Work history</h2>
       {% set workHistoryGuidanceHtml %}
         <h2 class="govuk-heading-m">Work history</h2>
-        <p class="govuk-body">Training providers need a complete picture of the last 5 years of of your work history, including time out of the workplace, to safeguard children.</p>
-        <p class="govuk-body">Breaks in work history won’t impact your application if you have a reasonable explanation for them (for example, parenting responsibilities, redundancy, illness or personal reasons such as study or travel).</p>
+        <p class="govuk-body">Training providers need a complete picture of your work history (outside of full time education), including time out of the workplace, to safeguard children.</p>
+        <p class="govuk-body">Breaks in work history will not impact your application if you have a reasonable explanation for them (for example, parenting responsibilities, redundancy, illness or personal reasons such as study or travel).</p>
       {% endset %}
       {{ govukDetails({
         summaryText: "View guidance given to candidate",


### PR DESCRIPTION
This removes job descriptions from work history (as in #268) and also moves the work history down the page to beneath the personal statement and referees sections, on the basis that candidates won't be asked for relevant skills and experience for each job, and instead a full work history is requested purely for safeguarding purposes.