### PR TITLE
Clear application search

### DIFF
--- a/app/views/_layout.njk
+++ b/app/views/_layout.njk
@@ -92,7 +92,7 @@
 {{ appPrimaryNavigation({
   items: [
     {
-      href: "/",
+      href: "/" + ('?keywords=' if data.keywords.length),
       text: "Applications",
       active: primaryNavId == 'applications'
     },


### PR DESCRIPTION
Fixes the issue where a user selects "Applications" from the main menu, after previously carrying out a search, and the search doesn't clear as expected.

https://trello.com/c/r0UtnmEr/3424-applications-list-clear-the-search-when-a-user-selects-applications-from-the-menu