### PR TITLE
Fix missing or incomplete sections in qualifications

### DIFF
--- a/app/views/_includes/applications/degrees.njk
+++ b/app/views/_includes/applications/degrees.njk
@@ -94,10 +94,18 @@
       {% if item.naric %}
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key">
-            Comparability
+            UK ENIC reference number
           </dt>
           <dd class="govuk-summary-list__value">
-            UK ENIC or NARIC statement #{{ item.naric.reference }} says this is comparable to a {{ item.naric.comparable }}.
+            {{ item.naric.reference }}
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Comparable UK qualification
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {{ item.naric.comparable }}
           </dd>
         </div>
       {% else %}

--- a/app/views/_includes/applications/degrees.njk
+++ b/app/views/_includes/applications/degrees.njk
@@ -109,14 +109,16 @@
           </dd>
         </div>
       {% else %}
-        <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key">
-            Do you have a UK ENIC statement of comparability?
-          </dt>
-          <dd class="govuk-summary-list__value">
-            No
-          </dd>
-        </div>
+        {% if application.personalDetails.isInternationalCandidate %}
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+              Do you have a UK ENIC statement of comparability?
+            </dt>
+            <dd class="govuk-summary-list__value">
+              No
+            </dd>
+          </div>
+        {% endif %}
       {% endif %}
 
     </dl>

--- a/app/views/_includes/applications/degrees.njk
+++ b/app/views/_includes/applications/degrees.njk
@@ -42,6 +42,17 @@
         </dd>
       </div>
 
+      {% if item.predicted %}
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Have you completed this degree?
+        </dt>
+        <dd class="govuk-summary-list__value">
+          No
+        </dd>
+      </div>
+      {% endif %}
+
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">
           {{ 'Predicted grade' if item.predicted else 'Grade' }}
@@ -87,6 +98,15 @@
           </dt>
           <dd class="govuk-summary-list__value">
             UK ENIC or NARIC statement #{{ item.naric.reference }} says this is comparable to a {{ item.naric.comparable }}.
+          </dd>
+        </div>
+      {% else %}
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Do you have a UK ENIC statement of comparability?
+          </dt>
+          <dd class="govuk-summary-list__value">
+            No
           </dd>
         </div>
       {% endif %}

--- a/app/views/_includes/applications/degrees.njk
+++ b/app/views/_includes/applications/degrees.njk
@@ -54,7 +54,7 @@
       {% if item.country != "United Kingdom" %}
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key">
-            Country
+            Country or territory
           </dt>
           <dd class="govuk-summary-list__value">
             {{ item.country }}

--- a/app/views/_includes/applications/gcses.njk
+++ b/app/views/_includes/applications/gcses.njk
@@ -59,10 +59,18 @@
           {% if item.naric %}
             <div class="govuk-summary-list__row">
               <dt class="govuk-summary-list__key">
-                Comparability
+                UK ENIC reference number
               </dt>
               <dd class="govuk-summary-list__value">
-                UK ENIC or NARIC statement #{{ item.naric.reference }} says this is comparable to a {{ item.naric.comparable }}.
+                {{ item.naric.reference }}
+              </dd>
+            </div>
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Comparable UK qualification
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {{ item.naric.comparable }}
               </dd>
             </div>
           {% else %}

--- a/app/views/_includes/applications/gcses.njk
+++ b/app/views/_includes/applications/gcses.njk
@@ -30,7 +30,7 @@
           {% if item.country != "United Kingdom" %}
             <div class="govuk-summary-list__row">
               <dt class="govuk-summary-list__key">
-                Country
+                Country or territory
               </dt>
               <dd class="govuk-summary-list__value">
                 {{ item.country }}

--- a/app/views/_includes/applications/gcses.njk
+++ b/app/views/_includes/applications/gcses.njk
@@ -74,14 +74,16 @@
               </dd>
             </div>
           {% else %}
-            <div class="govuk-summary-list__row">
-              <dt class="govuk-summary-list__key">
-                Do you have a UK ENIC statement of comparability?
-              </dt>
-              <dd class="govuk-summary-list__value">
-                No
-              </dd>
-            </div>
+            {% if application.personalDetails.isInternationalCandidate %}
+              <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                  Do you have a UK ENIC statement of comparability?
+                </dt>
+                <dd class="govuk-summary-list__value">
+                  No
+                </dd>
+              </div>
+            {% endif %}
           {% endif %}
 
         {% else %}

--- a/app/views/_includes/applications/gcses.njk
+++ b/app/views/_includes/applications/gcses.njk
@@ -65,6 +65,15 @@
                 UK ENIC or NARIC statement #{{ item.naric.reference }} says this is comparable to a {{ item.naric.comparable }}.
               </dd>
             </div>
+          {% else %}
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Do you have a UK ENIC statement of comparability?
+              </dt>
+              <dd class="govuk-summary-list__value">
+                No
+              </dd>
+            </div>
           {% endif %}
 
         {% else %}

--- a/app/views/_includes/applications/other-qualifications.njk
+++ b/app/views/_includes/applications/other-qualifications.njk
@@ -43,7 +43,7 @@
     }, {
       text: "Subject"
     }, {
-      text: "Country"
+      text: "Country or territory"
     } if hasOtherNonUkQualifications, {
       text: "Year awarded"
     }, {

--- a/scripts/generate-applications.js
+++ b/scripts/generate-applications.js
@@ -1729,7 +1729,7 @@ const generateFakeApplications = () => {
         hasQualification: 'No',
         subject: 'English',
         missing: {
-          hasQualification: 'I don’t have an english qualification yet',
+          hasQualification: 'I don’t have an English qualification yet',
           isStudying: 'No',
           otherReason: 'I applied to NARIC for the equivalent'
         }
@@ -1920,7 +1920,7 @@ const generateFakeApplications = () => {
         hasQualification: 'No',
         subject: 'English',
         missing: {
-          hasQualification: 'I don’t have an english qualification yet',
+          hasQualification: 'I don’t have an English qualification yet',
           isStudying: 'No',
           otherReason: 'I applied to NARIC for the equivalent'
         }


### PR DESCRIPTION
Changes made:

- Rename "Country" to "Country and territory" in degree, GCSE and other qualifications
- Add "Have you completed this degree?" to the degree section and display if the answer is no
- Split the "comparability" line in the degree and GCSE sections into separate lines, one for "UK ENIC reference number" and  another for "Comparable UK qualification"
- Handle missing ENIC number in the degree and GCSE sections: display "Do you have a UK ENIC statement of comparability?" if the answer is no.