### PR TITLE
Simplify personal statement rejection reason

### DIFF
--- a/app/views/applications/reject/index.njk
+++ b/app/views/applications/reject/index.njk
@@ -38,7 +38,7 @@
         {% endset %}
 
         {% set personalStatementReasonsHtml %}
-          {% include "_includes/reasons/personal-statement.njk" %}
+          {{appRejectionDetails({ category: 'personal-statement', reason: 'details', data: data })}}
         {% endset %}
 
         {% set teachingKnowledgeReasonsHtml %}


### PR DESCRIPTION
Could the "Quality of writing" and "Other" textareas for the personal statement rejection reason be combined into a single "Details" textarea?

This would:

* simplify the interface for providers
* let us drop the "Quality of writing" and "Other" headings for candidates, which don’t add much value (although we could do this anyway)

# Screenshots

## Before

<img width="822" alt="2-boxes" src="https://user-images.githubusercontent.com/30665/154949052-39e01332-441a-4e8f-9ce1-639753ce3666.png">

## After

<img width="697" alt="1-box" src="https://user-images.githubusercontent.com/30665/154949100-fe5ea1db-fe5c-4f5d-b99a-de82a093af4c.png">

