### PR TITLE
Only show activity from today and older

### DIFF
--- a/app/routes/activity-log.js
+++ b/app/routes/activity-log.js
@@ -78,6 +78,13 @@ module.exports = router => {
     // Get the activity
     let activity = getActivity(apps)
 
+    activity = activity.filter(item => {
+      itemDate = DateTime.fromISO(item.event.date)
+      return itemDate.startOf('day') <= DateTime.now().startOf('day')
+    })
+
+    console.log(activity);
+
     // Get the pagination data
     let pagination = PaginationHelper.getPagination(activity, req.query.page, req.query.limit)
 

--- a/app/routes/activity-log.js
+++ b/app/routes/activity-log.js
@@ -80,7 +80,7 @@ module.exports = router => {
 
     activity = activity.filter(item => {
       const itemDate = DateTime.fromISO(item.event.date)
-      return itemDate.startOf('day') <= DateTime.now().startOf('day')
+      return itemDate <= DateTime.now()
     })
 
     // Get the pagination data

--- a/app/routes/activity-log.js
+++ b/app/routes/activity-log.js
@@ -79,11 +79,9 @@ module.exports = router => {
     let activity = getActivity(apps)
 
     activity = activity.filter(item => {
-      itemDate = DateTime.fromISO(item.event.date)
+      const itemDate = DateTime.fromISO(item.event.date)
       return itemDate.startOf('day') <= DateTime.now().startOf('day')
     })
-
-    console.log(activity);
 
     // Get the pagination data
     let pagination = PaginationHelper.getPagination(activity, req.query.page, req.query.limit)


### PR DESCRIPTION
The activity log shows events in the future. This simple fix filters out all future events, so that the activity log only shows historical items.

This is an interim fix whilst we work on correcting the event data.