### PR TITLE
Remove usage data check

### DIFF
--- a/start.js
+++ b/start.js
@@ -4,36 +4,38 @@ const fs = require('fs')
 
 checkFiles()
 
-// Local dependencies
-const usageData = require('./lib/usage_data')
+// // Local dependencies
+// const usageData = require('./lib/usage_data')
+//
+// // Get usageDataConfig from file, if exists
+// const usageDataConfig = usageData.getUsageDataConfig()
+//
+// if (usageDataConfig.collectUsageData === undefined) {
+//   // No recorded answer, so ask for permission
+//   const promptPromise = usageData.askForUsageDataPermission()
+//   promptPromise.then(function (answer) {
+//     if (answer === 'yes') {
+//       usageDataConfig.collectUsageData = true
+//       usageData.setUsageDataConfig(usageDataConfig)
+//       usageData.startTracking(usageDataConfig)
+//     } else if (answer === 'no') {
+//       usageDataConfig.collectUsageData = false
+//       usageData.setUsageDataConfig(usageDataConfig)
+//     } else {
+//       console.error(answer)
+//     }
+//     runGulp()
+//   })
+// } else if (usageDataConfig.collectUsageData === true) {
+//   // Opted in
+//   usageData.startTracking(usageDataConfig)
+//   runGulp()
+// } else {
+//   // Opted out
+//   runGulp()
+// }
 
-// Get usageDataConfig from file, if exists
-const usageDataConfig = usageData.getUsageDataConfig()
-
-if (usageDataConfig.collectUsageData === undefined) {
-  // No recorded answer, so ask for permission
-  const promptPromise = usageData.askForUsageDataPermission()
-  promptPromise.then(function (answer) {
-    if (answer === 'yes') {
-      usageDataConfig.collectUsageData = true
-      usageData.setUsageDataConfig(usageDataConfig)
-      usageData.startTracking(usageDataConfig)
-    } else if (answer === 'no') {
-      usageDataConfig.collectUsageData = false
-      usageData.setUsageDataConfig(usageDataConfig)
-    } else {
-      console.error(answer)
-    }
-    runGulp()
-  })
-} else if (usageDataConfig.collectUsageData === true) {
-  // Opted in
-  usageData.startTracking(usageDataConfig)
-  runGulp()
-} else {
-  // Opted out
-  runGulp()
-}
+runGulp()
 
 // Warn if node_modules folder doesn't exist
 function checkFiles () {


### PR DESCRIPTION
The check creates an error on Heroku:

```
Latest build failed
Could not create review app. Postdeploy execution timed out.
```

We don't need the check, even though it's nice for the GOV.UK Design System team to know prototype kit usage.