### PR TITLE
Add next cycle’s dates and deadlines to the service guidance

### DIFF
--- a/app/views/guidance/_content/dates-and-deadlines.md
+++ b/app/views/guidance/_content/dates-and-deadlines.md
@@ -2,12 +2,26 @@
 title: Dates and deadlines
 ---
 
+## 2021 to 2022 recruitment cycle - current
+
 | Date and time | What happens |
 | --- | --- |
-| 12 October 2021 at 9am | Start of recruitment cycle - candidates can apply for courses. |
-| 21 December 2021 to 1 January 2022 | This period is not counted as working days when calculating time to make a decision. |
-| 2 April to 6 April 2022 | This period is not counted as working days when calculating time to make a decision. |
+| 12 October 2021 at 9am | Start of 2021 to 2022 recruitment cycle - candidates can apply for courses. |
+| 14 December 2021 to 16 January 2022 | This period is not counted as working days when calculating time to make a decision. |
+| 4 April to 18 April 2022 | This period is not counted as working days when calculating time to make a decision. |
 | 1 July 2022 | Time to make a decision is reduced from 40 working days to 20 working days. |
-| 7 September 2022 at 6pm | Candidates can no longer apply for courses, unless they have already applied within this recruitment cycle. |
-| 21 September 2022 at 6pm | Candidates can no longer apply for courses. |
-| 4 October 2022 at 11:59pm | End of recruitment cycle - applications awaiting decisions are automatically rejected. |
+| 6 September 2022 at 6pm | Candidates can no longer apply for courses, unless they have already applied within this recruitment cycle. |
+| 20 September 2022 at 6pm | Candidates can no longer apply for courses. |
+| 28 October 2022 at 11:59pm | End of 2021 to 2022 recruitment cycle - applications awaiting decisions are automatically rejected. |
+
+## 2022 to 2023 recruitment cycle
+
+| Date and time | What happens |
+| --- | --- |
+| 11 October 2022 at 9am | Start of 2022 to 2023 recruitment cycle - candidates can apply for courses. |
+| 19 December 2022 to 6 January 2023 | This period is not counted as working days when calculating time to make a decision. |
+| 27 March to 10 April 2023 | This period is not counted as working days when calculating time to make a decision. |
+| 1 July 2023 | Time to make a decision is reduced from 40 working days to 20 working days. |
+| 5 September 2023 at 6pm | Candidates can no longer apply for courses, unless they have already applied within this recruitment cycle. |
+| 19 September 2023 at 6pm | Candidates can no longer apply for courses. |
+| 27 September 2023 at 11:59pm | End of 2022 to 2023 recruitment cycle - applications awaiting decisions are automatically rejected. |


### PR DESCRIPTION
Providers sometimes want to know the dates and deadlines for the next recruitment cycle, particularly towards the end of a cycle. We added a table showing to show this information.