### PR TITLE
Remove filters not used in production

### DIFF
--- a/app/views/_includes/filter-panel.njk
+++ b/app/views/_includes/filter-panel.njk
@@ -15,21 +15,6 @@
   }) }}
 
   {{ govukCheckboxes({
-    idPrefix: "importantItem",
-    name: "importantItem",
-    classes: "govuk-checkboxes--small",
-    fieldset: {
-      legend: {
-        text: "Important",
-        isPageHeading: false,
-        classes: "govuk-fieldset__legend--s"
-      }
-    },
-    items: importantCheckboxItems
-  }) }}
-
-
-  {{ govukCheckboxes({
     idPrefix: 'noteItem',
     name: 'noteItem',
     classes: "govuk-checkboxes--small",

--- a/app/views/_includes/filter-panel.njk
+++ b/app/views/_includes/filter-panel.njk
@@ -28,35 +28,6 @@
     items: importantCheckboxItems
   }) }}
 
-  {% if userItems.length >= userItemsDisplayLimit %}
-
-    {{ appCheckboxFilter({
-      idPrefix: 'assignedUser',
-      name: 'assignedUser',
-      legend: {
-        text: 'Assigned user'
-      },
-      items: userItems,
-      selectedItems: selectedUsers,
-      classes: 'govuk-!-margin-bottom-7'
-    }) }}
-
-  {% else %}
-
-    {{ govukCheckboxes({
-      idPrefix: 'assignedUser',
-      name: 'assignedUser',
-      fieldset: {
-        legend: {
-          text: 'Assigned user',
-          classes: 'govuk-fieldset__legend--s'
-        }
-      },
-      items: userItems,
-      classes: "govuk-checkboxes--small"
-    }) }}
-
-  {% endif %}
 
   {{ govukCheckboxes({
     idPrefix: 'noteItem',

--- a/app/views/_includes/filter-panel.njk
+++ b/app/views/_includes/filter-panel.njk
@@ -15,19 +15,6 @@
   }) }}
 
   {{ govukCheckboxes({
-    idPrefix: 'noteItem',
-    name: 'noteItem',
-    classes: "govuk-checkboxes--small",
-    fieldset: {
-      legend: {
-        text: 'Notes',
-        classes: 'govuk-fieldset__legend--s'
-      }
-    },
-    items: noteCheckboxItems
-  }) }}
-
-  {{ govukCheckboxes({
     idPrefix: 'status',
     name: 'status',
     classes: "govuk-checkboxes--small",


### PR DESCRIPTION
Removes these filters:

* assigned users
* notes
* important

...as they are not in production, and we want to be able to test other potential new features without these distracting research participants.