### PR TITLE
Closing an application (iteration 2)

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -190,3 +190,8 @@ h1 .govuk-tag {
 .app-permission-text {
   color: govuk-colour("dark-grey");
 }
+
+.app-temp-offer-wrapper .app-offer-panel {
+  border: 0;
+  padding: 0;
+}

--- a/app/data/helpers/application.js
+++ b/app/data/helpers/application.js
@@ -206,7 +206,7 @@ exports.getStatusText = (application) => {
     status = "Interviewing"
   } else if (application.status === "Awaiting decision") {
     status = "Received"
-  } else if (application.status === "Declined" || application.status === "Rejected" || application.status === "Offer withdrawn" || application.status == "Application withdrawn" || application.status == "Conditions not met" ) {
+  } else if (application.status === "Declined" || application.status === "Rejected" || application.status === "Offer withdrawn" || application.status === "Application withdrawn" || application.status == "Conditions not met" ) {
     status = "Closed"
   }
 

--- a/app/data/helpers/application.js
+++ b/app/data/helpers/application.js
@@ -206,6 +206,8 @@ exports.getStatusText = (application) => {
     status = "Interviewing"
   } else if (application.status === "Awaiting decision") {
     status = "Received"
+  } else if (application.status === "Declined" || application.status === "Rejected" || application.status === "Offer withdrawn" || application.status == "Application withdrawn" || application.status == "Conditions not met" ) {
+    status = "Closed"
   }
 
   return status

--- a/app/data/helpers/application.js
+++ b/app/data/helpers/application.js
@@ -206,8 +206,6 @@ exports.getStatusText = (application) => {
     status = "Interviewing"
   } else if (application.status === "Awaiting decision") {
     status = "Received"
-  } else if (application.status === "Declined" || application.status === "Rejected" || application.status === "Offer withdrawn" || application.status == "Application withdrawn" || application.status == "Conditions not met" ) {
-    status = "Closed"
   }
 
   return status

--- a/app/routes/offer.js
+++ b/app/routes/offer.js
@@ -215,12 +215,14 @@ module.exports = router => {
       condition.status = req.session.data['edit-condition-statuses']['conditions'][condition.id]
     })
 
+    var flash = "Status of conditions updated"
+
     if (ApplicationHelper.hasMetAllConditions(application)) {
       application.status = 'Conditions met';
-    }
-
-    if(ApplicationHelper.getConditions(application).some(c => c.status == "Not met")) {
+      flash = "Conditions marked as met"
+    } else if(ApplicationHelper.getConditions(application).some(c => c.status == "Not met")) {
       application.status = 'Conditions not met';
+      flash = "Offer withdrawn and application closed"
     }
 
     ApplicationHelper.addEvent(application, {
@@ -229,7 +231,7 @@ module.exports = router => {
       "date": new Date().toISOString()
     })
 
-    req.flash('success', 'Status of conditions updated successfully')
+    req.flash('success', flash)
     res.redirect(`/applications/${req.params.applicationId}/offer`)
 
   })

--- a/app/routes/reject-application.js
+++ b/app/routes/reject-application.js
@@ -48,13 +48,21 @@ module.exports = router => {
   router.post('/applications/:applicationId/reject/check', (req, res) => {
     const applicationId = req.params.applicationId
     const application = req.session.data.applications.find(app => app.id === applicationId)
-    application.status = 'Rejected'
-    application.rejectedDate = new Date().toISOString()
-    application.rejectedReasons = ApplicationHelper.getRejectReasons(req.session.data.rejectionReasons)
+
+    if(req.session.data.rejectionReasons['other-offer'] == "Yes" || req.session.data.rejectionReasons['asked'] == "Yes") {
+      application.status = 'Application withdrawn'
+      application.withdrawnDate = new Date().toISOString()
+      application.rejectedReasons = ApplicationHelper.getRejectReasons(req.session.data.rejectionReasons)
+      req.flash('success', 'Application closed')
+    } else {
+      application.status = 'Rejected'
+      application.rejectedDate = new Date().toISOString()
+      application.rejectedReasons = ApplicationHelper.getRejectReasons(req.session.data.rejectionReasons)
+      req.flash('success', 'Application closed')
+    }
 
     delete req.session.data.rejectionReasons
 
-    req.flash('success', 'Application closed')
     res.redirect(`/applications/${applicationId}`)
   })
 }

--- a/app/routes/withdraw-offer.js
+++ b/app/routes/withdraw-offer.js
@@ -54,7 +54,7 @@ module.exports = router => {
     application.withdrawnReasons = ApplicationHelper.getRejectReasons(req.session.data.rejectionReasons)
     delete req.session.data.rejectionReasons
 
-    req.flash('success', 'Offer withdrawn')
+    req.flash('success', 'Offer withdrawn and application closed')
     res.redirect(`/applications/${applicationId}/offer`)
   })
 }

--- a/app/routes/withdraw-offer.js
+++ b/app/routes/withdraw-offer.js
@@ -12,15 +12,23 @@ module.exports = router => {
     // skip last page if safeguarding, honesty or other offer given
     if (req.session.data.rejectionReasons.honesty === 'Yes' || req.session.data.rejectionReasons.safeguarding === 'Yes') {
       res.redirect(`/applications/${req.params.applicationId}/offer/withdraw/check`)
+    } else if(req.session.data.rejectionReasons.conditions === 'Yes') {
+      res.redirect(`/applications/${req.params.applicationId}/offer/withdraw/conditions`)
     } else {
       res.redirect(`/applications/${req.params.applicationId}/offer/withdraw/other-reasons-for-rejection`)
     }
   })
 
+  router.get('/applications/:applicationId/offer/withdraw/conditions', (req, res) => {
+    res.render('applications/offer/withdraw/conditions', {
+      application: req.session.data.applications.find(app => app.id === req.params.applicationId)
+    })
+  })
+
   router.get('/applications/:applicationId/offer/withdraw/other-reasons-for-rejection', (req, res) => {
     var data = req.session.data.rejectionReasons
 
-    var noReasonsGivenYet = data.actions !== 'Yes' && data['missing-qualifications'] !== 'Yes' && data['application-quality'] !== 'Yes' && data['interview-performance'] !== 'Yes' && data['course-full'] !== 'Yes' && data['other-offer'] !== 'Yes' && data.honesty !== 'Yes' && data.safeguarding !== 'Yes'
+    var noReasonsGivenYet = data.actions !== 'Yes' && data['missing-qualifications'] !== 'Yes' && data['application-quality'] !== 'Yes' && data['interview-performance'] !== 'Yes' && data['course-full'] !== 'Yes' && data['other-offer'] !== 'Yes' && data.honesty !== 'Yes' && data.safeguarding !== 'Yes' && data.asked !== 'Yes'
 
     res.render('applications/offer/withdraw/other-reasons-for-rejection', {
       application: req.session.data.applications.find(app => app.id === req.params.applicationId),
@@ -46,7 +54,7 @@ module.exports = router => {
     application.withdrawnReasons = ApplicationHelper.getRejectReasons(req.session.data.rejectionReasons)
     delete req.session.data.rejectionReasons
 
-    req.flash('success', 'Offer successfully withdrawn')
+    req.flash('success', 'Offer withdrawn')
     res.redirect(`/applications/${applicationId}/offer`)
   })
 }

--- a/app/routes/withdraw-offer.js
+++ b/app/routes/withdraw-offer.js
@@ -49,12 +49,17 @@ module.exports = router => {
   router.post('/applications/:applicationId/offer/withdraw/check', (req, res) => {
     const applicationId = req.params.applicationId
     const application = req.session.data.applications.find(app => app.id === applicationId)
+
+    // if(req.session.data.rejectionReasons['other-offer'] == "Yes" || req.session.data.rejectionReasons['asked'] == "Yes") {
+      // application.status = 'Application withdrawn'
+    // } else {
     application.status = 'Offer withdrawn'
     application.withdrawnDate = new Date().toISOString()
     application.withdrawnReasons = ApplicationHelper.getRejectReasons(req.session.data.rejectionReasons)
-    delete req.session.data.rejectionReasons
-
+    // }
     req.flash('success', 'Offer withdrawn and application closed')
+
+    delete req.session.data.rejectionReasons
     res.redirect(`/applications/${applicationId}/offer`)
   })
 }

--- a/app/views/_components/offer-panel/template.njk
+++ b/app/views/_components/offer-panel/template.njk
@@ -8,7 +8,6 @@
         <a href="{{params.withdraw.href}}">Withdraw offer</a>
       {% endif %}
       {% if params.defer %}
-
         <a class="govuk-!-margin-left-2" href="{{params.defer.href}}">Defer offer</a>
       {% endif %}
     </p>

--- a/app/views/_components/offer-panel/template.njk
+++ b/app/views/_components/offer-panel/template.njk
@@ -8,13 +8,13 @@
         <a href="{{params.withdraw.href}}">Withdraw offer</a>
       {% endif %}
       {% if params.defer %}
-        {# or #}
-        <a href="{{params.defer.href}}">Defer offer</a>
+
+        <a class="govuk-!-margin-left-2" href="{{params.defer.href}}">Defer offer</a>
       {% endif %}
     </p>
   {% endif %}
 
-  <h2 class="govuk-heading-m">
+  <h2 class="govuk-heading-m govuk-!-margin-top-6 govuk-!-margin-bottom-2">
     Course details
   </h2>
   {{ govukSummaryList({

--- a/app/views/_includes/applications/application-details--sidebar.njk
+++ b/app/views/_includes/applications/application-details--sidebar.njk
@@ -1,0 +1,19 @@
+<div class="app-box govuk-!-margin-top-4">
+
+  <h2 class="govuk-heading-m govuk-!-margin-bottom-2 govuk-!-font-size-27">Application details</h2>
+
+  <p><a href="#" download>Download application (PDF)</a></p>
+
+  <h3 class="govuk-heading-s govuk-!-margin-bottom-1">Reference</h3>
+  <p>{{application.id}}</p>
+  <h3 class="govuk-heading-s govuk-!-margin-bottom-1">Submitted</h3>
+  <p>{{application.submittedDate | govukDateAtTime}}</p>
+  <h3 class="govuk-heading-s govuk-!-margin-bottom-1">Year received</h3>
+  <p>{{application.cycle | cycleText}}</p>
+
+  {% if application.status == "Awaiting decision" %}
+    <p><a href="/applications/{{application.id}}/reject">Reject or withdraw application</a></p>
+  {% else %}
+    <p><a href="/applications/{{application.id}}/reject">Withdraw application</a></p>
+  {% endif %}
+</div>

--- a/app/views/_includes/applications/application-details.njk
+++ b/app/views/_includes/applications/application-details.njk
@@ -1,4 +1,4 @@
-<h2 class="govuk-heading-m govuk-!-margin-top-4 govuk-!-margin-bottom-2 govuk-!-font-size-27">Application details</h2>
+<h2 class="govuk-heading-m govuk-!-margin-top-6 govuk-!-margin-bottom-2 govuk-!-font-size-27">Application details</h2>
 
 {{ govukSummaryList({
   rows: [
@@ -28,5 +28,3 @@
     }
   ]
 }) }}
-
-<p><a href="#" download>Download application (PDF)</a></p>

--- a/app/views/_includes/applications/close-option.njk
+++ b/app/views/_includes/applications/close-option.njk
@@ -1,3 +1,3 @@
 {% if application.statusText != "Closed" %}
-  <p class="govuk-!-margin-bottom-6" style="margin-top: -20px;"><a href="/applications/{{application.id}}/reject" class="govuk-link govuk-link--no-visited-state">Close application</a></p>
+  {# <p class="govuk-!-margin-bottom-6" style="margin-top: -20px;"><a href="/applications/{{application.id}}/reject" class="govuk-link govuk-link--no-visited-state">Close application</a></p> #}
 {% endif %}

--- a/app/views/_includes/applications/header.njk
+++ b/app/views/_includes/applications/header.njk
@@ -1,6 +1,4 @@
-{% include "_includes/applications/close-option.njk" %}
-
-  {% include "_includes/applications/respond-prompt.njk" %}
-  {% include "_includes/applications/interview-prompt.njk" %}
-  {% include "_includes/applications/defer-prompt.njk" %}
-  {% include "_includes/applications/feedback-prompt.njk" %}
+{% include "_includes/applications/respond-prompt.njk" %}
+{% include "_includes/applications/interview-prompt.njk" %}
+{% include "_includes/applications/defer-prompt.njk" %}
+{% include "_includes/applications/feedback-prompt.njk" %}

--- a/app/views/_includes/applications/respond-prompt.njk
+++ b/app/views/_includes/applications/respond-prompt.njk
@@ -9,10 +9,9 @@
     }) }}
     {{ govukButton({
       text: "Make decision",
-      classes: "govuk-!-margin-bottom-0 govuk-button--secondary",
+      classes: "govuk-!-margin-bottom-0 govuk-!-margin-right-2 govuk-button--secondary",
       href: "/applications/" + application.id + "/decision"
     }) }}
-
   {% endset %}
 
   <div class="govuk-grid-row">

--- a/app/views/_includes/candidate-feedback.njk
+++ b/app/views/_includes/candidate-feedback.njk
@@ -285,7 +285,10 @@
   {% if rejectionReasons['why'] %}
     <div class="app-feedback">
     <h2 class="govuk-heading-s">
-      Why your application was unsuccessful
+      {% if not whyHeading %}
+        {% set whyHeading = "Why your application was closed" %}
+      {% endif %}
+      {{whyHeading}}
     </h2>
     <p>{{rejectionReasons['why']}}</p>
     {% if rejectionChangeLinks %}

--- a/app/views/_includes/candidate-feedback.njk
+++ b/app/views/_includes/candidate-feedback.njk
@@ -1,4 +1,9 @@
 {% from "govuk/components/inset-text/macro.njk"       import govukInsetText %}
+
+{% if not baseUrl %}
+  {% set baseUrl = "/applications/" + application.id + "/reject" %}
+{% endif %}
+
 {% set previewHtml %}
 
   {% if rejectionReasons['actions'] == "Yes" %}
@@ -34,7 +39,7 @@
     </ul>
 
     {% if rejectionChangeLinks %}
-      <p class="app-rejection-change-link"><a class="govuk-link govuk-link--no-visited-state" href="/applications/{{application.id}}/reject">Change</a></p>
+      <p class="app-rejection-change-link"><a class="govuk-link govuk-link--no-visited-state" href="{{baseUrl}}">Change</a></p>
     {% endif %}
     </div>
   {% endif %}
@@ -78,7 +83,7 @@
     </ul>
 
     {% if rejectionChangeLinks %}
-      <p class="app-rejection-change-link"><a class="govuk-link govuk-link--no-visited-state" href="/applications/{{application.id}}/reject">Change</a></p>
+      <p class="app-rejection-change-link"><a class="govuk-link govuk-link--no-visited-state" href="{{baseUrl}}">Change</a></p>
     {% endif %}
     </div>
   {% endif %}
@@ -126,7 +131,7 @@
     </ul>
 
     {% if rejectionChangeLinks %}
-      <p class="app-rejection-change-link"><a class="govuk-link govuk-link--no-visited-state" href="/applications/{{application.id}}/reject">Change</a></p>
+      <p class="app-rejection-change-link"><a class="govuk-link govuk-link--no-visited-state" href="{{baseUrl}}">Change</a></p>
     {% endif %}
     </div>
   {% endif %}
@@ -142,7 +147,7 @@
     <p>{{rejectionReasons['interview-performance-advice']}}</p>
 
     {% if rejectionChangeLinks %}
-      <p class="app-rejection-change-link"><a class="govuk-link govuk-link--no-visited-state" href="/applications/{{application.id}}/reject">Change</a></p>
+      <p class="app-rejection-change-link"><a class="govuk-link govuk-link--no-visited-state" href="{{baseUrl}}">Change</a></p>
     {% endif %}
     </div>
   {% endif %}
@@ -155,7 +160,7 @@
     <p>The course you applied to was full.</p>
 
     {% if rejectionChangeLinks %}
-      <p class="app-rejection-change-link"><a class="govuk-link govuk-link--no-visited-state" href="/applications/{{application.id}}/reject">Change</a></p>
+      <p class="app-rejection-change-link"><a class="govuk-link govuk-link--no-visited-state" href="{{baseUrl}}">Change</a></p>
     {% endif %}
     </div>
   {% endif %}
@@ -169,7 +174,7 @@
     <p>{{rejectionReasons["other-offer-details"]}}</p>
 
     {% if rejectionChangeLinks %}
-      <p class="app-rejection-change-link"><a class="govuk-link govuk-link--no-visited-state" href="/applications/{{application.id}}/reject">Change</a></p>
+      <p class="app-rejection-change-link"><a class="govuk-link govuk-link--no-visited-state" href="{{baseUrl}}">Change</a></p>
     {% endif %}
     </div>
   {% endif %}
@@ -220,7 +225,7 @@
 
     </ul>
     {% if rejectionChangeLinks %}
-      <p class="app-rejection-change-link"><a class="govuk-link govuk-link--no-visited-state" href="/applications/{{application.id}}/reject">Change</a></p>
+      <p class="app-rejection-change-link"><a class="govuk-link govuk-link--no-visited-state" href="{{baseUrl}}">Change</a></p>
     {% endif %}
     </div>
   {% endif %}
@@ -262,7 +267,7 @@
 
     </ul>
     {% if rejectionChangeLinks %}
-      <p class="app-rejection-change-link"><a class="govuk-link govuk-link--no-visited-state" href="/applications/{{application.id}}/reject">Change</a></p>
+      <p class="app-rejection-change-link"><a class="govuk-link govuk-link--no-visited-state" href="{{baseUrl}}">Change</a></p>
     {% endif %}
     </div>
   {% endif %}
@@ -270,17 +275,15 @@
   {% if rejectionReasons['asked'] == "Yes" %}
     <div class="app-feedback">
     <h2 class="govuk-heading-s">
-      You asked to close your application
+      You asked to withdraw your application
     </h2>
     <p>{{rejectionReasons["asked-reasons"]}}</p>
 
     {% if rejectionChangeLinks %}
-      <p class="app-rejection-change-link"><a class="govuk-link govuk-link--no-visited-state" href="/applications/{{application.id}}/reject">Change</a></p>
+      <p class="app-rejection-change-link"><a class="govuk-link govuk-link--no-visited-state" href="{{baseUrl}}">Change</a></p>
     {% endif %}
     </div>
   {% endif %}
-
-
 
   {% if rejectionReasons['why'] %}
     <div class="app-feedback">
@@ -292,7 +295,7 @@
     </h2>
     <p>{{rejectionReasons['why']}}</p>
     {% if rejectionChangeLinks %}
-      <p class="app-rejection-change-link"><a class="govuk-link govuk-link--no-visited-state" href="/applications/{{application.id}}/reject/other-reasons-for-rejection/">Change</a></p>
+      <p class="app-rejection-change-link"><a class="govuk-link govuk-link--no-visited-state" href="{{baseUrl}}/other-reasons-for-rejection/">Change</a></p>
     {% endif %}
     </div>
   {% endif %}
@@ -304,7 +307,7 @@
     </h2>
     <p>{{rejectionReasons['other-feedback-details']}}</p>
     {% if rejectionChangeLinks %}
-      <p class="app-rejection-change-link"><a class="govuk-link govuk-link--no-visited-state" href="/applications/{{application.id}}/reject/other-reasons-for-rejection/">Change</a></p>
+      <p class="app-rejection-change-link"><a class="govuk-link govuk-link--no-visited-state" href="{{baseUrl}}/other-reasons-for-rejection/">Change</a></p>
     {% endif %}
     </div>
   {% endif %}
@@ -322,7 +325,7 @@
       {% endif %}
 
       {% if rejectionChangeLinks %}
-        <p class="app-rejection-change-link"><a class="govuk-link govuk-link--no-visited-state" href="/applications/{{application.id}}/reject/other-reasons-for-rejection/">Change</a></p>
+        <p class="app-rejection-change-link"><a class="govuk-link govuk-link--no-visited-state" href="{{baseUrl}}/other-reasons-for-rejection/">Change</a></p>
       {% endif %}
     </div>
   {% endif %}

--- a/app/views/_includes/filter-panel.njk
+++ b/app/views/_includes/filter-panel.njk
@@ -61,11 +61,11 @@
         text: 'Conditions met',
         checked: checked(data.status, "Conditions met") == 'checked'
       },
-      {
+       {
         value: 'Conditions not met',
         text: 'Conditions not met',
         checked: checked(data.status, "Conditions not met") == 'checked'
-      },
+      } if 1==2,
       {
         value: 'Deferred',
         text: 'Deferred',
@@ -75,27 +75,27 @@
         value: 'Declined',
         text: 'Declined',
         checked: checked(data.status, "Declined") == 'checked'
-      },
+      } if 1==2,
       {
         value: 'Rejected',
         text: 'Rejected',
         checked: checked(data.status, "Rejected") == 'checked'
-      },
+      } if 1==2,
       {
         value: 'Application withdrawn',
         text: 'Application withdrawn',
         checked: checked(data.status, "Application withdrawn") == 'checked'
-      },
+      } if 1==2,
       {
         value: 'Offer withdrawn',
         text: 'Offer withdrawn',
         checked: checked(data.status, "Offer withdrawn") == 'checked'
-      },
+      } if 1==2,
       {
         value: 'Closed',
         text: 'Closed',
         checked: checked(data.status, "Closed") == 'checked'
-      } if 1 == 2
+      }
     ]
   }) }}
 

--- a/app/views/_includes/filter-panel.njk
+++ b/app/views/_includes/filter-panel.njk
@@ -65,7 +65,7 @@
         value: 'Conditions not met',
         text: 'Conditions not met',
         checked: checked(data.status, "Conditions not met") == 'checked'
-      } if 1==2,
+      },
       {
         value: 'Deferred',
         text: 'Deferred',
@@ -75,27 +75,27 @@
         value: 'Declined',
         text: 'Declined',
         checked: checked(data.status, "Declined") == 'checked'
-      } if 1==2,
+      },
       {
         value: 'Rejected',
         text: 'Rejected',
         checked: checked(data.status, "Rejected") == 'checked'
-      } if 1==2,
+      },
       {
         value: 'Application withdrawn',
         text: 'Application withdrawn',
         checked: checked(data.status, "Application withdrawn") == 'checked'
-      } if 1==2,
+      },
       {
         value: 'Offer withdrawn',
         text: 'Offer withdrawn',
         checked: checked(data.status, "Offer withdrawn") == 'checked'
-      } if 1==2,
+      },
       {
         value: 'Closed',
         text: 'Closed',
         checked: checked(data.status, "Closed") == 'checked'
-      }
+      } if 1 == 2
     ]
   }) }}
 

--- a/app/views/_includes/filter-panel.njk
+++ b/app/views/_includes/filter-panel.njk
@@ -65,7 +65,7 @@
         value: 'Conditions not met',
         text: 'Conditions not met',
         checked: checked(data.status, "Conditions not met") == 'checked'
-      } if 1==2,
+      } if 1 == 2,
       {
         value: 'Deferred',
         text: 'Deferred',
@@ -75,22 +75,22 @@
         value: 'Declined',
         text: 'Declined',
         checked: checked(data.status, "Declined") == 'checked'
-      } if 1==2,
+      } if 1 == 2,
       {
         value: 'Rejected',
         text: 'Rejected',
         checked: checked(data.status, "Rejected") == 'checked'
-      } if 1==2,
+      } if 1 == 2,
       {
         value: 'Application withdrawn',
         text: 'Application withdrawn',
         checked: checked(data.status, "Application withdrawn") == 'checked'
-      } if 1==2,
+      } if 1 == 2,
       {
         value: 'Offer withdrawn',
         text: 'Offer withdrawn',
         checked: checked(data.status, "Offer withdrawn") == 'checked'
-      } if 1==2,
+      } if 1 == 2,
       {
         value: 'Closed',
         text: 'Closed',

--- a/app/views/_includes/reasons/actions.njk
+++ b/app/views/_includes/reasons/actions.njk
@@ -34,7 +34,7 @@
       value: "Did not reply to messages",
       html: "Did not reply to messages",
       checked: checked(data['rejectionReasons']['actions-reasons'], "Did not reply to messages")
-    } if application.status == 'Awaiting decision', {
+    }, {
       value: "Did not attend interview",
       text: "Did not attend interview",
       checked: checked(data['rejectionReasons']['actions-reasons'], "Did not attend interview")

--- a/app/views/_includes/reasons/other-offer.njk
+++ b/app/views/_includes/reasons/other-offer.njk
@@ -34,4 +34,4 @@
     text: "No",
     checked: checked(data['rejectionReasons']['other-offer'], "No")
   }]
-}) if application.status == 'Awaiting decision'}}
+}) if application.status == 'Awaiting decision' }}

--- a/app/views/applications/decision.njk
+++ b/app/views/applications/decision.njk
@@ -40,7 +40,7 @@
           },
           {
             value: "3",
-            text: "Close application"
+            text: "Reject or withdraw application"
           }]
         }) }}
 

--- a/app/views/applications/decision.njk
+++ b/app/views/applications/decision.njk
@@ -40,7 +40,7 @@
           },
           {
             value: "3",
-            text: "Reject or withdraw application"
+            text: "Close application"
           }]
         }) }}
 

--- a/app/views/applications/interviews/index.njk
+++ b/app/views/applications/interviews/index.njk
@@ -24,6 +24,8 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
+      <h2 class="govuk-heading-l govuk-!-margin-bottom govuk-!-font-size-36">Interviews</h2>
+
       {% if statusText == "Interviewing" %}
         {{ govukButton({
           text: "Set up interview",

--- a/app/views/applications/notes/index.njk
+++ b/app/views/applications/notes/index.njk
@@ -28,6 +28,9 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
+      <h2 class="govuk-heading-l govuk-!-margin-bottom govuk-!-font-size-36">Notes</h2>
+
+
       {% if application.notes %}
 
         {{govukButton({
@@ -39,7 +42,7 @@
         <div class="app-notes">
           {% for note in application.notes.items %}
             <div class="app-notes__note">
-              <h2 class="govuk-heading-m govuk-!-margin-bottom-1"><a class="govuk-link govuk-link--no-visited-state" href="/applications/{{application.id}}/notes/{{note.id}}">{{note.subject}}</a></h2>
+              <h2 class="govuk-heading-s govuk-!-margin-bottom-1"><a class="govuk-link govuk-link--no-visited-state" href="/applications/{{application.id}}/notes/{{note.id}}">{{note.subject}}</a></h2>
               <p class="govuk-!-margin-bottom-1">{{note.body | nl2br}}</p>
               <p class="app-notes__meta">{{note.sender}}, {{note.date | govukDateAtTime }}</p>
             </div>

--- a/app/views/applications/offer/edit-condition-statuses/check.njk
+++ b/app/views/applications/offer/edit-condition-statuses/check.njk
@@ -11,8 +11,6 @@
   {% set title = "Check and update status of conditions" %}
 {% endif %}
 
-
-
 {% block pageNavigation %}
   {{ govukBackLink({
     href: '/applications/' + application.id + '/offer/edit-condition-statuses'

--- a/app/views/applications/offer/edit-condition-statuses/check.njk
+++ b/app/views/applications/offer/edit-condition-statuses/check.njk
@@ -2,7 +2,16 @@
 
 {% set primaryNavId = 'applications' %}
 {% set name = application.personalDetails.name %}
-{% set title = "Check and update status of conditions" %}
+
+{% if hasNotMetConditions %}
+  {% set title = "Check status of conditions and withdraw offer" %}
+{% elseif allConditionsMet %}
+  {% set title = "Check status of conditions and mark conditions as met" %}
+{% else %}
+  {% set title = "Check and update status of conditions" %}
+{% endif %}
+
+
 
 {% block pageNavigation %}
   {{ govukBackLink({
@@ -38,30 +47,19 @@
         }
       })}}
 
-      {% if hasNotMetConditions %}
-        {{ govukWarningText({
-          text: "We’ll tell the candidate that their offer will be withdrawn because they have not met the conditions of the offer"
-        }) }}
-      {% elseif allConditionsMet %}
-        {{ govukWarningText({
-          text: "We’ll tell the candidate that they have met all of their conditions."
-        }) }}
-      {% else %}
-        {{ govukWarningText({
-          text: "We’ll tell the candidate the updated status of their conditions."
-        }) }}
-      {% endif %}
-
       <form method="post">
 
         {% if hasNotMetConditions %}
           {{ govukButton({
-            text: "Update conditions and withdraw offer",
-            classes: "govuk-button--warning"
+            text: "Withdraw offer and close application"
+          }) }}
+        {% elseif allConditionsMet %}
+          {{ govukButton({
+            text: "Mark conditions as met and tell candidate"
           }) }}
         {% else %}
           {{ govukButton({
-            text: "Update conditions"
+            text: "Update status and tell candidate"
           }) }}
         {% endif %}
       </form>

--- a/app/views/applications/offer/index.njk
+++ b/app/views/applications/offer/index.njk
@@ -28,39 +28,51 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      {{appOfferPanel({
-        withdrawx: {
-          href: "/applications/" + application.id + "/offer/withdraw"
-        } if application.status == "Offered" or application.status == "Accepted" or application.status == "Conditions met" or application.status == "Deferred",
-        defer: {
-          href: "/applications/" + application.id + "/offer/defer/check"
-        } if application.status == "Accepted" or application.status == "Conditions met",
-        provider: {
-          value: application.provider,
-          href: "/applications/"+application.id+"/offer/edit-provider" if application.status == "Offered"
-        },
-        course: {
-          value: application.course,
-          href: "/applications/"+application.id+"/offer/edit-course" if application.status == "Offered"
-        },
-        location: {
-          value: application.location,
-          href: "/applications/"+application.id+"/offer/edit-location" if application.status == "Offered"
-        },
+      <h2 class="govuk-heading-l govuk-!-margin-bottom govuk-!-font-size-36">Offer</h2>
 
-        changeConditions: {
-          href: "/applications/" + application.id + "/offer/edit-conditions"
-        } if application.status == "Offered",
+      <div class="app-temp-offer-wrapper">
+        {{appOfferPanel({
+          withdraw: {
+            href: "/applications/" + application.id + "/offer/withdraw"
+          } if application.status == "Offered" or application.status == "Accepted" or application.status == "Conditions met" or application.status == "Deferred",
+          defer: {
+            href: "/applications/" + application.id + "/offer/defer/check"
+          } if application.status == "Accepted" or application.status == "Conditions met",
+          provider: {
+            value: application.provider,
+            href: "/applications/"+application.id+"/offer/edit-provider" if application.status == "Offered"
+          },
+          course: {
+            value: application.course,
+            href: "/applications/"+application.id+"/offer/edit-course" if application.status == "Offered"
+          },
+          location: {
+            value: application.location,
+            href: "/applications/"+application.id+"/offer/edit-location" if application.status == "Offered"
+          },
 
-        changeStatus: {
-          href: "/applications/" + application.id + "/offer/edit-condition-statuses"
-        } if application.status == "Accepted",
+          changeConditions: {
+            href: "/applications/" + application.id + "/offer/edit-conditions"
+          } if application.status == "Offered",
 
-        conditions: {
-          items: conditions
-        }
-      })}}
+          changeStatus: {
+            href: "/applications/" + application.id + "/offer/edit-condition-statuses"
+          } if application.status == "Accepted",
 
+          conditions: {
+            items: conditions
+          }
+        })}}
+      </div>
+    </div>
+    <div class="govuk-grid-column-one-third">
+      {# <div class="app-box">
+        <h2 class="govuk-heading-m govuk-!-margin-bottom-2">Offer details</h2>
+        <p><a href="/applications/{{application.id}}/offer/withdraw">Withdraw offer</a></p>
+        <p><a href="/applications/{{application.id}}/offer/defer">Defer offer</a></p>
+        <h3 class="govuk-heading-s govuk-!-margin-bottom-1">Offer date</h3>
+        <p>{{application.offer.madeDate | govukDate}}</p>
+      </div> #}
     </div>
   </div>
 {% endblock %}

--- a/app/views/applications/offer/withdraw/check.njk
+++ b/app/views/applications/offer/withdraw/check.njk
@@ -4,9 +4,17 @@
 {% set name = application.personalDetails.name %}
 {% set title = "Check your feedback and withdraw offer" %}
 
+{% if data.rejectionReasons['other-offer'] == "Yes" or data.rejectionReasons['asked'] == "Yes" %}
+  {% set title = "Check your feedback and withdraw offer" %}
+  {% set buttonText = "Withdraw offer and close application" %}
+{% else %}
+  {% set title = "Check your feedback and withdraw offer" %}
+  {% set buttonText = "Withdraw offer and close application" %}
+{% endif %}
+
 {% block pageNavigation %}
   {{ govukBackLink({
-    href: "/applications/" + application.id + "/reject/other-reasons-for-rejection/"
+    href: "/applications/" + application.id + "/offer/withdraw/other-reasons-for-rejection/"
   }) }}
 {% endblock %}
 
@@ -21,11 +29,12 @@
       {% set rejectionReasons = data.rejectionReasons %}
       {% set rejectionChangeLinks = true %}
       {% set whyHeading = "Why the offer was withdrawn" %}
+      {% set baseUrl = "/applications/" + application.id + "/offer/withdraw" %}
       {% include "_includes/candidate-feedback.njk" %}
 
       <form method="post">
         {{ govukButton({
-          text: "Withdraw offer and close application"
+          text: buttonText
         }) }}
       </form>
       <p class="govuk-body"><a href="/applications/{{ application.id }}/offer">Cancel</a></p>

--- a/app/views/applications/offer/withdraw/check.njk
+++ b/app/views/applications/offer/withdraw/check.njk
@@ -20,11 +20,12 @@
 
       {% set rejectionReasons = data.rejectionReasons %}
       {% set rejectionChangeLinks = true %}
+      {% set whyHeading = "Why the offer was withdrawn" %}
       {% include "_includes/candidate-feedback.njk" %}
 
       <form method="post">
         {{ govukButton({
-          text: "Withdraw offer"
+          text: "Withdraw offer and close application"
         }) }}
       </form>
       <p class="govuk-body"><a href="/applications/{{ application.id }}/offer">Cancel</a></p>

--- a/app/views/applications/offer/withdraw/conditions.njk
+++ b/app/views/applications/offer/withdraw/conditions.njk
@@ -1,0 +1,29 @@
+{% extends "_layout.njk" %}
+
+{% set primaryNavId = 'applications' %}
+{% set name = application.personalDetails.name %}
+{% set title = "Conditions not met" %}
+
+{% block pageNavigation %}
+  {{ govukBackLink({
+    href: "/applications/" + application.id + "/reject"
+  }) }}
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <span class="govuk-caption-l">{{name}}</span>
+      <h1 class="govuk-heading-l">{{title}}</h1>
+
+      <p>You need to indicate the conditions which the candidate did not meet.</p>
+
+      {{ govukButton({
+        text: "Continue",
+        href: '/applications/'+application.id+'/offer/edit-condition-statuses'
+      }) }}
+
+      <p class="govuk-body"><a class="govuk-link--no-visited-state" href="/applications/{{ application.id }}">Cancel</a></p>
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/applications/offer/withdraw/index.njk
+++ b/app/views/applications/offer/withdraw/index.njk
@@ -18,15 +18,16 @@
       <p>When giving details or advice, bear in mind the candidate will see this feedback. </p>
 
       <form method="post">
-        {% include "_includes/reasons/asked.njk" %}
-        {% include "_includes/reasons/course-full.njk" %}
+        {% include "_includes/reasons/conditions.njk" %}
         {% include "_includes/reasons/actions.njk" %}
         {% include "_includes/reasons/application-quality.njk" %}
         {% include "_includes/reasons/missing-qualifications.njk" %}
         {% include "_includes/reasons/interview-performance.njk" %}
-        {% include "_includes/reasons/other-offer.njk" %}
         {% include "_includes/reasons/honesty.njk" %}
         {% include "_includes/reasons/safeguarding.njk" %}
+        {% include "_includes/reasons/other-offer.njk" %}
+        {% include "_includes/reasons/course-full.njk" %}
+        {% include "_includes/reasons/asked.njk" %}
         {{ govukButton({
           text: "Continue"
         }) }}

--- a/app/views/applications/offer/withdraw/index.njk
+++ b/app/views/applications/offer/withdraw/index.njk
@@ -15,7 +15,7 @@
     <div class="govuk-grid-column-two-thirds">
       <span class="govuk-caption-l">{{name}}</span>
       <h1 class="govuk-heading-l">{{title}}</h1>
-      <p>When giving details or advice, bear in mind the candidate will see this feedback. </p>
+      <p>This feedback will be sent to the candidate.</p>
 
       <form method="post">
         {% include "_includes/reasons/conditions.njk" %}

--- a/app/views/applications/offer/withdraw/other-reasons-for-rejection.njk
+++ b/app/views/applications/offer/withdraw/other-reasons-for-rejection.njk
@@ -15,7 +15,7 @@
     <div class="govuk-grid-column-two-thirds">
       <span class="govuk-caption-l">{{name}}</span>
       <h1 class="govuk-heading-l">{{title}}</h1>
-      <p>When giving details or advice, bear in mind the candidate will see this feedback. </p>
+      <p>This feedback will be sent to the candidate.</p>
 
       <form method="post">
         {% set whyLabel = "Why are you withdrawing your offer?" %}

--- a/app/views/applications/offer/withdraw/other-reasons-for-rejection.njk
+++ b/app/views/applications/offer/withdraw/other-reasons-for-rejection.njk
@@ -20,7 +20,17 @@
       <form method="post">
         {% set whyLabel = "Why are you withdrawing your offer?" %}
 
-        {% include "_includes/reject-form-fields-3.njk" %}
+        {% if noReasonsGivenYet %}
+          {% include "_includes/reasons/why.njk" %}
+        {% endif %}
+
+        {% if data.safeguarding != "Yes" %}
+          {% include "_includes/reasons/other-advice.njk" %}
+
+          {% if data['other-offer'] != "Yes" %}
+            {% include "_includes/reasons/future-applications.njk" %}
+          {% endif %}
+        {% endif %}
         {{ govukButton({
           text: "Continue"
         }) }}

--- a/app/views/applications/offer/withdraw/other-reasons-for-rejection.njk
+++ b/app/views/applications/offer/withdraw/other-reasons-for-rejection.njk
@@ -19,7 +19,6 @@
 
       <form method="post">
         {% set whyLabel = "Why are you withdrawing your offer?" %}
-
         {% if noReasonsGivenYet %}
           {% include "_includes/reasons/why.njk" %}
         {% endif %}

--- a/app/views/applications/reject/check.njk
+++ b/app/views/applications/reject/check.njk
@@ -2,7 +2,14 @@
 
 {% set primaryNavId = 'applications' %}
 {% set name = application.personalDetails.name %}
-{% set title = "Check your feedback and close application" %}
+
+{% if data.rejectionReasons['other-offer'] == "Yes" or data.rejectionReasons['asked'] == "Yes" %}
+  {% set title = "Check your feedback and withdraw application" %}
+  {% set buttonText = "Send feedback and withdraw application" %}
+{% else %}
+  {% set title = "Check your feedback and close application" %}
+  {% set buttonText = "Send feedback and close application" %}
+{% endif %}
 
 {% block pageNavigation %}
   {{ govukBackLink({
@@ -24,7 +31,7 @@
 
       <form method="post">
         {{ govukButton({
-          text: "Close application"
+          text: buttonText
         }) }}
       </form>
       <p class="govuk-body"><a class="govuk-link--no-visited-state" href="/applications/{{ application.id }}">Cancel</a></p>

--- a/app/views/applications/reject/index.njk
+++ b/app/views/applications/reject/index.njk
@@ -2,7 +2,7 @@
 
 {% set primaryNavId = 'applications' %}
 {% set name = application.personalDetails.name %}
-{% set title = "Reasons for closing this application" %}
+{% set title = "Reasons for rejecting or withdrawing this application" %}
 
 {% block pageNavigation %}
   {{ govukBackLink({

--- a/app/views/applications/reject/index.njk
+++ b/app/views/applications/reject/index.njk
@@ -3,7 +3,7 @@
 {% set primaryNavId = 'applications' %}
 {% set name = application.personalDetails.name %}
 
-{% set title = "Reasons for closing this application" %}
+{% set title = "Reasons for rejecting or withdrawing this application" %}
 
 {% block pageNavigation %}
   {{ govukBackLink({

--- a/app/views/applications/reject/index.njk
+++ b/app/views/applications/reject/index.njk
@@ -2,8 +2,12 @@
 
 {% set primaryNavId = 'applications' %}
 {% set name = application.personalDetails.name %}
-{% set title = "Reasons for rejecting or withdrawing this application" %}
 
+{% if application.status == "Awaiting decision "%}
+  {% set title = "Reasons for rejecting or withdrawing this application" %}
+{% else %}
+  {% set title = "Reasons for rejecting or withdrawing this application" %}
+{% endif %}
 {% block pageNavigation %}
   {{ govukBackLink({
     href: "/applications/" + application.id + "/decision"

--- a/app/views/applications/reject/index.njk
+++ b/app/views/applications/reject/index.njk
@@ -17,7 +17,7 @@
       <span class="govuk-caption-l">{{name}}</span>
       <h1 class="govuk-heading-l">{{title}}</h1>
 
-      <p>The candidate will be sent this feedback.</p>
+      <p>This feedback will be sent to the candidate.</p>
 
       <form method="post">
         {% include "_includes/reasons/conditions.njk" %}

--- a/app/views/applications/reject/index.njk
+++ b/app/views/applications/reject/index.njk
@@ -3,11 +3,8 @@
 {% set primaryNavId = 'applications' %}
 {% set name = application.personalDetails.name %}
 
-{% if application.status == "Awaiting decision "%}
-  {% set title = "Reasons for rejecting or withdrawing this application" %}
-{% else %}
-  {% set title = "Reasons for rejecting or withdrawing this application" %}
-{% endif %}
+{% set title = "Reasons for closing this application" %}
+
 {% block pageNavigation %}
   {{ govukBackLink({
     href: "/applications/" + application.id + "/decision"

--- a/app/views/applications/reject/other-reasons-for-rejection.njk
+++ b/app/views/applications/reject/other-reasons-for-rejection.njk
@@ -2,7 +2,7 @@
 
 {% set primaryNavId = 'applications' %}
 {% set name = application.personalDetails.name %}
-{% set title = "Other reasons for closing this application" %}
+{% set title = "Other reasons for rejecting or withdrawing this application" %}
 
 {% block pageNavigation %}
   {{ govukBackLink({

--- a/app/views/applications/reject/other-reasons-for-rejection.njk
+++ b/app/views/applications/reject/other-reasons-for-rejection.njk
@@ -2,7 +2,7 @@
 
 {% set primaryNavId = 'applications' %}
 {% set name = application.personalDetails.name %}
-{% set title = "Other reasons for rejecting or withdrawing this application" %}
+{% set title = "Other reasons for closing this application" %}
 
 {% block pageNavigation %}
   {{ govukBackLink({

--- a/app/views/applications/show.njk
+++ b/app/views/applications/show.njk
@@ -32,7 +32,7 @@
       <p>
         {# {% if application.status != "Rejected" and application.status != "Declined" and application.status != "Offer withdrawn" and application.status != "Application withdrawn" %} #}
         {% if application.status == "Awaiting decision" %}
-          <a class="govuk-!-margin-right-2" href="/applications/{{application.id}}/reject">Close application</a>
+          <a class="govuk-!-margin-right-2" href="/applications/{{application.id}}/reject">Reject or withdraw application</a>
         {% endif %}
         <a href="#" download>Download application (PDF)</a>
       </p>

--- a/app/views/applications/show.njk
+++ b/app/views/applications/show.njk
@@ -31,9 +31,9 @@
 
       <p>
         {# {% if application.status != "Rejected" and application.status != "Declined" and application.status != "Offer withdrawn" and application.status != "Application withdrawn" %} #}
-        {# {% if application.status == "Awaiting decision" %}
+        {% if application.status == "Awaiting decision" %}
           <a class="govuk-!-margin-right-2" href="/applications/{{application.id}}/reject">Close application</a>
-        {% endif %} #}
+        {% endif %}
         <a href="#" download>Download application (PDF)</a>
       </p>
 

--- a/app/views/applications/show.njk
+++ b/app/views/applications/show.njk
@@ -27,8 +27,16 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      {% include "_includes/applications/application-details.njk" %}
+      <h2 class="govuk-heading-l govuk-!-margin-bottom govuk-!-font-size-36">Application</h2>
 
+      <p>{% if application.status == "Awaiting decision" %}
+        <a href="/applications/{{application.id}}/reject">Reject or withdraw application</a>
+      {% else %}
+        <a href="/applications/{{application.id}}/reject">Withdraw application</a>
+      {% endif %}
+      <a class="govuk-!-margin-left-2" href="#" download>Download application (PDF)</a></p>
+
+      {% include "_includes/applications/application-details.njk" %}
 
       {% include "_includes/applications/rejection-details.njk" %}
       {% include "_includes/applications/personal-details.njk" %}
@@ -115,7 +123,7 @@
 
     </div>
     <div class="govuk-grid-column-one-third">
-
+      {# {% include "_includes/applications/application-details--sidebar.njk" %} #}
     </div>
   </div>
 

--- a/app/views/applications/show.njk
+++ b/app/views/applications/show.njk
@@ -29,10 +29,13 @@
 
       <h2 class="govuk-heading-l govuk-!-margin-bottom govuk-!-font-size-36">Application</h2>
 
-      <p>{% if application.status != "Rejected" and application.status != "Declined" and application.status != "Offer withdrawn" and application.status != "Application withdrawn" %}
-        <a class="govuk-!-margin-right-2" href="/applications/{{application.id}}/reject">Reject or withdraw application</a>
-      {% endif %}
-      <a href="#" download>Download application (PDF)</a></p>
+      <p>
+        {# {% if application.status != "Rejected" and application.status != "Declined" and application.status != "Offer withdrawn" and application.status != "Application withdrawn" %} #}
+        {% if application.status == "Awaiting decision" %}
+          <a class="govuk-!-margin-right-2" href="/applications/{{application.id}}/reject">Reject or withdraw application</a>
+        {% endif %}
+        <a href="#" download>Download application (PDF)</a>
+      </p>
 
       {% include "_includes/applications/application-details.njk" %}
 

--- a/app/views/applications/show.njk
+++ b/app/views/applications/show.njk
@@ -31,9 +31,9 @@
 
       <p>
         {# {% if application.status != "Rejected" and application.status != "Declined" and application.status != "Offer withdrawn" and application.status != "Application withdrawn" %} #}
-        {% if application.status == "Awaiting decision" %}
-          <a class="govuk-!-margin-right-2" href="/applications/{{application.id}}/reject">Reject or withdraw application</a>
-        {% endif %}
+        {# {% if application.status == "Awaiting decision" %}
+          <a class="govuk-!-margin-right-2" href="/applications/{{application.id}}/reject">Close application</a>
+        {% endif %} #}
         <a href="#" download>Download application (PDF)</a>
       </p>
 

--- a/app/views/applications/show.njk
+++ b/app/views/applications/show.njk
@@ -29,12 +29,10 @@
 
       <h2 class="govuk-heading-l govuk-!-margin-bottom govuk-!-font-size-36">Application</h2>
 
-      <p>{% if application.status == "Awaiting decision" %}
-        <a href="/applications/{{application.id}}/reject">Reject or withdraw application</a>
-      {% else %}
-        <a href="/applications/{{application.id}}/reject">Withdraw application</a>
+      <p>{% if application.status != "Rejected" and application.status != "Declined" and application.status != "Offer withdrawn" and application.status != "Application withdrawn" %}
+        <a class="govuk-!-margin-right-2" href="/applications/{{application.id}}/reject">Reject or withdraw application</a>
       {% endif %}
-      <a class="govuk-!-margin-left-2" href="#" download>Download application (PDF)</a></p>
+      <a href="#" download>Download application (PDF)</a></p>
 
       {% include "_includes/applications/application-details.njk" %}
 

--- a/app/views/applications/timeline/show.njk
+++ b/app/views/applications/timeline/show.njk
@@ -22,6 +22,8 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+
+      <h2 class="govuk-heading-l govuk-!-margin-bottom govuk-!-font-size-36">Timeline</h2>
       {{ appTimeline({items: timeline}) }}
     </div>
   </div>


### PR DESCRIPTION
Decision log:
- Retain ‘Close application’ as a decision because if it's withdraw or reject then the user can learn which structured reasons mean rejection and which mean withdrawal; and when the user answers ‘no’ to all structured questions, it’ll be impossible to know which status to apply
- Keep ‘Close application’ on the application details page for when candidates request withdrawal, for example. Having it within the ‘Make decision’ prompt lacks clarity.
- Withdrawing an offer is the only way to close an application when in the offered state.
- Withdrawing an offer or marking a condition as not met is the only way to close an application when in the accept state and conditions met state