### PR TITLE
Fix missing macro errors

### DIFF
--- a/app/views/_layout-register.njk
+++ b/app/views/_layout-register.njk
@@ -30,26 +30,9 @@
 {% from "govuk/components/textarea/macro.njk"                 import govukTextarea %}
 {% from "govuk/components/warning-text/macro.njk"             import govukWarningText %}
 
-{% from "_components/autocomplete/macro.njk"                  import appAutocomplete %}
-{% from "_components/banner/macro.njk"                        import appBanner %}
-{% from "_components/card-list/macro.njk"                     import appCardList %}
 {% from "_components/cookie-banner/macro.njk"                 import appCookieBanner %}
-{% from "_components/filter/macro.njk"                        import appFilter %}
 {% from "_components/footer/macro.njk"                        import appFooter %}
-{% from "_components/icon/macro.njk"                          import appIcon %}
-{% from "_components/log-card/macro.njk"                      import appLogCard %}
-{% from "_components/notification-card/macro.njk"             import appNotificationCard %}
-{% from "_components/offer-panel/macro.njk"                   import appOfferPanel %}
-{% from "_components/pagination/macro.njk"                    import appPagination %}
-{% from "_components/previous-next-navigation/macro.njk"      import appPreviousNextNavigation %}
-{% from "_components/primary-navigation/macro.njk"            import appPrimaryNavigation %}
-{% from "_components/search/macro.njk"                        import appSearch %}
-{% from "_components/sub-navigation/macro.njk"                import appSubNavigation %}
-{% from "_components/summary-card/macro.njk"                  import appSummaryCard %}
 {% from "_components/task-list/macro.njk"                     import appTaskList %}
-{% from "_components/timeline/macro.njk"                      import appTimeline %}
-{% from "_components/interview-card/macro.njk"                import appInterviewCard %}
-{% from "_components/no-information-shared/macro.njk"         import appNoInformationShared %}
 
 {% block head %}
   {% include "_includes/head.njk" %}


### PR DESCRIPTION
Remove unnecessary macros from the `_layout-register.njk` file.