### PR TITLE
Remove 'Export data' link from Applications index

### DIFF
--- a/app/views/applications/index.njk
+++ b/app/views/applications/index.njk
@@ -10,8 +10,6 @@
     {{title}}
   </h1>
 
-  <p class="govuk-body govuk-!-margin-bottom-6"><a class="govuk-link" href="/reports/export">Export data</a></p>
-
   <div class="app-filter-layout">
     <div class="app-filter-layout__filter">
       {% include "_includes/filter-panel.njk" %}


### PR DESCRIPTION
We don't have this on production.