### PR TITLE
Bugfix: setting conditions not met

### DIFF
--- a/app/data/helpers/application.js
+++ b/app/data/helpers/application.js
@@ -84,7 +84,10 @@ exports.getCondition = (offer, conditionId) => {
 }
 
 exports.hasMetAllConditions = (offer) => {
-  return this.getConditions(offer).filter(condition => condition.status === 'Pending').length === 0
+  const conditions = this.getConditions(offer);
+  const numberOfConditionsMet = conditions.filter(condition => condition.status === 'Met').length
+
+  return numberOfConditionsMet === conditions.length
 }
 
 exports.deleteCondition = (application, conditionId) => {


### PR DESCRIPTION
The status was being set as "conditions met" even if one of the conditions was "not met" due to a bug with the logic, which only checked whether there were no conditions still pending.