### PR TITLE
3088 distinguish not asked questions from not answered

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -186,3 +186,7 @@ h1 .govuk-tag {
 .app-table__row--indent > td {
   padding-left: govuk-spacing(3);
 }
+
+.app-permission-text {
+  color: govuk-colour("dark-grey");
+}

--- a/app/data/generators/disability.js
+++ b/app/data/generators/disability.js
@@ -1,5 +1,5 @@
 module.exports = (faker) => {
-  let response = faker.helpers.randomize([false, true])
+  let response = faker.helpers.randomize([true])
 
   let details;
 

--- a/app/data/generators/disability.js
+++ b/app/data/generators/disability.js
@@ -1,0 +1,11 @@
+module.exports = (faker) => {
+  let response = faker.helpers.randomize([false, true])
+
+  let details;
+
+  if(response) {
+    details = "I need wheelchair access."
+  }
+
+  return { response, details }
+}

--- a/app/data/generators/interview-needs.js
+++ b/app/data/generators/interview-needs.js
@@ -1,14 +1,18 @@
-module.exports = (faker) => {
-  return faker.helpers.randomize([
-    'I have employment commitments',
-    'I’ll be travelling a long way to get to the interview',
-    'I use a wheelchair',
-    '',
-    '',
-    '',
-    '',
-    '',
-    '',
-    ''
-  ])
+const faker = require('faker')
+faker.locale = 'en_GB'
+
+module.exports = () => {
+  let response = faker.helpers.randomize([true])
+
+  let details;
+
+  if(response) {
+    details = faker.helpers.randomize([
+      'I have employment commitments',
+      'I’ll be travelling a long way to get to the interview',
+      'I use a wheelchair'
+    ])
+  }
+
+  return { response, details }
 }

--- a/app/data/generators/safeguarding.js
+++ b/app/data/generators/safeguarding.js
@@ -1,3 +1,14 @@
-module.exports = (faker) => {
-  return faker.helpers.randomize(["I have an offence from a job I held in 2002.", null])
+const faker = require('faker')
+faker.locale = 'en_GB'
+
+module.exports = () => {
+  let response = faker.helpers.randomize([false, false, false, true])
+
+  let details;
+
+  if(response) {
+    details = "I have an offence from a job I held in 2002."
+  }
+
+  return { response, details }
 }

--- a/app/data/generators/safeguarding.js
+++ b/app/data/generators/safeguarding.js
@@ -1,0 +1,3 @@
+module.exports = (faker) => {
+  return faker.helpers.randomize(["I have an offence from a job I held in 2002.", null])
+}

--- a/app/data/generators/safeguarding.js
+++ b/app/data/generators/safeguarding.js
@@ -2,7 +2,7 @@ const faker = require('faker')
 faker.locale = 'en_GB'
 
 module.exports = () => {
-  let response = faker.helpers.randomize([true, false])
+  let response = faker.helpers.randomize([true])
 
   let details;
 

--- a/app/data/generators/safeguarding.js
+++ b/app/data/generators/safeguarding.js
@@ -2,7 +2,7 @@ const faker = require('faker')
 faker.locale = 'en_GB'
 
 module.exports = () => {
-  let response = faker.helpers.randomize([false, false, false, true])
+  let response = faker.helpers.randomize([true, false])
 
   let details;
 

--- a/app/data/generators/work-history.js
+++ b/app/data/generators/work-history.js
@@ -23,7 +23,7 @@ module.exports = (faker) => {
     }
   }
 
-  const count = faker.random.number({ min: 1, max: 8 })
+  const count = faker.random.number({ min: 0, max: 8 })
   const items = []
   for (var i = 0; i < count; i++) {
     items.push(item(faker))

--- a/app/views/_components/no-information-shared/macro.njk
+++ b/app/views/_components/no-information-shared/macro.njk
@@ -1,0 +1,3 @@
+{% macro appNoInformationShared(params) %}
+  {%- include "./template.njk" -%}
+{% endmacro %}

--- a/app/views/_components/no-information-shared/template.njk
+++ b/app/views/_components/no-information-shared/template.njk
@@ -1,1 +1,1 @@
-{{ ["The candidate chose not to complete this section.", "The candidate was not asked to complete this section."] | random }}
+{{ ["No", "The candidate was not asked this question."] | random }}

--- a/app/views/_components/no-information-shared/template.njk
+++ b/app/views/_components/no-information-shared/template.njk
@@ -1,0 +1,1 @@
+{{ ["The candidate chose not to share information.", "The candidate was never asked this question."] | random }}

--- a/app/views/_components/no-information-shared/template.njk
+++ b/app/views/_components/no-information-shared/template.njk
@@ -1,1 +1,1 @@
-{{ ["The candidate chose not to share information.", "The candidate was never asked this question."] | random }}
+{{ ["The candidate chose not to complete this section.", "The candidate was not asked to complete this section."] | random }}

--- a/app/views/_includes/application/details.njk
+++ b/app/views/_includes/application/details.njk
@@ -91,7 +91,7 @@
       text: "Address"
     },
     value: {
-      html: application.contactDetails.address | toArray | join("<br>") if application.contactDetails.address else "No information shared"
+      html: application.contactDetails.address | toArray | join("<br>")
     }
   }]
 }) }}

--- a/app/views/_includes/application/diversity-information.njk
+++ b/app/views/_includes/application/diversity-information.njk
@@ -1,5 +1,4 @@
-{# Whether viewing user has ‘view diversity information’ permission on their account #}
-{% set providerHasViewDiversityInformationPermission = true %}
+{% set providerHasViewDiversityInformationPermission = [true, false] | random %}
 
 {# Whether candidate has completed diversity questionnaire #}
 {% set diversityQuestionnaireCompleted = application.personalDetails.diversityQuestionnaireAnswered %}
@@ -71,8 +70,7 @@
   }) }}
 {% endset %}
 
-{# Candidate guidance #}
-{% set diversityInformationGuidanceHtml %}
+{# {% set diversityInformationGuidanceHtml %}
   <h2 class="govuk-heading-m">Equality and diversity</h2>
   <p class="govuk-body">
     The equality and diversity questionnaire is optional and has no impact on the progress of your application.
@@ -88,7 +86,7 @@
 {{ govukDetails({
   summaryText: "View guidance given to candidate",
   html: diversityInformationGuidanceHtml
-}) }}
+}) }} #}
 
 
 {% if diversityQuestionnaireCompleted %}
@@ -99,7 +97,7 @@
       {{ diversityInformationSummaryList | safe}}
     {% else %}
       <p class="govuk-body">The candidate disclosed information in the equality and diversity questionnaire.</p>
-      <p class="govuk-body">You will be able to view this when {{offerContext}} offer has been accepted.</p>
+      <p class="govuk-body">You’ll be able to view this when {{offerContext}} offer has been accepted.</p>
     {% endif %}
 
   {% else %}

--- a/app/views/_includes/application/diversity-information.njk
+++ b/app/views/_includes/application/diversity-information.njk
@@ -114,7 +114,7 @@
   {% endif %}
 
 {% else %}
-  <p class="govuk-body">No information shared</p>
+  <p class="govuk-body">{{appNoInformationShared()}}</p>
 {% endif %}
 
 

--- a/app/views/_includes/application/english-language-qualification.njk
+++ b/app/views/_includes/application/english-language-qualification.njk
@@ -2,7 +2,7 @@
 <div class="govuk-!-margin-bottom-8">
   <h2 class="govuk-heading-m">English as a foreign language</h2>
 
-{{ govukSummaryList({
+{# {{ govukSummaryList({
   rows: [
     {
       key: {
@@ -21,7 +21,7 @@
       }
     } if application.englishLanguageQualification.hasQualification == "Yes"
   ]
-}) }}
+}) }} #}
 
 
 

--- a/app/views/_includes/application/english-language-qualification.njk
+++ b/app/views/_includes/application/english-language-qualification.njk
@@ -1,6 +1,30 @@
 {% set item = application.englishLanguageQualification %}
 <div class="govuk-!-margin-bottom-8">
   <h2 class="govuk-heading-m">English as a foreign language</h2>
+
+{{ govukSummaryList({
+  rows: [
+    {
+      key: {
+        text: "Do you have an English as a foreign language qualification?"
+      },
+      value: {
+        text: item.hasQualification
+      }
+    },
+    {
+      key: {
+        text: "Do you have an English as a foreign language qualification?"
+      },
+      value: {
+        text: item.type
+      }
+    } if application.englishLanguageQualification.hasQualification == "Yes"
+  ]
+}) }}
+
+
+
   <p class="govuk-body">{{ item.status }}.</p>
   {% if item.hasQualification == "Yes" %}
     <div class="govuk-grid">

--- a/app/views/_includes/application/no-information-shared.njk
+++ b/app/views/_includes/application/no-information-shared.njk
@@ -1,0 +1,1 @@
+{{ ["The candidate chose not to share information.", "The candidate was never asked this question."] | random }}

--- a/app/views/_includes/application/no-information-shared.njk
+++ b/app/views/_includes/application/no-information-shared.njk
@@ -1,1 +1,0 @@
-{{ ["The candidate chose not to share information.", "The candidate was never asked this question."] | random }}

--- a/app/views/_includes/application/school-experience.njk
+++ b/app/views/_includes/application/school-experience.njk
@@ -22,5 +22,5 @@
     </div>
   {% endfor %}
 {% else %}
-  <p class="govuk-body">No information shared</p>
+  <p class="govuk-body">{{appNoInformationShared()}}</p>
 {% endif %}

--- a/app/views/_layout.njk
+++ b/app/views/_layout.njk
@@ -49,6 +49,7 @@
 {% from "_components/task-list/macro.njk" import appTaskList %}
 {% from "_components/timeline/macro.njk" import appTimeline %}
 {% from "_components/interview-card/macro.njk" import appInterviewCard %}
+{% from "_components/no-information-shared/macro.njk" import appNoInformationShared %}
 
 {% block head %}
   {% include "_includes/head.njk" %}

--- a/app/views/application/index.njk
+++ b/app/views/application/index.njk
@@ -280,8 +280,8 @@
       }) }} #}
       {% include "_includes/application/school-experience.njk" %}
 
-      <h2 class="govuk-heading-m govuk-!-margin-top-8 govuk-!-margin-bottom-2 govuk-!-font-size-27">Personal statement</h2>
-      {% set personalStatementGuidanceHtml %}
+      <h2 class="govuk-heading-m govuk-!-margin-top-8 govuk-!-font-size-27">Personal statement</h2>
+      {# {% set personalStatementGuidanceHtml %}
         <h2 class="govuk-heading-m">Why do you want to be a teacher?</h2>
         <p class="govuk-body">Use this section to showcase your motivation, commitment and teaching potential, backing up your answer with specific examples.</p>
         <p class="govuk-body">Give providers an insight into your personality by writing honestly and thoughtfully. Avoid cliché and write in clear, correct, concise English.</p>
@@ -310,16 +310,16 @@
       {{ govukDetails({
         summaryText: "View guidance given to candidate",
         html: personalStatementGuidanceHtml
-      }) }}
+      }) }} #}
 
-      <h3 class="govuk-heading-s govuk-!-margin-bottom-0">Vocation</h3>
+      <h3 class="govuk-heading-s govuk-!-margin-top-6">Why do you want to become a teacher?</h3>
       <p>{{ application.personalStatement.vocation | safe | nl2br or "—" }}</p>
 
-      <h3 class="govuk-heading-s govuk-!-margin-bottom-0">Subject knowledge</h3>
+      <h3 class="govuk-heading-s govuk-!-margin-top-6">What do you know about the subject you want to teach?</h3>
       <p>{{ application.personalStatement.subjectKnowledge | safe | nl2br or "—" }}</p>
 
-      <h2 class="govuk-heading-m govuk-!-margin-top-8 govuk-!-margin-bottom-2 govuk-!-font-size-27">References</h2>
-      {% set referencesGuidanceHtml %}
+      <h2 class="govuk-heading-m govuk-!-margin-top-8 govuk-!-font-size-27">References</h2>
+      {# {% set referencesGuidanceHtml %}
         <h2 class="govuk-heading-m">Choosing referees</h2>
         <p class="govuk-body">Referees should not be family members, partners or friends.</p>
         <p class="govuk-body">If you’re struggling to find a suitable referee, contact your provider to discuss this.</p>
@@ -334,12 +334,12 @@
       {{ govukDetails({
         summaryText: "View guidance given to candidate",
         html: referencesGuidanceHtml
-      }) }}
-      <h3 class="govuk-heading-m govuk-!-margin-bottom-2">First referee</h2>
+      }) }} #}
+      <h3 class="govuk-heading-m govuk-!-margin-top-6 govuk-!-margin-bottom-2">First referee</h2>
       {% set referenceId = "first" %}
       {% include "_includes/application/reference.njk" %}
 
-      <h3 class="govuk-heading-m govuk-!-margin-top-8 govuk-!-margin-bottom-2">Second referee</h2>
+      <h3 class="govuk-heading-m govuk-!-margin-top-6 govuk-!-margin-top-8 govuk-!-margin-bottom-2">Second referee</h2>
       {% set referenceId = "second" %}
       {% include "_includes/application/reference.njk" %}
 

--- a/app/views/application/index.njk
+++ b/app/views/application/index.njk
@@ -161,7 +161,8 @@
         summaryText: "View guidance given to candidate",
         html: disabilityGuidanceHtml
       }) }}
-      <p class="govuk-body">{{application["reasonable-adjustments"] | nl2br or "No information shared"}}</p>
+
+      <p class="govuk-body">{{application["reasonable-adjustments"] | nl2br or appNoInformationShared()}}</p>
 
       <h2 class="govuk-heading-m govuk-!-margin-top-8 govuk-!-margin-bottom-2 govuk-!-font-size-27">Criminal convictions and professional misconduct</h2>
       {% set safeguardingGuidanceHtml %}
@@ -191,7 +192,7 @@
           html: safeguardingHtml
         }) }}
       {% else %}
-        <p class="govuk-body">No information shared</p>
+        <p class="govuk-body">{{appNoInformationShared()}}</p>
       {% endif %}
 
       <h2 class="govuk-heading-m govuk-!-margin-top-8 govuk-!-margin-bottom-2 govuk-!-font-size-27">Interview</h2>
@@ -211,10 +212,7 @@
         summaryText: "View guidance given to candidate",
         html: interviewGuidanceHtml
       }) }}
-      <p class="govuk-body">{{ application.interviewNeeds | nl2br or "No information shared" }}</p>
-    </div>
-    <div class="govuk-grid-column-one-third">
-
+      <p class="govuk-body">{{ application.interviewNeeds | nl2br or appNoInformationShared() }}</p>
     </div>
   </div>
 

--- a/app/views/application/index.njk
+++ b/app/views/application/index.njk
@@ -138,7 +138,7 @@
         }]
       }) }}
 
-      <h2 class="govuk-heading-m govuk-!-margin-top-8 govuk-!-margin-bottom-2 govuk-!-font-size-27">Support for a disability</h2>
+      <h2 class="govuk-heading-m govuk-!-margin-top-8 govuk-!-margin-bottom-2 govuk-!-font-size-27">Disability support</h2>
 
       {{ govukSummaryList({
         rows: [
@@ -147,7 +147,7 @@
               text: "Do you want to ask for help to become a teacher?"
             },
             value: {
-              text: "Yes" if application.disability.response
+            text: "Yes, I want to share information about myself so my provider can take steps to support me" if application.disability.response else "No"
             }
           },
           {
@@ -161,20 +161,20 @@
         ]
       }) }}
 
-      <h2 class="govuk-heading-m govuk-!-margin-top-8 govuk-!-margin-bottom-2 govuk-!-font-size-27">Safeguarding</h2>
+      <h2 class="govuk-heading-m govuk-!-margin-top-8 govuk-!-margin-bottom-2 govuk-!-font-size-27">Safeguarding issues</h2>
 
       {% set safeguardingValueHtml %}
         {% if application.safeguarding.response %}
           {% if (["canViewSafeguardingInformation", ""] | random) == "canViewSafeguardingInformation" %}
-            {% set safeguardingDetailsHtml %}
-              <p class="govuk-body">{{ application.safeguarding.details | nl2br }}</p>
-            {% endset %}
+            {# {% set safeguardingDetailsHtml %} #}
+              <p>{{ application.safeguarding.details | nl2br }}</p>
+            {# {% endset %}
             {{ govukDetails({
               summaryText: "View information",
               html: safeguardingDetailsHtml
-            }) }}
+            }) }} #}
           {% else %}
-            <p>You cannot safeguarding information. This is because you and/or your organisation does not have this permission.</p>
+            <p>You cannot view safeguarding information. You and your organisation would need to have this permission to view it.</p>
           {% endif %}
         {% endif %}
       {% endset %}

--- a/app/views/application/index.njk
+++ b/app/views/application/index.njk
@@ -174,7 +174,9 @@
               html: safeguardingDetailsHtml
             }) }} #}
           {% else %}
-            <p>You and your organisation both need to have permission to view safeguarding information.</p>
+            <div style="color:#505A5F">
+            Unavailable: you and your organisation both need permission to view these safeguarding issues.
+            </div>
           {% endif %}
         {% endif %}
       {% endset %}

--- a/app/views/application/index.njk
+++ b/app/views/application/index.njk
@@ -152,7 +152,7 @@
           },
           {
             key: {
-              text: "Details"
+              text: "Give any relevant information"
             },
             value: {
               html: application.disability.details
@@ -161,38 +161,21 @@
         ]
       }) }}
 
-      <!--
-,
-          {
-            key: {
-              text: "Do you have any interview needs?"
-            },
-            value: {
-              text: "Yes"
-            }
-          },
-          {
-            key: {
-              text: "Interview needs"
-            },
-            value: {
-              text: "I need lots of sweets to get me through this ordeal"
-            }
-          }
-      -->
-
-
       <h2 class="govuk-heading-m govuk-!-margin-top-8 govuk-!-margin-bottom-2 govuk-!-font-size-27">Safeguarding</h2>
 
       {% set safeguardingValueHtml %}
         {% if application.safeguarding.response %}
-          {% set safeguardingDetailsHtml %}
-            <p class="govuk-body">{{ application.safeguarding | nl2br }}</p>
-          {% endset %}
-          {{ govukDetails({
-            summaryText: "View information disclosed by the candidate",
-            html: safeguardingDetailsHtml
-          }) }}
+          {% if (["canViewSafeguardingInformation", ""] | random) == "canViewSafeguardingInformation" %}
+            {% set safeguardingDetailsHtml %}
+              <p class="govuk-body">{{ application.safeguarding.details | nl2br }}</p>
+            {% endset %}
+            {{ govukDetails({
+              summaryText: "View information",
+              html: safeguardingDetailsHtml
+            }) }}
+          {% else %}
+            <p>You cannot safeguarding information. This is because you and/or your organisation does not have this permission.</p>
+          {% endif %}
         {% endif %}
       {% endset %}
 
@@ -203,96 +186,43 @@
               text: "Do you want to share any safeguarding issues?"
             },
             value: {
-              text: "Yes" if application.safeguarding.response else appNoInformationShared()
+              text: "Yes" if application.safeguarding.response else "No"
             }
           },
           {
             key: {
-              text: "Safeguarding issues"
+              text: "Give any relevant information"
             },
             value: {
               html: safeguardingValueHtml
             }
-          } if application.safeguarding.response
+          } if application.safeguarding.details
         ]
       }) }}
 
+      <h2 class="govuk-heading-m govuk-!-margin-top-8 govuk-!-margin-bottom-2 govuk-!-font-size-27">Interview needs</h2>
 
-      {# <h2 class="govuk-heading-m govuk-!-margin-top-8 govuk-!-margin-bottom-2 govuk-!-font-size-27">Disability, access and other needs</h2>
-      {% set disabilityGuidanceHtml %}
-        <h2 class="govuk-heading-m ">Asking for support if you have a disability or other needs</h2>
-        <p class="govuk-body">You might benefit from extra support if you’re disabled, have a mental health condition or educational needs.</p>
-        <p class="govuk-body">If you choose to tell us you need support, we’ll let your training provider know. They can then make adjustments so you can attend an interview or do the training.</p>
-        <p class="govuk-body">Examples of support could be:</p>
-        <ul class="govuk-list govuk-list--bullet">
-          <li>organising equipment like a hearing loop or an adapted keyboard</li>
-          <li>putting you in touch with support staff if you have a mental health condition</li>
-          <li>making sure classrooms are wheelchair accessible</li>
-        </ul>
-        <p class="govuk-body">If the help you need is not covered by your provider making adjustments, you might also be able to get support from <a href="https://www.gov.uk/access-to-work">Access to Work</a>. This could include a grant to help cover the costs of practical support in the workplace.</p>
-        <h2 class="govuk-heading-m">It’s against the law to discriminate</h2>
-        <p class="govuk-body">If you’re disabled, <a href="/getintoteaching/train-to-teach-with-a-disability">it’s against the law to discriminate against you</a>. Training providers must not:</p>
-        <ul class="govuk-list govuk-list--bullet">
-          <li>ask disability or health questions if they’re not relevant to your ability to become a teacher</li>
-          <li>reject your application because you’re disabled</li>
-        </ul>
-      {% endset %}
-      {{ govukDetails({
-        summaryText: "View guidance given to candidate",
-        html: disabilityGuidanceHtml
+      {{ govukSummaryList({
+        rows: [
+          {
+            key: {
+              text: "Do you have any interview needs?"
+            },
+            value: {
+              text: "Yes" if application.interviewNeeds.response else "No"
+            }
+          },
+          {
+            key: {
+              text: "What are your interview needs?"
+            },
+            value: {
+              html: application.interviewNeeds.details
+            }
+          } if application.interviewNeeds.details
+        ]
       }) }}
 
-      <p class="govuk-body">{{application["reasonable-adjustments"] | nl2br or appNoInformationShared()}}</p>
-
-      <h2 class="govuk-heading-m govuk-!-margin-top-8 govuk-!-margin-bottom-2 govuk-!-font-size-27">Criminal convictions and professional misconduct</h2>
-      {% set safeguardingGuidanceHtml %}
-        <h2 class="govuk-heading-m">Declaring any safeguarding issues</h2>
-        <p class="govuk-body">Teacher training providers need to check that it’s safe for you to work with children and young people.</p>
-        <p class="govuk-body">As well as confirming your identity and your right to work in the UK, providers will check:</p>
-        <ul class="govuk-list govuk-list--bullet">
-          <li>your criminal record in the UK (they'll do an enhanced <a href="https://www.gov.uk/government/organisations/disclosure-and-barring-service/about#dbs-checks">DBS check)</a> and abroad where relevant</li>
-          <li>whether you’ve been banned from teaching or working with children</li>
-          <li>your professional behaviour, such as whether you’ve been removed from teacher training and what your referees say about you</li>
-        </ul>
-        <p class="govuk-body">Tell your provider about any potential safeguarding issues, such as offences, cautions, reprimands and final warnings. They can give advice about whether this will affect your application.</p>
-        <p class="govuk-body">It won’t necessarily stop you becoming a teacher.</p>
-      {% endset %}
-      {{ govukDetails({
-        summaryText: "View guidance given to candidate",
-        html: safeguardingGuidanceHtml
-      }) }} #}
-
-      {# {% if application.safeguarding %}
-        {% set safeguardingHtml %}
-          <p class="govuk-body">{{ application.safeguarding | nl2br }}</p>
-        {% endset %}
-        <p class="govuk-body">The candidate has disclosed sensitive material related to safeguarding.</p>
-        {{ govukDetails({
-          summaryText: "View information disclosed by the candidate",
-          html: safeguardingHtml
-        }) }}
-      {% else %}
-        <p class="govuk-body">{{appNoInformationShared()}}</p>
-      {% endif %} #}
-
-      {# <h2 class="govuk-heading-m govuk-!-margin-top-8 govuk-!-margin-bottom-2 govuk-!-font-size-27">Interview needs</h2>
-      {% set interviewGuidanceHtml %}
-        <h2 class="govuk-heading-m">Interview needs</h2>
-        <p class="govuk-body">Interviews usually take place over the course of a day. You'll need to attend in person.</p>
-        <p class="govuk-body">Training providers might not have much flexibility when setting a date and time for interview.</p>
-        <p class="govuk-body">If there's a reason why you need some flexibility you can tell us about it here.</p>
-        <p class="govuk-body">For example:</p>
-        <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-7">
-          <li>you have commitments such as employment or caring responsibilities</li>
-          <li>you'll be travelling a long way to get to the interview</li>
-          <li>you'll need some adjustments because you're disabled</li>
-        </ul>
-      {% endset %}
-      {{ govukDetails({
-        summaryText: "View guidance given to candidate",
-        html: interviewGuidanceHtml
-      }) }}
-      <p class="govuk-body">{{ application.interviewNeeds | nl2br or appNoInformationShared() }}</p> #}
     </div>
   </div>
 
@@ -311,9 +241,9 @@
       }) }} #}
       {% include "_includes/application/degrees.njk" %}
       {% include "_includes/application/gcses.njk" %}
-      {# {% if application.personalDetails.isInternationalCandidate %} #}
+      {% if application.personalDetails.isInternationalCandidate %}
         {% include "_includes/application/english-language-qualification.njk" %}
-      {# {% endif %} #}
+      {% endif %}
     </div>
   </div>
 

--- a/app/views/application/index.njk
+++ b/app/views/application/index.njk
@@ -174,9 +174,7 @@
               html: safeguardingDetailsHtml
             }) }} #}
           {% else %}
-            <div style="color:#505A5F">
-            Unavailable: you and your organisation both need permission to view these safeguarding issues.
-            </div>
+            <span class="app-permission-text">Unavailable: you and your organisation both need permission to view these safeguarding issues.</span>
           {% endif %}
         {% endif %}
       {% endset %}

--- a/app/views/application/index.njk
+++ b/app/views/application/index.njk
@@ -174,7 +174,7 @@
               html: safeguardingDetailsHtml
             }) }} #}
           {% else %}
-            <p>You cannot view safeguarding information. You and your organisation would need to have this permission to view it.</p>
+            <p>You and your organisation both need to have permission to view safeguarding information.</p>
           {% endif %}
         {% endif %}
       {% endset %}
@@ -186,7 +186,7 @@
               text: "Do you want to share any safeguarding issues?"
             },
             value: {
-              text: "Yes" if application.safeguarding.response else "No"
+              text: "Yes, I want to share something" if application.safeguarding.response else "No"
             }
           },
           {

--- a/app/views/application/index.njk
+++ b/app/views/application/index.njk
@@ -228,13 +228,13 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
-      <h2 class="govuk-heading-m govuk-!-margin-top-8 govuk-!-margin-bottom-2 govuk-!-font-size-27">Qualifications</h2>
-      {% set qualificationsGuidanceHtml %}
+      <h2 class="govuk-heading-m govuk-!-margin-top-6  govuk-!-font-size-27">Qualifications</h2>
+      {# {% set qualificationsGuidanceHtml %}
         <h2 class="govuk-heading-m">Academic and other relevant qualifications</h2>
         <p class="govuk-body">Your undergraduate degree confirms your eligibility to teach. Enter the details of your degree as they appear on your certificate, translating them into English if necessary.</p>
         <p class="govuk-body">You should also include any postgraduate degrees.</p>
         <p class="govuk-body">Enter your other qualifications as completely as you can, including all your GCSEs and A levels (or equivalents), and any other qualifications where you showed skills that might help you as a teacher.</p>
-      {% endset %}
+      {% endset %} #}
       {# {{ govukDetails({
         summaryText: "View guidance given to candidate",
         html: qualificationsGuidanceHtml
@@ -251,8 +251,8 @@
     <div class="govuk-grid-column-two-thirds">
       {% include "_includes/application/other-qualifications.njk" %}
 
-      <h2 class="govuk-heading-m govuk-!-margin-top-8 govuk-!-margin-bottom-2 govuk-!-font-size-27">Work history</h2>
-      {% set workHistoryGuidanceHtml %}
+      <h2 class="govuk-heading-m govuk-!-margin-top-8 govuk-!-font-size-27">Work history</h2>
+      {# {% set workHistoryGuidanceHtml %}
         <h2 class="govuk-heading-m">Work history</h2>
         <p class="govuk-body">Training providers need a complete picture of the last 5 years of of your work history, including time out of the workplace, to safeguard children.</p>
         <p class="govuk-body">Breaks in work history won’t impact your application if you have a reasonable explanation for them (for example, parenting responsibilities, redundancy, illness or personal reasons such as study or travel).</p>
@@ -260,11 +260,11 @@
       {{ govukDetails({
         summaryText: "View guidance given to candidate",
         html: workHistoryGuidanceHtml
-      }) }}
+      }) }} #}
       {% include "_includes/application/work-history.njk" %}
 
-      <h2 class="govuk-heading-m govuk-!-margin-top-8 govuk-!-margin-bottom-2 govuk-!-font-size-27">Unpaid experience and volunteering</h2>
-      {% set volunteeringGuidanceHtml %}
+      <h2 class="govuk-heading-m govuk-!-margin-top-8  govuk-!-font-size-27">Unpaid experience and volunteering</h2>
+      {# {% set volunteeringGuidanceHtml %}
         <h2 class="govuk-heading-m">Unpaid experience working with children and other volunteering</h2>
         <p class="govuk-body">Tell us about any unpaid experience you have working with children or in a school. For example:</p>
         <ul class="govuk-list govuk-list--bullet">
@@ -277,7 +277,7 @@
       {{ govukDetails({
         summaryText: "View guidance given to candidate",
         html: volunteeringGuidanceHtml
-      }) }}
+      }) }} #}
       {% include "_includes/application/school-experience.njk" %}
 
       <h2 class="govuk-heading-m govuk-!-margin-top-8 govuk-!-margin-bottom-2 govuk-!-font-size-27">Personal statement</h2>

--- a/app/views/application/index.njk
+++ b/app/views/application/index.njk
@@ -138,7 +138,7 @@
         }]
       }) }}
 
-      <h2 class="govuk-heading-m govuk-!-margin-top-8 govuk-!-margin-bottom-2 govuk-!-font-size-27">Adjustments</h2>
+      <h2 class="govuk-heading-m govuk-!-margin-top-8 govuk-!-margin-bottom-2 govuk-!-font-size-27">Support for a disability</h2>
 
       {{ govukSummaryList({
         rows: [
@@ -147,9 +147,22 @@
               text: "Do you want to ask for help to become a teacher?"
             },
             value: {
-              text: "No"
+              text: "Yes" if application.disability.response
             }
           },
+          {
+            key: {
+              text: "Details"
+            },
+            value: {
+              html: application.disability.details
+            }
+          } if application.disability.details
+        ]
+      }) }}
+
+      <!--
+,
           {
             key: {
               text: "Do you have any interview needs?"
@@ -166,23 +179,20 @@
               text: "I need lots of sweets to get me through this ordeal"
             }
           }
-        ]
-      }) }}
+      -->
+
 
       <h2 class="govuk-heading-m govuk-!-margin-top-8 govuk-!-margin-bottom-2 govuk-!-font-size-27">Safeguarding</h2>
 
-      {% set safeguardingBoomHtml %}
-        {% if application.safeguarding %}
-          {% set safeguardingHtml %}
+      {% set safeguardingValueHtml %}
+        {% if application.safeguarding.response %}
+          {% set safeguardingDetailsHtml %}
             <p class="govuk-body">{{ application.safeguarding | nl2br }}</p>
           {% endset %}
-          {# <p class="govuk-body">The candidate has disclosed sensitive material related to safeguarding.</p> #}
           {{ govukDetails({
             summaryText: "View information disclosed by the candidate",
-            html: safeguardingHtml
+            html: safeguardingDetailsHtml
           }) }}
-        {% else %}
-          <p class="govuk-body">{{appNoInformationShared()}}</p>
         {% endif %}
       {% endset %}
 
@@ -193,22 +203,22 @@
               text: "Do you want to share any safeguarding issues?"
             },
             value: {
-              text: "Yes"
+              text: "Yes" if application.safeguarding.response else appNoInformationShared()
             }
           },
           {
             key: {
-              text: "Safeguarding isues"
+              text: "Safeguarding issues"
             },
             value: {
-              html: safeguardingBoomHtml
+              html: safeguardingValueHtml
             }
-          }
+          } if application.safeguarding.response
         ]
       }) }}
 
 
-      <h2 class="govuk-heading-m govuk-!-margin-top-8 govuk-!-margin-bottom-2 govuk-!-font-size-27">Disability, access and other needs</h2>
+      {# <h2 class="govuk-heading-m govuk-!-margin-top-8 govuk-!-margin-bottom-2 govuk-!-font-size-27">Disability, access and other needs</h2>
       {% set disabilityGuidanceHtml %}
         <h2 class="govuk-heading-m ">Asking for support if you have a disability or other needs</h2>
         <p class="govuk-body">You might benefit from extra support if you’re disabled, have a mental health condition or educational needs.</p>
@@ -250,9 +260,9 @@
       {{ govukDetails({
         summaryText: "View guidance given to candidate",
         html: safeguardingGuidanceHtml
-      }) }}
+      }) }} #}
 
-      {% if application.safeguarding %}
+      {# {% if application.safeguarding %}
         {% set safeguardingHtml %}
           <p class="govuk-body">{{ application.safeguarding | nl2br }}</p>
         {% endset %}
@@ -263,9 +273,9 @@
         }) }}
       {% else %}
         <p class="govuk-body">{{appNoInformationShared()}}</p>
-      {% endif %}
+      {% endif %} #}
 
-      <h2 class="govuk-heading-m govuk-!-margin-top-8 govuk-!-margin-bottom-2 govuk-!-font-size-27">Interview needs</h2>
+      {# <h2 class="govuk-heading-m govuk-!-margin-top-8 govuk-!-margin-bottom-2 govuk-!-font-size-27">Interview needs</h2>
       {% set interviewGuidanceHtml %}
         <h2 class="govuk-heading-m">Interview needs</h2>
         <p class="govuk-body">Interviews usually take place over the course of a day. You'll need to attend in person.</p>
@@ -282,7 +292,7 @@
         summaryText: "View guidance given to candidate",
         html: interviewGuidanceHtml
       }) }}
-      <p class="govuk-body">{{ application.interviewNeeds | nl2br or appNoInformationShared() }}</p>
+      <p class="govuk-body">{{ application.interviewNeeds | nl2br or appNoInformationShared() }}</p> #}
     </div>
   </div>
 
@@ -295,15 +305,15 @@
         <p class="govuk-body">You should also include any postgraduate degrees.</p>
         <p class="govuk-body">Enter your other qualifications as completely as you can, including all your GCSEs and A levels (or equivalents), and any other qualifications where you showed skills that might help you as a teacher.</p>
       {% endset %}
-      {{ govukDetails({
+      {# {{ govukDetails({
         summaryText: "View guidance given to candidate",
         html: qualificationsGuidanceHtml
-      }) }}
+      }) }} #}
       {% include "_includes/application/degrees.njk" %}
       {% include "_includes/application/gcses.njk" %}
-      {% if application.personalDetails.isInternationalCandidate %}
+      {# {% if application.personalDetails.isInternationalCandidate %} #}
         {% include "_includes/application/english-language-qualification.njk" %}
-      {% endif %}
+      {# {% endif %} #}
     </div>
   </div>
 

--- a/app/views/application/index.njk
+++ b/app/views/application/index.njk
@@ -138,6 +138,76 @@
         }]
       }) }}
 
+      <h2 class="govuk-heading-m govuk-!-margin-top-8 govuk-!-margin-bottom-2 govuk-!-font-size-27">Adjustments</h2>
+
+      {{ govukSummaryList({
+        rows: [
+          {
+            key: {
+              text: "Do you want to ask for help to become a teacher?"
+            },
+            value: {
+              text: "No"
+            }
+          },
+          {
+            key: {
+              text: "Do you have any interview needs?"
+            },
+            value: {
+              text: "Yes"
+            }
+          },
+          {
+            key: {
+              text: "Interview needs"
+            },
+            value: {
+              text: "I need lots of sweets to get me through this ordeal"
+            }
+          }
+        ]
+      }) }}
+
+      <h2 class="govuk-heading-m govuk-!-margin-top-8 govuk-!-margin-bottom-2 govuk-!-font-size-27">Safeguarding</h2>
+
+      {% set safeguardingBoomHtml %}
+        {% if application.safeguarding %}
+          {% set safeguardingHtml %}
+            <p class="govuk-body">{{ application.safeguarding | nl2br }}</p>
+          {% endset %}
+          {# <p class="govuk-body">The candidate has disclosed sensitive material related to safeguarding.</p> #}
+          {{ govukDetails({
+            summaryText: "View information disclosed by the candidate",
+            html: safeguardingHtml
+          }) }}
+        {% else %}
+          <p class="govuk-body">{{appNoInformationShared()}}</p>
+        {% endif %}
+      {% endset %}
+
+      {{ govukSummaryList({
+        rows: [
+          {
+            key: {
+              text: "Do you want to share any safeguarding issues?"
+            },
+            value: {
+              text: "Yes"
+            }
+          },
+          {
+            key: {
+              text: "Safeguarding isues"
+            },
+            value: {
+              html: safeguardingBoomHtml
+            }
+          }
+        ]
+      }) }}
+
+
       <h2 class="govuk-heading-m govuk-!-margin-top-8 govuk-!-margin-bottom-2 govuk-!-font-size-27">Disability, access and other needs</h2>
       {% set disabilityGuidanceHtml %}
         <h2 class="govuk-heading-m ">Asking for support if you have a disability or other needs</h2>
@@ -195,7 +265,7 @@
         <p class="govuk-body">{{appNoInformationShared()}}</p>
       {% endif %}
 
-      <h2 class="govuk-heading-m govuk-!-margin-top-8 govuk-!-margin-bottom-2 govuk-!-font-size-27">Interview</h2>
+      <h2 class="govuk-heading-m govuk-!-margin-top-8 govuk-!-margin-bottom-2 govuk-!-font-size-27">Interview needs</h2>
       {% set interviewGuidanceHtml %}
         <h2 class="govuk-heading-m">Interview needs</h2>
         <p class="govuk-body">Interviews usually take place over the course of a day. You'll need to attend in person.</p>

--- a/app/views/application/interviews/edit/index.njk
+++ b/app/views/application/interviews/edit/index.njk
@@ -20,10 +20,10 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      {% if application.interviewNeeds %}
+      {% if application.interviewNeeds.details %}
         <div class="app-box">
           <h2 class="govuk-heading-m govuk-!-margin-bottom-2">Candidate interview preferences</h2>
-          <p>{{application.interviewNeeds | nl2br}}</p>
+          <p>{{application.interviewNeeds.details | nl2br}}</p>
         </div>
       {% endif %}
 

--- a/app/views/application/interviews/index.njk
+++ b/app/views/application/interviews/index.njk
@@ -67,9 +67,9 @@
                   text: "Interview preferences"
                 },
                 value: {
-                  text: application.interviewNeeds
+                  text: application.interviewNeeds.details
                 }
-              } if application.interviewNeeds,
+              } if application.interviewNeeds.details,
               {
                 key: {
                   text: "Organisation carrying out interview"
@@ -150,9 +150,9 @@
                   text: "Interview preferences"
                 },
                 value: {
-                  text: application.interviewNeeds
+                  text: application.interviewNeeds.details
                 }
-              } if application.interviewNeeds,
+              } if application.interviewNeeds.details,
               {
                 key: {
                   text: "Organisation carrying out interview"

--- a/app/views/application/interviews/new/index.njk
+++ b/app/views/application/interviews/new/index.njk
@@ -28,10 +28,10 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      {% if application.interviewNeeds %}
+      {% if application.interviewNeeds.details %}
         <div class="app-box">
           <h2 class="govuk-heading-m govuk-!-margin-bottom-2">Candidate interview preferences</h2>
-          <p>{{application.interviewNeeds | nl2br}}</p>
+          <p>{{application.interviewNeeds.details | nl2br}}</p>
         </div>
       {% endif %}
 

--- a/app/views/application/notes/index.njk
+++ b/app/views/application/notes/index.njk
@@ -44,7 +44,7 @@
           {% for note in application.notes.items %}
             <div class="app-notes__note">
               <h2 class="govuk-heading-m govuk-!-margin-bottom-1"><a class="govuk-link govuk-link--no-visited-state" href="/application/{{application.id}}/notes/{{note.id}}">{{note.subject}}</a></h2>
-              <p class="govuk-!-margin-bottom-1">{{note.body | nl2br or "No information shared"}}</p>
+              <p class="govuk-!-margin-bottom-1">{{note.body | nl2br}}</p>
               <p class="app-notes__meta">{{note.sender}}, {{note.date | govukDateAtTime }}</p>
             </div>
           {% endfor %}

--- a/app/views/interviews/index.njk
+++ b/app/views/interviews/index.njk
@@ -44,7 +44,7 @@
                 name: interview.app.personalDetails.givenName + ' ' + interview.app.personalDetails.familyName,
                 course: interview.app.course,
                 provider: interview.app.provider,
-                hasInterviewPreferences: interview.app.interviewNeeds.length
+                hasInterviewPreferences: interview.app.interviewNeeds.details
               })}}
             {% endfor %}
           {% endfor %}

--- a/app/views/interviews/past.njk
+++ b/app/views/interviews/past.njk
@@ -38,7 +38,7 @@
                 name: interview.app.personalDetails.givenName + ' ' + interview.app.personalDetails.familyName,
                 course: interview.app.course,
                 provider: interview.app.provider,
-                hasInterviewPreferences: interview.app.interviewNeeds.length
+                hasInterviewPreferences: interview.app.interviewNeeds.details
               })}}
             {% endfor %}
           {% endfor %}

--- a/scripts/generate-applications.js
+++ b/scripts/generate-applications.js
@@ -21,6 +21,7 @@ const generateSchoolExperience = require('../app/data/generators/school-experien
 const generatePersonalStatement = require('../app/data/generators/personal-statement')
 const generateReferences = require('../app/data/generators/references')
 const generateInterviewNeeds = require('../app/data/generators/interview-needs')
+const generateSafeguarding = require('../app/data/generators/safeguarding')
 
 // Fake data generators: application management
 const generateOffer = require('../app/data/generators/offer')
@@ -87,7 +88,8 @@ const generateFakeApplication = (params = {}) => {
     schoolExperience: generateSchoolExperience(faker),
     personalStatement: generatePersonalStatement(faker),
     references: generateReferences(faker),
-    miscellaneous: faker.lorem.paragraph()
+    miscellaneous: faker.lorem.paragraph(),
+    safeguarding: generateSafeguarding(faker)
   }
 }
 

--- a/scripts/generate-applications.js
+++ b/scripts/generate-applications.js
@@ -22,6 +22,7 @@ const generatePersonalStatement = require('../app/data/generators/personal-state
 const generateReferences = require('../app/data/generators/references')
 const generateInterviewNeeds = require('../app/data/generators/interview-needs')
 const generateSafeguarding = require('../app/data/generators/safeguarding')
+const generateDisability = require('../app/data/generators/disability')
 
 // Fake data generators: application management
 const generateOffer = require('../app/data/generators/offer')
@@ -80,7 +81,7 @@ const generateFakeApplication = (params = {}) => {
     personalDetails,
     contactDetails: params.contactDetails || generateContactDetails(faker, personalDetails),
     interviewNeeds: generateInterviewNeeds(faker),
-    workHistory: generateWorkHistory(faker),
+    workHistory: params.workHistory || generateWorkHistory(faker),
     degree: params.degree || generateDegree(faker, personalDetails.isInternationalCandidate),
     gcse: params.gcse || generateGcse(faker, personalDetails.isInternationalCandidate),
     englishLanguageQualification: params.englishLanguageQualification || generateEnglishLanguageQualification(faker),
@@ -89,7 +90,8 @@ const generateFakeApplication = (params = {}) => {
     personalStatement: generatePersonalStatement(faker),
     references: generateReferences(faker),
     miscellaneous: faker.lorem.paragraph(),
-    safeguarding: generateSafeguarding(faker)
+    safeguarding: generateSafeguarding(faker),
+    disability: generateDisability(faker)
   }
 }
 
@@ -209,7 +211,8 @@ const generateFakeApplications = () => {
       givenName: 'Emma',
       familyName: 'Hayes',
       sex: 'Female'
-    }
+    },
+    workHistory: []
   }))
 
   applications.push(generateFakeApplication({

--- a/scripts/generate-applications.js
+++ b/scripts/generate-applications.js
@@ -80,7 +80,7 @@ const generateFakeApplication = (params = {}) => {
     events,
     personalDetails,
     contactDetails: params.contactDetails || generateContactDetails(faker, personalDetails),
-    interviewNeeds: generateInterviewNeeds(faker),
+    interviewNeeds: generateInterviewNeeds(),
     workHistory: params.workHistory || generateWorkHistory(faker),
     degree: params.degree || generateDegree(faker, personalDetails.isInternationalCandidate),
     gcse: params.gcse || generateGcse(faker, personalDetails.isInternationalCandidate),


### PR DESCRIPTION
We've made a series of changes to the disability, interview needs and safeguarding sections. The aim was to bring the sections more in line with the rest of the page and make the content clearer, such as by giving the exact questions asked and the exact responses (including generic ones from the radio button text).

We've also removed details components which revealed guidance, as we plan to move this into the guidance section. We don't think that users need to be able to access it within every candidate's application.