### PR TITLE
Group applications by status

### DIFF
--- a/app/views/applications/index.njk
+++ b/app/views/applications/index.njk
@@ -32,9 +32,11 @@
             {%- for a in applications %}
 
 
-              {% include "_includes/application-card.njk" %}
-
-
+              {% if a.heading %}
+                <h2 class="govuk-heading-m app-application-cards__heading">{{a.heading}}</h2>
+              {% else %}
+                {% include "_includes/application-card.njk" %}
+              {% endif %}
             {% endfor -%}
           </div>
 


### PR DESCRIPTION
This reverts some changes in the prototype, which allowed applications to be sorted in different orders, to match the production service, where applications are shown in a fixed order and grouped by status.