### PR TITLE
Add '2 references' as a standard offer condition

### DIFF
--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -90,13 +90,15 @@ defaults.user = user
 
 defaults["standard-conditions"] = [
   "Fitness to train to teach check",
-  "Disclosure and Barring Service (DBS) check"
+  "Disclosure and Barring Service (DBS) check",
+  "2 references"
 ]
 
 defaults['new-offer'] = {
   'standard-conditions': [
     "Fitness to train to teach check",
-    "Disclosure and Barring Service (DBS) check"
+    "Disclosure and Barring Service (DBS) check",
+    "2 references"
   ]
 }
 

--- a/app/views/applications/offer/new/conditions.njk
+++ b/app/views/applications/offer/new/conditions.njk
@@ -41,6 +41,10 @@
             value: "Disclosure and Barring Service (DBS) check",
             text: "Disclosure and Barring Service (DBS) check",
             checked: checked("['new-offer']['standard-conditions']", "Disclosure and Barring Service (DBS) check")
+          },{
+            value: "2 references",
+            text: "2 references",
+            checked: checked("['new-offer']['standard-conditions']", "2 references")
           }]
         }) }}
 


### PR DESCRIPTION
This is an option we’re exploring as part of moving references to being a post-offer process.

➡️ [Preview](https://manage-appli-add-2-refe-xa7smy.herokuapp.com/applications/)

See also:

* [Asking for referees within the application but not collecting references until later ](https://github.com/DFE-Digital/apply-for-teacher-training-prototype/pull/650)
* [Displaying offer conditions as a task list to candidates](https://github.com/DFE-Digital/apply-for-teacher-training-prototype/pull/649)

## Screenshot

![make-offer-2-references](https://user-images.githubusercontent.com/30665/170665835-6281b516-e337-4b11-8c07-da44dbfc8e8a.png)

