### PR TITLE
Fixed routing for data exports

### DIFF
--- a/app/routes/data.js
+++ b/app/routes/data.js
@@ -219,14 +219,14 @@ module.exports = router => {
     })
   })
 
-  router.get('/reports/:organisationId/export', (req, res) => {
+  router.get('/reports/export', (req, res) => {
     const organisation = req.session.data.user.organisations.find(org => org.id === req.params.organisationId)
     res.render('data/export/index', {
       organisation
     })
   })
 
-  router.get('/reports/:organisationId/hesa', (req, res) => {
+  router.get('/reports/hesa', (req, res) => {
     const organisation = req.session.data.user.organisations.find(org => org.id === req.params.organisationId)
     res.render('data/export/hesa', {
       organisation

--- a/app/views/data/index.njk
+++ b/app/views/data/index.njk
@@ -15,13 +15,13 @@
 
       <ul class="govuk-list govuk-list--spaced">
         <li>
-          <a class="govuk-link" href="/reports/{{ organisation.id }}/export">
-            Export application data <span class="govuk-visually-hidden">for {{ organisation.name }}</span>
+          <a class="govuk-link" href="/reports/export">
+            Export application data
           </a>
         </li>
         <li>
-          <a class="govuk-link" href="/reports/{{ organisation.id }}/hesa">
-            Export data for Higher Education Statistics Agency (HESA) <span class="govuk-visually-hidden">for {{ organisation.name }}</span>
+          <a class="govuk-link" href="/reports/hesa">
+            Export data for Higher Education Statistics Agency (HESA)
           </a>
         </li>
         <li>
@@ -40,13 +40,13 @@
 
       <ul class="govuk-list govuk-list--spaced">
         <li>
-          <a class="govuk-link" href="/reports/{{ organisation.id }}/export">
-            Export application data <span class="govuk-visually-hidden">for {{ organisation.name }}</span>
+          <a class="govuk-link" href="/reports/export">
+            Export application data
           </a>
         </li>
         <li>
-          <a class="govuk-link" href="/reports/{{ organisation.id }}/hesa">
-            Export data for Higher Education Statistics Agency (HESA) <span class="govuk-visually-hidden">for {{ organisation.name }}</span>
+          <a class="govuk-link" href="/reports/hesa">
+            Export data for Higher Education Statistics Agency (HESA)
           </a>
         </li>
       </ul>


### PR DESCRIPTION
The links to the general and HESA exports included the organisation ID, but that isn't necessary as those exports are cross-organisation. I removed the organisation ID and amended the routing accordingly.