### PR TITLE
Fixes to change course

### DIFF
--- a/app/data/generators/events.js
+++ b/app/data/generators/events.js
@@ -21,7 +21,8 @@ module.exports = (params) => {
         location: params.location,
         studyMode: params.studyMode,
         accreditedBody: params.accreditedBody,
-        fundingType: params.fundingType
+        fundingType: params.fundingType,
+        qualifications: params.qualifications
       }
     }
   })
@@ -164,6 +165,7 @@ module.exports = (params) => {
           studyMode: params.studyMode,
           accreditedBody: params.accreditedBody,
           fundingType: params.fundingType,
+          qualifications: params.qualifications,
           conditions
         }
       }
@@ -185,6 +187,7 @@ module.exports = (params) => {
           studyMode: params.studyMode,
           accreditedBody: params.accreditedBody,
           fundingType: params.fundingType,
+          qualifications: params.qualifications,
           conditions
         }
       }
@@ -206,6 +209,7 @@ module.exports = (params) => {
           studyMode: params.studyMode,
           accreditedBody: params.accreditedBody,
           fundingType: params.fundingType,
+          qualifications: params.qualifications,
           conditions
         }
       }
@@ -225,6 +229,7 @@ module.exports = (params) => {
           studyMode: params.studyMode,
           accreditedBody: params.accreditedBody,
           fundingType: params.fundingType,
+          qualifications: params.qualifications,
           conditions
         }
       }
@@ -246,6 +251,7 @@ module.exports = (params) => {
             studyMode: params.studyMode,
             accreditedBody: params.accreditedBody,
             fundingType: params.fundingType,
+            qualifications: params.qualifications,
             conditions
           }
         }
@@ -263,6 +269,7 @@ module.exports = (params) => {
             studyMode: params.studyMode,
             accreditedBody: params.accreditedBody,
             fundingType: params.fundingType,
+            qualifications: params.qualifications,
             conditions
           }
         }
@@ -281,6 +288,7 @@ module.exports = (params) => {
             studyMode: params.studyMode,
             accreditedBody: params.accreditedBody,
             fundingType: params.fundingType,
+            qualifications: params.qualifications,
           }
         }
       })
@@ -304,6 +312,7 @@ module.exports = (params) => {
           studyMode: params.studyMode,
           accreditedBody: params.accreditedBody,
           fundingType: params.fundingType,
+          qualifications: params.qualifications,
           conditions
         }
       }
@@ -325,6 +334,7 @@ module.exports = (params) => {
           studyMode: params.studyMode,
           accreditedBody: params.accreditedBody,
           fundingType: params.fundingType,
+          qualifications: params.qualifications,
           conditions
         }
       }

--- a/app/data/generators/offer.js
+++ b/app/data/generators/offer.js
@@ -60,6 +60,7 @@ module.exports = (params) => {
     studyMode: params.studyMode,
     accreditedBody: params.accreditedBody,
     fundingType: params.fundingType,
+    qualifications: params.qualifications,
     madeDate,
     acceptedDate,
     standardConditions,

--- a/app/filters.js
+++ b/app/filters.js
@@ -395,5 +395,23 @@ filters.falsify = (input) => {
     return html
   }
 
+  /* ------------------------------------------------------------------
+  utility function to and array into a list
+  example: {{ ['PGCE','QTS'] | arrayToList(', ',' with ') }}
+  output: "PGCE with QTS"
+  ------------------------------------------------------------------ */
+
+  filters.arrayToList = (array, join = ', ', final = ' and ') => {
+    const arr = array.slice(0)
+
+    const last = arr.pop()
+
+    if (array.length > 1) {
+      return arr.join(join) + final + last
+    }
+
+    return last
+  }
+
   return filters
 }

--- a/app/routes.js
+++ b/app/routes.js
@@ -37,4 +37,7 @@ require('./routes/users')(router)
 require('./routes/withdraw-application')(router)
 require('./routes/withdraw-offer')(router)
 
+// examples
+require('./routes/examples')(router)
+
 module.exports = router

--- a/app/routes/edit-course.js
+++ b/app/routes/edit-course.js
@@ -85,7 +85,7 @@ module.exports = router => {
     } else if (req.session.data.course.locations.length > 1) {
       res.redirect(`/applications/${req.params.applicationId}/course/edit/location?referrer=study-mode`)
     } else {
-      req.session.data['edit-course'].location = req.session.data.course.locations[0]
+      req.session.data['edit-course'].location = req.session.data.course.locations[0].id
       res.redirect(`/applications/${req.params.applicationId}/course/edit/check?referrer=study-mode`)
     }
   })

--- a/app/routes/edit-course.js
+++ b/app/routes/edit-course.js
@@ -192,7 +192,8 @@ module.exports = router => {
       application.course = course.name + ' (' + course.code + ')'
       application.courseCode = course.code
       application.accreditedBody = course.accreditedBody.name
-      application.fundingType = course.fundingType
+      application.fundingType = course.fundingType,
+      application.qualifications = course.qualifications
     }
 
     if (req.session.data['edit-course'].studyMode) {
@@ -215,7 +216,8 @@ module.exports = router => {
           studyMode: application.studyMode,
           location: application.location,
           accreditedBody: application.accreditedBody,
-          fundingType: application.fundingType
+          fundingType: application.fundingType,
+          qualifications: application.qualifications
         }
       }
     })

--- a/app/routes/edit-offer.js
+++ b/app/routes/edit-offer.js
@@ -304,6 +304,7 @@ module.exports = router => {
       application.offer.provider = course.trainingProvider.name
       application.offer.accreditedBody = course.accreditedBody.name
       application.offer.fundingType = course.fundingType
+      application.offer.qualifications = course.qualifications
     }
 
     application.offer.studyMode = req.session.data['edit-offer'].studyMode || application.offer.studyMode
@@ -352,6 +353,7 @@ module.exports = router => {
           studyMode: application.offer.studyMode,
           accreditedBody: application.offer.accreditedBody,
           fundingType: application.offer.fundingType,
+          qualifications: application.offer.qualifications,
           conditions: ApplicationHelper.getConditions(application.offer)
         }
       }

--- a/app/routes/edit-offer.js
+++ b/app/routes/edit-offer.js
@@ -109,7 +109,7 @@ module.exports = router => {
     } else if (req.session.data.course.locations.length > 1) {
       res.redirect(`/applications/${req.params.applicationId}/offer/edit/location?referrer=study-mode`)
     } else {
-      req.session.data['edit-offer'].location = req.session.data.course.locations[0]
+      req.session.data['edit-offer'].location = req.session.data.course.locations[0].id
       res.redirect(`/applications/${req.params.applicationId}/offer/edit/check?referrer=study-mode`)
     }
   })

--- a/app/routes/examples.js
+++ b/app/routes/examples.js
@@ -1,0 +1,26 @@
+module.exports = router => {
+  router.get('/examples/courses', (req, res) => {
+    const courses = require('../data/courses')
+    res.render('_examples/courses/index', {
+      courses
+    })
+  })
+
+  router.get('/examples/qualifications/degrees', (req, res) => {
+    res.render('_examples/qualifications/degree', {
+
+    })
+  })
+
+  router.get('/examples/qualifications/english', (req, res) => {
+    res.render('_examples/qualifications/english', {
+
+    })
+  })
+
+  router.get('/examples/qualifications/gcse', (req, res) => {
+    res.render('_examples/qualifications/gcse', {
+
+    })
+  })
+}

--- a/app/routes/examples.js
+++ b/app/routes/examples.js
@@ -1,8 +1,21 @@
 module.exports = router => {
+
+  router.get('/examples', (req, res) => {
+    res.render('_examples/index', {
+
+    })
+  })
+
   router.get('/examples/courses', (req, res) => {
     const courses = require('../data/courses')
     res.render('_examples/courses/index', {
       courses
+    })
+  })
+
+  router.get('/examples/qualifications', (req, res) => {
+    res.render('_examples/qualifications/index', {
+
     })
   })
 

--- a/app/routes/make-offer.js
+++ b/app/routes/make-offer.js
@@ -125,7 +125,8 @@ module.exports = router => {
       location: CourseHelper.getCourseLocation(req.session.data['new-offer'].location) || application.location,
       studyMode: req.session.data['new-offer'].studyMode || application.studyMode,
       accreditedBody: course.accreditedBody.name,
-      fundingType: course.fundingType
+      fundingType: course.fundingType,
+      qualifications: course.qualifications
     }
 
     application.offer.declineByDate = ApplicationHelper.calculateDeclineDate(application)
@@ -173,6 +174,7 @@ module.exports = router => {
           studyMode: application.offer.studyMode,
           accreditedBody: application.offer.accreditedBody,
           fundingType: application.offer.fundingType,
+          qualifications: application.offer.qualifications,
           conditions: ApplicationHelper.getConditions(application.offer)
         }
       }
@@ -372,6 +374,7 @@ module.exports = router => {
     delete req.session.data['new-offer'].location
     delete req.session.data['new-offer'].accreditedBody
     delete req.session.data['new-offer'].fundingType
+    delete req.session.data['new-offer'].qualifications
 
     delete req.session.data.flow
 

--- a/app/routes/make-offer.js
+++ b/app/routes/make-offer.js
@@ -292,7 +292,7 @@ module.exports = router => {
     } else if (req.session.data.course.locations.length > 1) {
       res.redirect(`/applications/${req.params.applicationId}/offer/new/location?referrer=study-mode`)
     } else {
-      req.session.data['new-offer'].location = req.session.data.course.locations[0]
+      req.session.data['new-offer'].location = req.session.data.course.locations[0].id
       res.redirect(`/applications/${req.params.applicationId}/offer/new/check?referrer=study-mode`)
     }
   })

--- a/app/views/_components/event-application/template.njk
+++ b/app/views/_components/event-application/template.njk
@@ -45,6 +45,14 @@
     },
     {
       key: {
+        text: "Qualification"
+      },
+      value: {
+        text: params.application.qualifications | arrayToList(', ',' with ')
+      }
+    },
+    {
+      key: {
         text: "Funding type"
       },
       value: {

--- a/app/views/_components/event-offer/template.njk
+++ b/app/views/_components/event-offer/template.njk
@@ -59,6 +59,22 @@
     },
     {
       key: {
+        text: "Qualification"
+      },
+      value: {
+        text: params.offer.qualifications | arrayToList(', ',' with ')
+      }
+    },
+    {
+      key: {
+        text: "Funding type"
+      },
+      value: {
+        text: params.offer.fundingType
+      }
+    },
+    {
+      key: {
         text: "Conditions"
       },
       value: {

--- a/app/views/_components/offer-panel/template.njk
+++ b/app/views/_components/offer-panel/template.njk
@@ -104,6 +104,22 @@
         } if params.accreditedBody.href
       } if params.accreditedBody.value != params.provider.value, {
         key: {
+          text: "Qualification"
+        },
+        value: {
+          html: params.qualifications.value
+        },
+        actions: {
+          items: [
+            {
+              href: params.qualifications.href or "#",
+              text: "Change",
+              visuallyHiddenText: "qualification"
+            }
+          ]
+        } if params.qualifications.href
+      }, {
+        key: {
           text: "Funding type"
         },
         value: {

--- a/app/views/_examples/courses/index.njk
+++ b/app/views/_examples/courses/index.njk
@@ -4,6 +4,13 @@
 
 {% set title = "Courses (" + courses.length + ")"  %}
 
+{% block beforeContent %}
+{{ govukBackLink({
+  text: "Back",
+  href: "/examples"
+}) }}
+{% endblock %}
+
 {% block content %}
 
 <div class="govuk-grid-row">

--- a/app/views/_examples/courses/index.njk
+++ b/app/views/_examples/courses/index.njk
@@ -1,0 +1,91 @@
+{% extends "_layout.njk" %}
+
+{% set primaryNavId = "examples" %}
+
+{% set title = "Courses (" + courses.length + ")"  %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+  <h2 class="govuk-heading-l">
+    {{ title }}
+  </h2>
+
+  {% for course in courses %}
+
+    {% set locationHtml %}
+      {% for location in course.locations %}
+        {{ appLocation(location) }}
+        {% if not loop.last %}
+          <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+        {% endif %}
+      {% endfor %}
+    {% endset %}
+
+    {{ appSummaryCard({
+      classes: "govuk-!-margin-bottom-5",
+      titleHtml: course.name + " (" + course.code + ")",
+      html: govukSummaryList({
+        classes: "govuk-!-margin-bottom-0",
+        rows: [{
+          key: {
+            text: "Training provider"
+          },
+          value: {
+            html: course.trainingProvider.name
+          }
+        }, {
+          key: {
+            text: "Course"
+          },
+          value: {
+            html: course.name + " (" + course.code + ")"
+          }
+        }, {
+          key: {
+            text: "Full time or part time"
+          },
+          value: {
+            html: course.studyModes | arrayToList(', ',' or ')
+          }
+        }, {
+          key: {
+            text: "Location" + ("s" if course.locations.length > 1)
+          },
+          value: {
+            html: locationHtml
+          }
+        }, {
+          key: {
+            text: "Accredited body"
+          },
+          value: {
+            html: course.accreditedBody.name
+          }
+        }, {
+          key: {
+            text: "Qualification"
+          },
+          value: {
+            html: course.qualifications | arrayToList(', ',' with ')
+          }
+        }, {
+          key: {
+            text: "Funding type"
+          },
+          value: {
+            html: course.fundingType
+          }
+        }]
+      })
+    }) }}
+
+  {% endfor %}
+
+
+
+  </div>
+</div>
+{% endblock %}

--- a/app/views/_examples/courses/index.njk
+++ b/app/views/_examples/courses/index.njk
@@ -84,8 +84,6 @@
 
   {% endfor %}
 
-
-
   </div>
 </div>
 {% endblock %}

--- a/app/views/_examples/index.njk
+++ b/app/views/_examples/index.njk
@@ -2,7 +2,7 @@
 
 {% set primaryNavId = "examples" %}
 
-{% set title = "Example" %}
+{% set title = "Examples" %}
 
 {% block content %}
 

--- a/app/views/_examples/index.njk
+++ b/app/views/_examples/index.njk
@@ -1,0 +1,45 @@
+{% extends "_layout.njk" %}
+
+{% set primaryNavId = "examples" %}
+
+{% set title = "Example" %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+  <h1 class="govuk-heading-l">
+    {{ title }}
+  </h1>
+
+  <h2 class="govuk-heading-m">
+    Courses
+  </h2>
+
+  <ul class="govuk-list">
+    <li>
+      <a class="govuk-link" href="/examples/courses">Courses</a>
+    </li>
+    </li>
+  </ul>
+
+  <h2 class="govuk-heading-m">
+    Qualifications
+  </h2>
+
+  <ul class="govuk-list">
+    <li>
+      <a class="govuk-link" href="/examples/qualifications/degrees">Degrees</a>
+    </li>
+    <li>
+      <a class="govuk-link" href="/examples/qualifications/gcse">GCSE or equivalent</a>
+    </li>
+    <li>
+      <a class="govuk-link" href="/examples/qualifications/english">English as a foreign language</a>
+    </li>
+  </ul>
+
+  </div>
+</div>
+{% endblock %}

--- a/app/views/_examples/qualifications/degree.njk
+++ b/app/views/_examples/qualifications/degree.njk
@@ -1,6 +1,6 @@
 {% extends "_layout.njk" %}
 
-{% set primaryNavId = 'applications' %}
+{% set primaryNavId = "examples" %}
 
 {% set title = "Degrees" %}
 
@@ -9,523 +9,523 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
-  <h2 class="govuk-heading-l">
-    {{ title }}
-  </h2>
-
-  <hr class="govuk-section-break govuk-section-break--xl">
-
-  <h3 class="govuk-heading-m">
-    Degree
-  </h3>
-
-  <dl class="govuk-summary-list">
-
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        Degree type
-      </dt>
-      <dd class="govuk-summary-list__value">
-        BSc - Bachelor of Science (Hons)
-      </dd>
-    </div>
-
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        Subject
-      </dt>
-      <dd class="govuk-summary-list__value">
-        Educational psychology
-      </dd>
-    </div>
-
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        Institution
-      </dt>
-      <dd class="govuk-summary-list__value">
-        University College London
-      </dd>
-    </div>
-
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        Grade
-      </dt>
-      <dd class="govuk-summary-list__value">
-        Upper second-class honours (2:1)
-      </dd>
-    </div>
-
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        Start year
-      </dt>
-      <dd class="govuk-summary-list__value">
-        2016
-      </dd>
-    </div>
-
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        Graduation year
-      </dt>
-      <dd class="govuk-summary-list__value">
-        2020
-      </dd>
-    </div>
-  </dl>
-
-  <hr class="govuk-section-break govuk-section-break--xl">
-
-  <h3 class="govuk-heading-m">
-    First degree
-  </h3>
-
-  <dl class="govuk-summary-list">
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        Degree type
-      </dt>
-      <dd class="govuk-summary-list__value">
-        BSc - Bachelor of Science (Hons)
-      </dd>
-    </div>
-
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        Subject
-      </dt>
-      <dd class="govuk-summary-list__value">
-        Educational psychology
-      </dd>
-    </div>
-
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        Institution
-      </dt>
-      <dd class="govuk-summary-list__value">
-        University College London
-      </dd>
-    </div>
-
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        Grade
-      </dt>
-      <dd class="govuk-summary-list__value">
-        Upper second-class honours (2:1)
-      </dd>
-    </div>
-
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        Start year
-      </dt>
-      <dd class="govuk-summary-list__value">
-        2010
-      </dd>
-    </div>
-
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        Graduation year
-      </dt>
-      <dd class="govuk-summary-list__value">
-        2013
-      </dd>
-    </div>
-  </dl>
-
-  <h3 class="govuk-heading-m govuk-!-margin-top-9">
-    Second degree
-  </h3>
-
-  <dl class="govuk-summary-list">
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        Degree type
-      </dt>
-      <dd class="govuk-summary-list__value">
-        MSc - Master of Science
-      </dd>
-    </div>
-
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        Subject
-      </dt>
-      <dd class="govuk-summary-list__value">
-        Child psychology
-      </dd>
-    </div>
-
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        Institution
-      </dt>
-      <dd class="govuk-summary-list__value">
-        King’s College London
-      </dd>
-    </div>
-
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        Grade
-      </dt>
-      <dd class="govuk-summary-list__value">
-        Distinction
-      </dd>
-    </div>
-
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        Start year
-      </dt>
-      <dd class="govuk-summary-list__value">
-        2014
-      </dd>
-    </div>
-
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        Graduation year
-      </dt>
-      <dd class="govuk-summary-list__value">
-        2015
-      </dd>
-    </div>
-  </dl>
-
-  <hr class="govuk-section-break govuk-section-break--xl">
-
-  <h3 class="govuk-heading-m govuk-!-margin-top-9">
-    Degree
-  </h3>
-
-  <dl class="govuk-summary-list">
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        Degree type
-      </dt>
-      <dd class="govuk-summary-list__value">
-        Diplôme
-      </dd>
-    </div>
-
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        Subject
-      </dt>
-      <dd class="govuk-summary-list__value">
-        Educational psychology
-      </dd>
-    </div>
-
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        Institution
-      </dt>
-      <dd class="govuk-summary-list__value">
-        University of Paris
-      </dd>
-    </div>
-
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        Country or territory
-      </dt>
-      <dd class="govuk-summary-list__value">
-        France
-      </dd>
-    </div>
-
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        Grade
-      </dt>
-      <dd class="govuk-summary-list__value">
-        Distinction
-      </dd>
-    </div>
-
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        Start year
-      </dt>
-      <dd class="govuk-summary-list__value">
-        2016
-      </dd>
-    </div>
-
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        Graduation year
-      </dt>
-      <dd class="govuk-summary-list__value">
-        2019
-      </dd>
-    </div>
-
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        UK ENIC reference number
-      </dt>
-      <dd class="govuk-summary-list__value">
-        4000228363
-      </dd>
-    </div>
-
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        Comparable UK degree
-      </dt>
-      <dd class="govuk-summary-list__value">
-        Bachelor (Honours) degree
-      </dd>
-    </div>
-  </dl>
-
-  <hr class="govuk-section-break govuk-section-break--xl">
-
-  <h3 class="govuk-heading-m govuk-!-margin-top-9">
-    Degree
-  </h3>
-
-  <dl class="govuk-summary-list">
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        Degree type
-      </dt>
-      <dd class="govuk-summary-list__value">
-        Diplôme
-      </dd>
-    </div>
-
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        Subject
-      </dt>
-      <dd class="govuk-summary-list__value">
-        Educational psychology
-      </dd>
-    </div>
-
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        Institution
-      </dt>
-      <dd class="govuk-summary-list__value">
-        University of Paris
-      </dd>
-    </div>
-
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        Country or territory
-      </dt>
-      <dd class="govuk-summary-list__value">
-        France
-      </dd>
-    </div>
-
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        Grade
-      </dt>
-      <dd class="govuk-summary-list__value">
-        Distinction
-      </dd>
-    </div>
-
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        Start year
-      </dt>
-      <dd class="govuk-summary-list__value">
-        2016
-      </dd>
-    </div>
-
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        Graduation year
-      </dt>
-      <dd class="govuk-summary-list__value">
-        2019
-      </dd>
-    </div>
-
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        Do you have a UK ENIC statement of comparability?
-      </dt>
-      <dd class="govuk-summary-list__value">
-        No
-      </dd>
-    </div>
-  </dl>
-
-  <hr class="govuk-section-break govuk-section-break--xl">
-
-  <h3 class="govuk-heading-m">
-    Degree
-  </h3>
-
-  <dl class="govuk-summary-list">
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        Degree type
-      </dt>
-      <dd class="govuk-summary-list__value">
-        BSc - Bachelor of Science (Hons)
-      </dd>
-    </div>
-
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        Subject
-      </dt>
-      <dd class="govuk-summary-list__value">
-        Educational psychology
-      </dd>
-    </div>
-
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        Institution
-      </dt>
-      <dd class="govuk-summary-list__value">
-        University College London
-      </dd>
-    </div>
-
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        Have you completed this degree?
-      </dt>
-      <dd class="govuk-summary-list__value">
-        No
-      </dd>
-    </div>
-
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        Predicted grade
-      </dt>
-      <dd class="govuk-summary-list__value">
-        Upper second-class honours (2:1)
-      </dd>
-    </div>
-
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        Start year
-      </dt>
-      <dd class="govuk-summary-list__value">
-        2019
-      </dd>
-    </div>
-
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        Graduation year
-      </dt>
-      <dd class="govuk-summary-list__value">
-        2022
-      </dd>
-    </div>
-  </dl>
-
-  <hr class="govuk-section-break govuk-section-break--xl">
-
-  <h3 class="govuk-heading-m govuk-!-margin-top-9">
-    Degree
-  </h3>
-
-  <dl class="govuk-summary-list">
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        Degree type
-      </dt>
-      <dd class="govuk-summary-list__value">
-        Diplôme
-      </dd>
-    </div>
-
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        Subject
-      </dt>
-      <dd class="govuk-summary-list__value">
-        Educational psychology
-      </dd>
-    </div>
-
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        Institution
-      </dt>
-      <dd class="govuk-summary-list__value">
-        University of Paris
-      </dd>
-    </div>
-
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        Country or territory
-      </dt>
-      <dd class="govuk-summary-list__value">
-        France
-      </dd>
-    </div>
-
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        Have you completed this degree?
-      </dt>
-      <dd class="govuk-summary-list__value">
-        No
-      </dd>
-    </div>
-
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        Predicted grade
-      </dt>
-      <dd class="govuk-summary-list__value">
-        Distinction
-      </dd>
-    </div>
-
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        Start year
-      </dt>
-      <dd class="govuk-summary-list__value">
-        2019
-      </dd>
-    </div>
-
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        Graduation year
-      </dt>
-      <dd class="govuk-summary-list__value">
-        2022
-      </dd>
-    </div>
-
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        Do you have a UK ENIC statement of comparability?
-      </dt>
-      <dd class="govuk-summary-list__value">
-        No
-      </dd>
-    </div>
-  </dl>
+    <h1 class="govuk-heading-l">
+      {{ title }}
+    </h1>
+
+    <hr class="govuk-section-break govuk-section-break--xl">
+
+    <h2 class="govuk-heading-m">
+      Degree
+    </h2>
+
+    <dl class="govuk-summary-list">
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Degree type
+        </dt>
+        <dd class="govuk-summary-list__value">
+          BSc - Bachelor of Science (Hons)
+        </dd>
+      </div>
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Subject
+        </dt>
+        <dd class="govuk-summary-list__value">
+          Educational psychology
+        </dd>
+      </div>
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Institution
+        </dt>
+        <dd class="govuk-summary-list__value">
+          University College London
+        </dd>
+      </div>
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Grade
+        </dt>
+        <dd class="govuk-summary-list__value">
+          Upper second-class honours (2:1)
+        </dd>
+      </div>
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Start year
+        </dt>
+        <dd class="govuk-summary-list__value">
+          2016
+        </dd>
+      </div>
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Graduation year
+        </dt>
+        <dd class="govuk-summary-list__value">
+          2020
+        </dd>
+      </div>
+    </dl>
+
+    <hr class="govuk-section-break govuk-section-break--xl">
+
+    <h2 class="govuk-heading-m">
+      First degree
+    </h2>
+
+    <dl class="govuk-summary-list">
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Degree type
+        </dt>
+        <dd class="govuk-summary-list__value">
+          BSc - Bachelor of Science (Hons)
+        </dd>
+      </div>
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Subject
+        </dt>
+        <dd class="govuk-summary-list__value">
+          Educational psychology
+        </dd>
+      </div>
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Institution
+        </dt>
+        <dd class="govuk-summary-list__value">
+          University College London
+        </dd>
+      </div>
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Grade
+        </dt>
+        <dd class="govuk-summary-list__value">
+          Upper second-class honours (2:1)
+        </dd>
+      </div>
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Start year
+        </dt>
+        <dd class="govuk-summary-list__value">
+          2010
+        </dd>
+      </div>
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Graduation year
+        </dt>
+        <dd class="govuk-summary-list__value">
+          2013
+        </dd>
+      </div>
+    </dl>
+
+    <h2 class="govuk-heading-m govuk-!-margin-top-9">
+      Second degree
+    </h2>
+
+    <dl class="govuk-summary-list">
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Degree type
+        </dt>
+        <dd class="govuk-summary-list__value">
+          MSc - Master of Science
+        </dd>
+      </div>
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Subject
+        </dt>
+        <dd class="govuk-summary-list__value">
+          Child psychology
+        </dd>
+      </div>
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Institution
+        </dt>
+        <dd class="govuk-summary-list__value">
+          King’s College London
+        </dd>
+      </div>
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Grade
+        </dt>
+        <dd class="govuk-summary-list__value">
+          Distinction
+        </dd>
+      </div>
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Start year
+        </dt>
+        <dd class="govuk-summary-list__value">
+          2014
+        </dd>
+      </div>
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Graduation year
+        </dt>
+        <dd class="govuk-summary-list__value">
+          2015
+        </dd>
+      </div>
+    </dl>
+
+    <hr class="govuk-section-break govuk-section-break--xl">
+
+    <h2 class="govuk-heading-m govuk-!-margin-top-9">
+      Degree
+    </h2>
+
+    <dl class="govuk-summary-list">
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Degree type
+        </dt>
+        <dd class="govuk-summary-list__value">
+          Diplôme
+        </dd>
+      </div>
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Subject
+        </dt>
+        <dd class="govuk-summary-list__value">
+          Educational psychology
+        </dd>
+      </div>
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Institution
+        </dt>
+        <dd class="govuk-summary-list__value">
+          University of Paris
+        </dd>
+      </div>
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Country or territory
+        </dt>
+        <dd class="govuk-summary-list__value">
+          France
+        </dd>
+      </div>
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Grade
+        </dt>
+        <dd class="govuk-summary-list__value">
+          Distinction
+        </dd>
+      </div>
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Start year
+        </dt>
+        <dd class="govuk-summary-list__value">
+          2016
+        </dd>
+      </div>
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Graduation year
+        </dt>
+        <dd class="govuk-summary-list__value">
+          2019
+        </dd>
+      </div>
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          UK ENIC reference number
+        </dt>
+        <dd class="govuk-summary-list__value">
+          4000228363
+        </dd>
+      </div>
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Comparable UK degree
+        </dt>
+        <dd class="govuk-summary-list__value">
+          Bachelor (Honours) degree
+        </dd>
+      </div>
+    </dl>
+
+    <hr class="govuk-section-break govuk-section-break--xl">
+
+    <h2 class="govuk-heading-m govuk-!-margin-top-9">
+      Degree
+    </h2>
+
+    <dl class="govuk-summary-list">
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Degree type
+        </dt>
+        <dd class="govuk-summary-list__value">
+          Diplôme
+        </dd>
+      </div>
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Subject
+        </dt>
+        <dd class="govuk-summary-list__value">
+          Educational psychology
+        </dd>
+      </div>
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Institution
+        </dt>
+        <dd class="govuk-summary-list__value">
+          University of Paris
+        </dd>
+      </div>
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Country or territory
+        </dt>
+        <dd class="govuk-summary-list__value">
+          France
+        </dd>
+      </div>
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Grade
+        </dt>
+        <dd class="govuk-summary-list__value">
+          Distinction
+        </dd>
+      </div>
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Start year
+        </dt>
+        <dd class="govuk-summary-list__value">
+          2016
+        </dd>
+      </div>
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Graduation year
+        </dt>
+        <dd class="govuk-summary-list__value">
+          2019
+        </dd>
+      </div>
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Do you have a UK ENIC statement of comparability?
+        </dt>
+        <dd class="govuk-summary-list__value">
+          No
+        </dd>
+      </div>
+    </dl>
+
+    <hr class="govuk-section-break govuk-section-break--xl">
+
+    <h2 class="govuk-heading-m">
+      Degree
+    </h2>
+
+    <dl class="govuk-summary-list">
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Degree type
+        </dt>
+        <dd class="govuk-summary-list__value">
+          BSc - Bachelor of Science (Hons)
+        </dd>
+      </div>
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Subject
+        </dt>
+        <dd class="govuk-summary-list__value">
+          Educational psychology
+        </dd>
+      </div>
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Institution
+        </dt>
+        <dd class="govuk-summary-list__value">
+          University College London
+        </dd>
+      </div>
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Have you completed this degree?
+        </dt>
+        <dd class="govuk-summary-list__value">
+          No
+        </dd>
+      </div>
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Predicted grade
+        </dt>
+        <dd class="govuk-summary-list__value">
+          Upper second-class honours (2:1)
+        </dd>
+      </div>
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Start year
+        </dt>
+        <dd class="govuk-summary-list__value">
+          2019
+        </dd>
+      </div>
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Graduation year
+        </dt>
+        <dd class="govuk-summary-list__value">
+          2022
+        </dd>
+      </div>
+    </dl>
+
+    <hr class="govuk-section-break govuk-section-break--xl">
+
+    <h2 class="govuk-heading-m govuk-!-margin-top-9">
+      Degree
+    </h2>
+
+    <dl class="govuk-summary-list">
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Degree type
+        </dt>
+        <dd class="govuk-summary-list__value">
+          Diplôme
+        </dd>
+      </div>
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Subject
+        </dt>
+        <dd class="govuk-summary-list__value">
+          Educational psychology
+        </dd>
+      </div>
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Institution
+        </dt>
+        <dd class="govuk-summary-list__value">
+          University of Paris
+        </dd>
+      </div>
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Country or territory
+        </dt>
+        <dd class="govuk-summary-list__value">
+          France
+        </dd>
+      </div>
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Have you completed this degree?
+        </dt>
+        <dd class="govuk-summary-list__value">
+          No
+        </dd>
+      </div>
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Predicted grade
+        </dt>
+        <dd class="govuk-summary-list__value">
+          Distinction
+        </dd>
+      </div>
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Start year
+        </dt>
+        <dd class="govuk-summary-list__value">
+          2019
+        </dd>
+      </div>
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Graduation year
+        </dt>
+        <dd class="govuk-summary-list__value">
+          2022
+        </dd>
+      </div>
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Do you have a UK ENIC statement of comparability?
+        </dt>
+        <dd class="govuk-summary-list__value">
+          No
+        </dd>
+      </div>
+    </dl>
 
   </div>
 </div>

--- a/app/views/_examples/qualifications/degree.njk
+++ b/app/views/_examples/qualifications/degree.njk
@@ -4,12 +4,20 @@
 
 {% set title = "Degrees" %}
 
+{% block beforeContent %}
+{{ govukBackLink({
+  text: "Back",
+  href: "/examples"
+}) }}
+{% endblock %}
+
 {% block content %}
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
     <h1 class="govuk-heading-l">
+      <span class="govuk-caption-l">Qualification examples</span>
       {{ title }}
     </h1>
 

--- a/app/views/_examples/qualifications/english.njk
+++ b/app/views/_examples/qualifications/english.njk
@@ -4,12 +4,20 @@
 
 {% set title = "English as a foreign language" %}
 
+{% block beforeContent %}
+{{ govukBackLink({
+  text: "Back",
+  href: "/examples"
+}) }}
+{% endblock %}
+
 {% block content %}
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
     <h1 class="govuk-heading-l">
+      <span class="govuk-caption-l">Qualification examples</span>
       {{ title }}
     </h1>
 

--- a/app/views/_examples/qualifications/english.njk
+++ b/app/views/_examples/qualifications/english.njk
@@ -1,6 +1,6 @@
 {% extends "_layout.njk" %}
 
-{% set primaryNavId = 'applications' %}
+{% set primaryNavId = "examples" %}
 
 {% set title = "English as a foreign language" %}
 
@@ -9,154 +9,155 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
-  <h2 class="govuk-heading-l">
-    {{ title }}
-  </h2>
+    <h1 class="govuk-heading-l">
+      {{ title }}
+    </h1>
 
-  <hr class="govuk-section-break govuk-section-break--xl">
+    <hr class="govuk-section-break govuk-section-break--xl">
 
-  <h3 class="govuk-heading-m">
-    English as a foreign language
-  </h3>
+    <h2 class="govuk-heading-m">
+      English as a foreign language
+    </h2>
 
-  <dl class="govuk-summary-list">
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        Assessment type
-      </dt>
-      <dd class="govuk-summary-list__value">
-        International English Language Testing System (IELTS)
-      </dd>
-    </div>
+    <dl class="govuk-summary-list">
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Assessment type
+        </dt>
+        <dd class="govuk-summary-list__value">
+          International English Language Testing System (IELTS)
+        </dd>
+      </div>
 
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        Test report form (TRF) number
-      </dt>
-      <dd class="govuk-summary-list__value">
-        02GB0674SOOM599A
-      </dd>
-    </div>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Test report form (TRF) number
+        </dt>
+        <dd class="govuk-summary-list__value">
+          02GB0674SOOM599A
+        </dd>
+      </div>
 
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        Overall band score
-      </dt>
-      <dd class="govuk-summary-list__value">
-        7.5
-      </dd>
-    </div>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Overall band score
+        </dt>
+        <dd class="govuk-summary-list__value">
+          7.5
+        </dd>
+      </div>
 
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        Year completed
-      </dt>
-      <dd class="govuk-summary-list__value">
-        2020
-      </dd>
-    </div>
-  </dl>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Year completed
+        </dt>
+        <dd class="govuk-summary-list__value">
+          2020
+        </dd>
+      </div>
+    </dl>
 
-  <hr class="govuk-section-break govuk-section-break--xl">
+    <hr class="govuk-section-break govuk-section-break--xl">
 
-  <h3 class="govuk-heading-m">
-    English as a foreign language
-  </h3>
+    <h2 class="govuk-heading-m">
+      English as a foreign language
+    </h2>
 
-  <dl class="govuk-summary-list">
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        Assessment type
-      </dt>
-      <dd class="govuk-summary-list__value">
-        Test of English as a Foreign Language (TOEFL)
-      </dd>
-    </div>
+    <dl class="govuk-summary-list">
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Assessment type
+        </dt>
+        <dd class="govuk-summary-list__value">
+          Test of English as a Foreign Language (TOEFL)
+        </dd>
+      </div>
 
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        TOEFL registration number
-      </dt>
-      <dd class="govuk-summary-list__value">
-        0000 0000 2500 2147
-      </dd>
-    </div>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          TOEFL registration number
+        </dt>
+        <dd class="govuk-summary-list__value">
+          0000 0000 2500 2147
+        </dd>
+      </div>
 
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        Total score
-      </dt>
-      <dd class="govuk-summary-list__value">
-        92
-      </dd>
-    </div>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Total score
+        </dt>
+        <dd class="govuk-summary-list__value">
+          92
+        </dd>
+      </div>
 
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        Year completed
-      </dt>
-      <dd class="govuk-summary-list__value">
-        2020
-      </dd>
-    </div>
-  </dl>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Year completed
+        </dt>
+        <dd class="govuk-summary-list__value">
+          2020
+        </dd>
+      </div>
+    </dl>
 
-  <hr class="govuk-section-break govuk-section-break--xl">
+    <hr class="govuk-section-break govuk-section-break--xl">
 
-  <h3 class="govuk-heading-m">
-    English as a foreign language
-  </h3>
+    <h2 class="govuk-heading-m">
+      English as a foreign language
+    </h2>
 
-  <dl class="govuk-summary-list">
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        Assessment type
-      </dt>
-      <dd class="govuk-summary-list__value">
-        Pearson Test of English
-      </dd>
-    </div>
+    <dl class="govuk-summary-list">
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Assessment type
+        </dt>
+        <dd class="govuk-summary-list__value">
+          Pearson Test of English
+        </dd>
+      </div>
 
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        Score or grade
-      </dt>
-      <dd class="govuk-summary-list__value">
-        85
-      </dd>
-    </div>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Score or grade
+        </dt>
+        <dd class="govuk-summary-list__value">
+          85
+        </dd>
+      </div>
 
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        Year completed
-      </dt>
-      <dd class="govuk-summary-list__value">
-        2020
-      </dd>
-    </div>
-  </dl>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Year completed
+        </dt>
+        <dd class="govuk-summary-list__value">
+          2020
+        </dd>
+      </div>
+    </dl>
 
-  <hr class="govuk-section-break govuk-section-break--xl">
+    <hr class="govuk-section-break govuk-section-break--xl">
 
-  <h3 class="govuk-heading-m">
-    English as a foreign language
-  </h3>
+    <h2 class="govuk-heading-m">
+      English as a foreign language
+    </h2>
 
-  <dl class="govuk-summary-list">
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        Have you done an English as a foreign language assessment?
-      </dt>
-      <dd class="govuk-summary-list__value">
-        No, English is not a foreign language to me
-      </dd>
-    </div>
-  </dl>
+    <dl class="govuk-summary-list">
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Have you done an English as a foreign language assessment?
+        </dt>
+        <dd class="govuk-summary-list__value">
+          No, English is not a foreign language to me
+        </dd>
+      </div>
+    </dl>
 
-  <hr class="govuk-section-break govuk-section-break--xl">
+    <hr class="govuk-section-break govuk-section-break--xl">
 
-  <h3 class="govuk-heading-m">
-    English as a foreign language
+    <h2 class="govuk-heading-m">
+      English as a foreign language
+    </h2>
 
     <dl class="govuk-summary-list">
       <div class="govuk-summary-list__row">
@@ -178,8 +179,7 @@
       </div>
     </dl>
 
-  <hr class="govuk-section-break govuk-section-break--xl">
-
+    <hr class="govuk-section-break govuk-section-break--xl">
 
   </div>
 </div>

--- a/app/views/_examples/qualifications/gcse.njk
+++ b/app/views/_examples/qualifications/gcse.njk
@@ -1,6 +1,6 @@
 {% extends "_layout.njk" %}
 
-{% set primaryNavId = 'applications' %}
+{% set primaryNavId = "examples" %}
 
 {% set title = "GCSE or equivalent" %}
 
@@ -9,9 +9,9 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
-  <h2 class="govuk-heading-l">
-    {{ title }}
-  </h2>
+    <h1 class="govuk-heading-l">
+      {{ title }}
+    </h1>
 
   <hr class="govuk-section-break govuk-section-break--xl">
 

--- a/app/views/_examples/qualifications/gcse.njk
+++ b/app/views/_examples/qualifications/gcse.njk
@@ -4,12 +4,20 @@
 
 {% set title = "GCSE or equivalent" %}
 
+{% block beforeContent %}
+{{ govukBackLink({
+  text: "Back",
+  href: "/examples"
+}) }}
+{% endblock %}
+
 {% block content %}
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
     <h1 class="govuk-heading-l">
+      <span class="govuk-caption-l">Qualification examples</span>
       {{ title }}
     </h1>
 

--- a/app/views/_examples/qualifications/index.njk
+++ b/app/views/_examples/qualifications/index.njk
@@ -1,0 +1,30 @@
+{% extends "_layout.njk" %}
+
+{% set primaryNavId = "examples" %}
+
+{% set title = "Qualifications" %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+  <h1 class="govuk-heading-l">
+    {{ title }}
+  </h1>
+
+  <ul class="govuk-list">
+    <li>
+      <a class="govuk-link" href="/examples/qualifications/degrees">Degrees</a>
+    </li>
+    <li>
+      <a class="govuk-link" href="/examples/qualifications/gcse">GCSE or equivalent</a>
+    </li>
+    <li>
+      <a class="govuk-link" href="/examples/qualifications/english">English as a foreign language</a>
+    </li>
+  </ul>
+
+  </div>
+</div>
+{% endblock %}

--- a/app/views/_examples/qualifications/index.njk
+++ b/app/views/_examples/qualifications/index.njk
@@ -4,12 +4,20 @@
 
 {% set title = "Qualifications" %}
 
+{% block beforeContent %}
+{{ govukBackLink({
+  text: "Back",
+  href: "/examples"
+}) }}
+{% endblock %}
+
 {% block content %}
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
   <h1 class="govuk-heading-l">
+    <span class="govuk-caption-l">Qualifications</span>
     {{ title }}
   </h1>
 

--- a/app/views/_includes/applications/course-details.njk
+++ b/app/views/_includes/applications/course-details.njk
@@ -83,10 +83,35 @@
     } if application.status in ["Received","Interviewing"] and 1 == 0
   } if application.accreditedBody != application.provider, {
     key: {
+      text: "Qualification"
+    },
+    value: {
+      text: application.qualifications | arrayToList(', ',' with ')
+    },
+    actions: {
+      items: [
+        {
+          href: "/applications/" + application.id + "/course/edit/qualifications?referrer=details",
+          text: "Change",
+          visuallyHiddenText: "qualification"
+        }
+      ]
+    } if application.status in ["Received","Interviewing"] and 1 == 0
+  }, {
+    key: {
       text: "Funding type"
     },
     value: {
       text: application.fundingType
-    }
+    },
+    actions: {
+      items: [
+        {
+          href: "/applications/" + application.id + "/course/edit/funding-type?referrer=details",
+          text: "Change",
+          visuallyHiddenText: "funding type"
+        }
+      ]
+    } if application.status in ["Received","Interviewing"] and 1 == 0
   }]
 }) }}

--- a/app/views/applications/course/check.njk
+++ b/app/views/applications/course/check.njk
@@ -92,6 +92,13 @@
           value: {
             html: course.accreditedBody.name or application.accreditedBody
           }
+        } if (course.accreditedBody.name or application.accreditedBody) != (data['edit-course'].provider or application.provider), {
+          key: {
+            text: "Qualification"
+          },
+          value: {
+            html: course.qualifications | arrayToList(', ',' with ')
+          }
         }, {
           key: {
             text: "Funding type"

--- a/app/views/applications/decision.njk
+++ b/app/views/applications/decision.njk
@@ -60,6 +60,13 @@
             value: {
               html: application.accreditedBody
             }
+          } if application.accreditedBody != application.provider, {
+            key: {
+              text: "Qualification"
+            },
+            value: {
+              html: application.qualifications | arrayToList(', ',' with ')
+            }
           }, {
             key: {
               text: "Funding type"

--- a/app/views/applications/offer/edit/check.njk
+++ b/app/views/applications/offer/edit/check.njk
@@ -38,6 +38,9 @@
         },
         accreditedBody: {
           value: application.offer.accreditedBody
+        } if application.offer.accreditedBody != (data['edit-offer'].provider or application.offer.provider),
+        qualifications: {
+          value: course.qualifications | arrayToList(', ',' with ')
         },
         fundingType: {
           value: application.offer.fundingType

--- a/app/views/applications/offer/new/check.njk
+++ b/app/views/applications/offer/new/check.njk
@@ -6,7 +6,7 @@
 
 {% block pageNavigation %}
 {{ govukBackLink({
-  href: '/applications/' + application.id + '/offer/new'
+  href: actions.back
 }) }}
 {% endblock %}
 
@@ -39,6 +39,9 @@
         },
         accreditedBody: {
           value: course.accreditedBody.name
+        } if course.accreditedBody.name != course.provider.name,
+        qualifications: {
+          value: course.qualifications | arrayToList(', ',' with ')
         },
         fundingType: {
           value: course.fundingType

--- a/app/views/applications/offer/show.njk
+++ b/app/views/applications/offer/show.njk
@@ -41,6 +41,9 @@
             value: application.offer.course,
             href: "/applications/" + application.id + "/offer/edit/course?referrer=offer" if application.status == "Offered" and not query.transferred
           },
+          qualifications: {
+            value: application.offer.qualifications | arrayToList(', ',' with ')
+          },
           studyMode: {
             value: application.offer.studyMode,
             href: "/applications/" + application.id + "/offer/edit/study-mode?referrer=offer" if application.status == "Offered" and course.studyModes.length > 1 and not query.transferred
@@ -51,7 +54,7 @@
           },
           accreditedBody: {
             value: application.offer.accreditedBody
-          },
+          } if application.offer.accreditedBody != application.offer.provider,
           fundingType: {
             value: application.offer.fundingType
           },

--- a/scripts/generate-applications.js
+++ b/scripts/generate-applications.js
@@ -74,6 +74,7 @@ const generateFakeApplication = (params = {}) => {
   const studyMode = faker.helpers.randomize(tempCourse.studyModes)
   const subjectLevel = tempCourse.subjectLevel
   const fundingType = tempCourse.fundingType
+  const qualifications = tempCourse.qualifications
 
 
   let offer = null
@@ -87,7 +88,8 @@ const generateFakeApplication = (params = {}) => {
       courseCode,
       location,
       studyMode,
-      fundingType
+      fundingType,
+      qualifications
     })
   }
 
@@ -112,6 +114,7 @@ const generateFakeApplication = (params = {}) => {
     studyMode,
     accreditedBody: accreditedBody.name,
     fundingType,
+    qualifications,
     organisation,
     assignedUsers
   })
@@ -176,6 +179,7 @@ const generateFakeApplication = (params = {}) => {
     subject: params.subject || subjects,
     subjectLevel: params.subjectLevel || subjectLevel,
     course: params.course || course,
+    qualifications: params.qualifications || qualifications,
     courseCode: params.courseCode || courseCode,
     location: params.location || location,
     status,


### PR DESCRIPTION
- fix bug with location not showing in the summary list when editing a course
- added qualifications data to the applications generators
- added qualifications to summary lists
  - change course
  - make offer
  - edit offer
- added qualifications and funding type to application log and timeline
- added an `arrayToList` filter
- added a `courses` example page so we can see all course detail in the prototype