### PR TITLE
Offer conditions: References with details

### DIFF
--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -90,13 +90,15 @@ defaults.user = user
 
 defaults["standard-conditions"] = [
   "Fitness to train to teach check",
-  "Disclosure and Barring Service (DBS) check"
+  "Disclosure and Barring Service (DBS) check",
+  "2 references"
 ]
 
 defaults['new-offer'] = {
   'standard-conditions': [
     "Fitness to train to teach check",
-    "Disclosure and Barring Service (DBS) check"
+    "Disclosure and Barring Service (DBS) check",
+    "2 references"
   ]
 }
 

--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -91,14 +91,14 @@ defaults.user = user
 defaults["standard-conditions"] = [
   "Fitness to train to teach check",
   "Disclosure and Barring Service (DBS) check",
-  "2 references"
+  "References"
 ]
 
 defaults['new-offer'] = {
   'standard-conditions': [
     "Fitness to train to teach check",
     "Disclosure and Barring Service (DBS) check",
-    "2 references"
+    "References"
   ]
 }
 

--- a/app/views/applications/offer/new/conditions.njk
+++ b/app/views/applications/offer/new/conditions.njk
@@ -24,6 +24,22 @@
 
       <form action="{{ actions.save }}" method="post" accept-charset="UTF-8" novalidate>
 
+      {% set referencesDetails %}
+
+        {{ govukTextarea({
+          name: "references-details",
+          id: "references-details",
+          rows: "5",
+          label: {
+            text: "Give details",
+            classes: "govuk-label--s"
+          },
+          hint: {
+            text: "Tell candidates how many referees they need to provide, and whether one of them needs to be an academic reference or a reference from their recent employer."
+          }
+        }) }}
+      {% endset %}
+
         {{ govukCheckboxes({
           idPrefix: "[new-offer][standard-conditions]",
           name: "[new-offer][standard-conditions]",
@@ -42,9 +58,12 @@
             text: "Disclosure and Barring Service (DBS) check",
             checked: checked("['new-offer']['standard-conditions']", "Disclosure and Barring Service (DBS) check")
           },{
-            value: "2 references",
-            text: "2 references",
-            checked: checked("['new-offer']['standard-conditions']", "2 references")
+            value: "References",
+            text: "References",
+            checked: checked("['new-offer']['standard-conditions']", "References"),
+            conditional: {
+              html: referencesDetails
+            }
           }]
         }) }}
 

--- a/app/views/applications/offer/new/conditions.njk
+++ b/app/views/applications/offer/new/conditions.njk
@@ -41,6 +41,10 @@
             value: "Disclosure and Barring Service (DBS) check",
             text: "Disclosure and Barring Service (DBS) check",
             checked: checked("['new-offer']['standard-conditions']", "Disclosure and Barring Service (DBS) check")
+          },{
+            value: "2 references",
+            text: "2 references",
+            checked: checked("['new-offer']['standard-conditions']", "2 references")
           }]
         }) }}
 


### PR DESCRIPTION
This is an alternative to #546 which asks providers to give details of the number and type of referees required.

This has the advantage that it is more flexible depending on the requirements of the provider, and would allow us to remove all the guidance we show to candidates about the types of reference required (for example, an academic reference if graduating within the past 5 years).

## Screenshot

<img width="726" alt="Screenshot 2022-05-27 at 15 52 26" src="https://user-images.githubusercontent.com/30665/170724190-c4722f80-86cb-427b-997e-5fe9849a556e.png">

