### PR TITLE
Rollback Sass version to fix deprecation warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "portscanner": "^2.1.1",
     "prompt": "^1.1.0",
     "require-dir": "^1.0.0",
-    "sass": "^1.35.2",
+    "sass": "~1.32.13",
     "sync-request": "^6.1.0",
     "universal-analytics": "^0.4.16",
     "uuid": "^8.3.2",


### PR DESCRIPTION
There are a number of deprecation warnings related to dependencies such as `govuk-frontend` and caused by using the latest version of Sass. For example:

```
DEPRECATION WARNING: Using / for division is deprecated and will be removed in Dart Sass 2.0.0.
```

Rollback Sass version from `1.35.2` to `1.32.13` and wait until `govuk-frontend` updates their Sass.

Use the tilde `~` to only patch the version.