### PR TITLE
Added 'set up interviews' to make decisions permission

### DIFF
--- a/app/views/_includes/permissions-checkboxes.njk
+++ b/app/views/_includes/permissions-checkboxes.njk
@@ -3,12 +3,12 @@
   name: "makedecisions",
   fieldset: {
     legend: {
-      text: "Who can make decisions?",
+      text: "Who can make decisions and set up interviews?",
       classes: "govuk-fieldset__legend--m"
     }
   },
   hint: {
-    text: "This allows an organisation to make offers, amend offers and rejection applications"
+    text: "This allows an organisation to make offers, amend offers and reject applications"
   },
   items: [
     {

--- a/app/views/account/organisational-permissions/show.njk
+++ b/app/views/account/organisational-permissions/show.njk
@@ -72,7 +72,7 @@
               {% if relationship.org.isAccreditedBody %}
                 <p>{{ relationship.partner.name }} has not set this up yet – contact them to change this.</p>
               {% else %}
-                <p class="govuk-!-margin-bottom-0">No users can make decisions, because you have not set this up yet.</p>
+                <p class="govuk-!-margin-bottom-0">No users can make decisions and set up interviews, because you have not set this up yet.</p>
               {% endif %}
             {% endif %}
           {% endset %}
@@ -138,7 +138,7 @@
                 },
                 {
                   key: {
-                    text: "Who can make decisions?"
+                    text: "Who can make decisions and set up interviews?"
                   },
                   value: {
                     html: makeDecisionsHtml

--- a/app/views/account/profile.njk
+++ b/app/views/account/profile.njk
@@ -32,7 +32,7 @@
   <p class="govuk-!-font-weight-bold">{{ appIcon({
         icon: "check",
         hidden: true
-      }) }} Make decisions</p>
+      }) }} Make decisions and set up interviews</p>
   <div class="govuk-!-margin-left-5">
     <p class="govuk-!-margin-bottom-1">Applies to courses run by:</p>
   <ul class="govuk-list">
@@ -84,7 +84,7 @@
     <p class="govuk-!-font-weight-bold">{{ appIcon({
           icon: "check",
           hidden: true
-        }) }} Make decisions</p>
+        }) }} Make decisions and set up interviews</p>
           <div class="govuk-!-margin-left-5">
       <p class="govuk-!-margin-bottom-1">Applies to courses ratified by:</p>
     <ul class="govuk-list">

--- a/app/views/account/users/change-organisations/check.njk
+++ b/app/views/account/users/change-organisations/check.njk
@@ -36,7 +36,7 @@
               classes: "govuk-!-margin-right-1",
               icon: "check",
               hidden: true
-            }) }} Make decisions</p>
+            }) }} Make decisions and set up interviews</p>
         <div class="govuk-!-margin-left-5">
          <p class="govuk-!-margin-bottom-1">Applies to courses ratified by:</p>
         <ul class="govuk-list">
@@ -119,7 +119,7 @@
               classes: "govuk-!-margin-right-1",
               icon: "check",
               hidden: true
-            }) }} Make decisions</p>
+            }) }} Make decisions and set up interviews</p>
              <div class="govuk-!-margin-left-5">
          <p class="govuk-!-margin-bottom-1">Applies to courses ratified by:</p>
         <ul class="govuk-list">

--- a/app/views/account/users/change-organisations/permissions1.njk
+++ b/app/views/account/users/change-organisations/permissions1.njk
@@ -118,7 +118,7 @@
               },
               {
                 value: "Make decisions",
-                html: "Make decisions",
+                html: "Make decisions and set up interviews",
                 label: {
                   classes: "govuk-label--s"
                 },

--- a/app/views/account/users/change-permissions.njk
+++ b/app/views/account/users/change-permissions.njk
@@ -181,7 +181,7 @@
                 },
                 {
                   value: "makeDecisions",
-                  html: "Make decisions",
+                  html: "Make decisions and set up interviews",
                   label: {
                     classes: "govuk-label--s"
                   },

--- a/app/views/account/users/new/check.njk
+++ b/app/views/account/users/new/check.njk
@@ -103,7 +103,7 @@
               {% if org.permissions.makeDecisions %}
                 <p class="govuk-!-font-weight-bold">
                   {{ appIcon({ icon: "check", hidden: true }) }}
-                  Make decisions
+                  Make decisions and set up interviews
                 </p>
 
                 {% if org.permissions.applicableOrgs.makeDecisions %}

--- a/app/views/account/users/new/index.njk
+++ b/app/views/account/users/new/index.njk
@@ -63,7 +63,7 @@
         }) }}
 
          {{ govukWarningText({
-        text: "Anyone you invite to your organisation will be able to view all applications to courses you look after. They'll be able to make decisions about applications and view sensitive information, if you give them permission.",
+        text: "Anyone you invite to your organisation will be able to view all applications to courses you look after. They'll be able to make decisions about applications, set up interviews and view sensitive information if you give them permission.",
         iconFallbackText: "Fallback text"
       }) }}
 

--- a/app/views/account/users/new/index.njk
+++ b/app/views/account/users/new/index.njk
@@ -63,7 +63,7 @@
         }) }}
 
          {{ govukWarningText({
-        text: "Anyone you invite to your organisation will be able to view all applications to courses you look after. They'll be able to make decisions about applications, set up interviews and view sensitive information if you give them permission.",
+        text: "Anyone you invite to your organisation will be able to view all applications to courses you look after. They’ll be able to make decisions about applications, set up interviews and view sensitive information if you give them permission.",
         iconFallbackText: "Fallback text"
       }) }}
 

--- a/app/views/account/users/new/permissions.njk
+++ b/app/views/account/users/new/permissions.njk
@@ -178,7 +178,7 @@
                 },
                 {
                   value: "makeDecisions",
-                  html: "Make decisions",
+                  html: "Make decisions and set up interviews",
                   label: {
                     classes: "govuk-label--s"
                   },

--- a/app/views/account/users/show.njk
+++ b/app/views/account/users/show.njk
@@ -119,7 +119,7 @@
               {% if org.permissions.makeDecisions %}
                 <p class="govuk-!-font-weight-bold">
                   {{ appIcon({ icon: "check", hidden: true }) }}
-                  Make decisions
+                  Make decisions and set up interviews
                 </p>
 
                 {% if org.permissions.applicableOrgs.makeDecisions %}

--- a/app/views/onboard/check.njk
+++ b/app/views/onboard/check.njk
@@ -73,7 +73,7 @@
           },
           {
             key: {
-              text: "Who can make decisions?"
+              text: "Who can make decisions and set up interviews?"
             },
             value: {
               html: makeDecisionsHtml

--- a/app/views/onboard/index.njk
+++ b/app/views/onboard/index.njk
@@ -36,7 +36,7 @@
         <p>You need to set permissions at an organisational level for your own organisations and your accredited bodies. Choose who can:</p>
 
         <ul class="govuk-list govuk-list--bullet">
-          <li>make decisions about applications</li>
+          <li>make decisions about applications and set up interviews</li>
           <li>access sensitive candidate information</li>
         </ul>
 


### PR DESCRIPTION
I've updated the 'Make decisions' permission to 'Make decisions and set up interviews' throughout.

I also fixed a typo in app/views/_includes/permissions-checkboxes.njk, which isn't in production.