### PR TITLE
Add references guidance to 'Make offer' flow

### DIFF
--- a/app/views/applications/offer/new/conditions.njk
+++ b/app/views/applications/offer/new/conditions.njk
@@ -58,15 +58,14 @@
             value: "Disclosure and Barring Service (DBS) check",
             text: "Disclosure and Barring Service (DBS) check",
             checked: checked("['new-offer']['standard-conditions']", "Disclosure and Barring Service (DBS) check")
-          },{
-            value: "References",
-            text: "References",
-            checked: checked("['new-offer']['standard-conditions']", "References"),
-            conditional: {
-              html: referencesDetails
-            }
           }]
         }) }}
+
+        <h2 class="govuk-heading-m">References</h2>
+
+        <p class="govuk-body">Candidates will be able to request references if they accept your offer. They’ll be advised that they need to receive 2 references.</p>
+
+        <p class="govuk-body">If you have specific reference requirements, you can add them as an offer condition below.</p>
 
         <div class="app-add-another">
 


### PR DESCRIPTION
A bit of a placeholder to explain to providers that candidates will be asked to request 2 references if they accept an offer, and to prompt providers to add further conditions if they need to say anything specific about references...

A future enhancement could be to add an optional text box directly within the 'References' sub-section, to avoid the awkward reference to the interface below...

## Screenshot

<img width="817" alt="Screenshot 2022-08-26 at 16 44 25" src="https://user-images.githubusercontent.com/30665/186943431-bc4d7848-fb8c-414c-aabf-8fb7eefe21d1.png">

