### PR TITLE
References tab changes

### DIFF
--- a/app/data/generators/references.js
+++ b/app/data/generators/references.js
@@ -1,7 +1,10 @@
 const faker = require('faker')
 faker.locale = 'en_GB'
 
-module.exports = () => {
+module.exports = (status) => {
+
+  console.log('generating reference for ' + status)
+
   const type = faker.helpers.randomize([
     'Academic',
     'Professional',
@@ -24,26 +27,28 @@ module.exports = () => {
     'Was the head coach for my athletics club. I’ve known them for 5 years'
   ])
 
-  const referee = () => {
+  const referee = (status) => {
     const firstName = faker.name.firstName()
     const lastName = faker.name.lastName()
 
-    return {
+    let ref =  {
       type,
       name: `${firstName} ${lastName}`,
       email: faker.internet.email(firstName, lastName).toLowerCase(),
-      tel: faker.phone.phoneNumber(),
       relationship: {
-        summary: relationshipSummary,
-        validated: faker.datatype.boolean(),
-        correction: 'We worked together over a period of a year, but did not wotk that closely.'
-      },
-      safeguarding: {
-        response: faker.helpers.randomize(['no', 'yes']),
-        concerns: 'Impatient and intolerant by nature, and therefore not suited to work with children.'
-      },
-      comments
+        summary: relationshipSummary
+      }
     }
+
+    if (status != 'Received') {
+      ref['comments'] = comments
+      ref.relationship.validated = true
+      ref['safeguarding'] = {
+        response:  'no'
+      }
+    }
+
+    return ref
   }
 
   const rand = Math.floor(Math.random() * 10);
@@ -51,15 +56,15 @@ module.exports = () => {
   var references = {}
 
   if (rand > 1) {
-    references['first'] = referee()
+    references['first'] = referee(status)
   }
 
   if (rand > 3) {
-    references['second'] = referee()
+    references['second'] = referee(status)
   }
 
   if (rand > 8) {
-    references['third'] = referee()
+    references['third'] = referee(status)
   }
 
   return references

--- a/app/data/generators/references.js
+++ b/app/data/generators/references.js
@@ -51,21 +51,9 @@ module.exports = (status) => {
     return ref
   }
 
-  const rand = Math.floor(Math.random() * 10);
-
-  var references = {}
-
-  if (rand > 1) {
-    references['first'] = referee(status)
-  }
-
-  if (rand > 3) {
-    references['second'] = referee(status)
-  }
-
-  if (rand > 8) {
-    references['third'] = referee(status)
-  }
+  let references = {}
+  references['12446'] = referee(status)
+  references['26436'] = referee(status)
 
   return references
 }

--- a/app/views/_includes/applications/references.njk
+++ b/app/views/_includes/applications/references.njk
@@ -1,18 +1,141 @@
 
-{% if application["references"]["first"] %}
-  <h2 class="govuk-heading-m govuk-!-margin-top-4 govuk-!-margin-bottom-2">{{ application["references"]["first"].type }} reference from {{ application["references"]["first"].name }}</h2>
-  {% set referenceId = "first" %}
-  {% include "_includes/applications/reference.njk" %}
+
+{% set referencesArray = application["references"] | toArray %}
+
+{% set referencesReceived = referencesArray | selectattr("comments") %}
+{% set referencesPending = referencesArray | rejectattr("comments") %}
+
+{% if referencesReceived | length > 0 %}
+  <h2 class="govuk-heading-m">Received references</h2>
+  {% for reference in referencesReceived %}
+
+    <h3 class="govuk-heading-s govuk-!-margin-top-4 govuk-!-margin-bottom-2">{{reference.type }} reference from {{  reference.name }}</h3>
+
+    {% set relationshipHtml %}
+      <p class="govuk-body">{{ reference.relationship.summary | nl2br }}</p>
+
+      {% if reference.relationship.validated %}
+        <p class="govuk-body">Confirmed by {{ reference.name }}</p>
+      {% else %}
+        <p class="govuk-body">No</p>
+      {% endif %}
+    {% endset %}
+
+    {% set safeguardingResponseHtml -%}
+      {%- if reference.safeguarding.response == "yes" -%}
+        <p class="govuk-body">Yes</p>
+      {%- elif reference.safeguarding.response == "no" -%}
+        <p class="govuk-body">No</p>
+      {%- endif -%}
+    {%- endset %}
+
+    {{ govukSummaryList({
+      rows: [{
+        key: {
+          text: "Name"
+        },
+        value: {
+          text: reference.name
+        }
+      }, {
+        key: {
+          text: "Email address"
+        },
+        value: {
+          html: "<a href=\"mailto:" + reference.email + "\">" + reference.email + "</a>"
+        }
+      }, {
+        key: {
+          html: "Type"
+        },
+        value: {
+          html: reference.type
+        }
+      }, {
+        key: {
+          text: "How they are known and for how long"
+        },
+        value: {
+          text: relationshipHtml | safe
+        }
+      }, {
+        key: {
+          text: "Relationship amended by referee"
+        },
+        value: {
+          text: reference.relationship.correction
+        }
+      } if not reference.relationship.validated,
+      {
+        key: {
+          text: "Does referee know of any reason why this candidate should not work with children?"
+        },
+        value: {
+          html: safeguardingResponseHtml
+        }
+      },
+      {
+        key: {
+          text: "Reason(s) given by referee why this candidate should not work with children"
+        },
+        value: {
+          html: reference.safeguarding.concerns | nl2br
+        }
+      } if reference.safeguarding.response == "yes",
+      {
+        key: {
+          html: "Reference"
+        },
+        value: {
+          html: reference.comments | nl2br
+        }
+      }]
+    }) }}
+
+  {% endfor %}
 {% endif %}
 
-{% if application["references"]["second"] %}
-  <h2 class="govuk-heading-m govuk-!-margin-top-4 govuk-!-margin-bottom-2">{{ application["references"]["second"].type }} reference from {{ application["references"]["second"].name }}</h2>
-  {% set referenceId = "second" %}
-  {% include "_includes/applications/reference.njk" %}
-{% endif %}
 
-{% if application["references"]["third"] %}
-  <h2 class="govuk-heading-m govuk-!-margin-top-4 govuk-!-margin-bottom-2">{{ application["references"]["third"].type }} reference from {{ application["references"]["third"].name }}</h2>
-  {% set referenceId = "third" %}
-  {% include "_includes/applications/reference.njk" %}
+{% if referencesPending | length > 0 %}
+  <h2 class="govuk-heading-m">Requested references</h2>
+  {% for reference in referencesPending %}
+
+    {{ reference | dump }}
+
+
+    <h3 class="govuk-heading-s govuk-!-margin-top-4 govuk-!-margin-bottom-2">{{reference.type }} reference from {{  reference.name }}</h3>
+
+    {{ govukSummaryList({
+      rows: [{
+        key: {
+          text: "Name"
+        },
+        value: {
+          text: reference.name
+        }
+      }, {
+        key: {
+          text: "Email address"
+        },
+        value: {
+          html: "<a href=\"mailto:" + reference.email + "\">" + reference.email + "</a>"
+        }
+      }, {
+        key: {
+          html: "Type"
+        },
+        value: {
+          html: reference.type
+        }
+      }, {
+        key: {
+          text: "How they are known and for how long"
+        },
+        value: {
+          text: reference.relationship.summary | nl2br
+        }
+      }]
+    }) }}
+
+  {% endfor %}
 {% endif %}

--- a/app/views/_includes/applications/references.njk
+++ b/app/views/_includes/applications/references.njk
@@ -6,16 +6,20 @@
 {% set referencesPending = referencesArray | rejectattr("comments") %}
 
 {% if application.status != 'Received' %}
-  <p class="govuk-body">{{ application.personalDetails.name }} has
+  <p class="govuk-body">The candidate has
 
   {%- if referencesReceived | length > 0 %}
     received {{ referencesReceived | length }} {{ "reference" if referencesReceived | length == 1 else "references" }}
   {%- endif %}
   {%- if referencesReceived | length > 0 and referencesPending | length > 0 %}
-    and
+    and has
   {%- endif %}
   {%- if referencesPending | length > 0 %}
-    requested {{ referencesPending | length }} {{ "reference" if referencesPending | length == 1 else "references" }}
+    requested {{ referencesPending | length }}
+  {%- if referencesReceived | length > 0 and referencesPending | length > 0 %}
+    other
+  {%- endif %}
+     {{ "reference" if referencesPending | length == 1 else "references" }}
   {%- endif %}
 .
 </p>
@@ -26,12 +30,21 @@
   {% for reference in referencesReceived %}
 
     {% set relationshipHtml %}
+
+      {% if not reference.relationship.validated %}
+        <p class="govuk-body">The candidate said:</p>
+      {% endif %}
+
       <p class="govuk-body">{{ reference.relationship.summary | nl2br }}</p>
 
       {% if reference.relationship.validated %}
-        <p class="govuk-body">Confirmed by {{ reference.name }}</p>
+        <p class="govuk-body">This was confirmed by {{ reference.name }}.</p>
       {% else %}
-        <p class="govuk-body">No</p>
+        <p class="govuk-body">{{ reference.name }} said:</p>
+
+        <p class="govuk-body">{{ reference.relationship.how_they_know_candidate }}</p>
+
+
       {% endif %}
     {% endset %}
 
@@ -41,7 +54,7 @@
           {{ reference.safeguarding.concerns }}
         </p>
       {%- elif reference.safeguarding.response == "no" -%}
-        <p class="govuk-body">No concerns</p>
+        <p class="govuk-body">No concerns.</p>
       {%- endif -%}
     {%- endset %}
 
@@ -59,33 +72,19 @@
             text: "Email address"
           },
           value: {
-            html: "<a href=\"mailto:" + reference.email + "\">" + reference.email + "</a>"
+            html: reference.email
           }
         }, {
           key: {
-            html: "Type"
-          },
-          value: {
-            html: reference.type
-          }
-        }, {
-          key: {
-            text: "How they are known and for how long"
+            text: "How the candidate knows them and how long for"
           },
           value: {
             text: relationshipHtml | safe
           }
-        }, {
-          key: {
-            text: "Relationship amended by referee"
-          },
-          value: {
-            text: reference.relationship.correction
-          }
-        } if not reference.relationship.validated,
+        },
         {
           key: {
-            text: "Concerns about " + application.personalDetails.name + " working with children"
+            text: "Concerns about the candidate working with children"
           },
           value: {
             html: safeguardingResponseHtml
@@ -93,7 +92,7 @@
         },
         {
           key: {
-            html: "Reference"
+            html: "Does the candidate have the potential to teach?<br><br> Reference<br><br> (depending on when asked)"
           },
           value: {
             html: reference.comments | nl2br
@@ -132,18 +131,11 @@
             text: "Email address"
           },
           value: {
-            html: "<a href=\"mailto:" + reference.email + "\">" + reference.email + "</a>"
+            html: reference.email
           }
         }, {
           key: {
-            html: "Type"
-          },
-          value: {
-            html: reference.type
-          }
-        }, {
-          key: {
-            text: "How they are known and for how long"
+            text: "How the candidate knows them and for how long"
           },
           value: {
             text: reference.relationship.summary | nl2br

--- a/app/views/_includes/applications/references.njk
+++ b/app/views/_includes/applications/references.njk
@@ -87,7 +87,7 @@
         },
         {
           key: {
-            html: "Does the candidate have the potential to teach?<br><br> Reference<br><br> (depending on when asked)"
+            html: "Reference"
           },
           value: {
             html: reference.comments | nl2br

--- a/app/views/_includes/applications/references.njk
+++ b/app/views/_includes/applications/references.njk
@@ -11,17 +11,12 @@
   {%- if referencesReceived | length > 0 %}
     received {{ referencesReceived | length }} {{ "reference" if referencesReceived | length == 1 else "references" }}
   {%- endif %}
-  {%- if referencesReceived | length > 0 and referencesPending | length > 0 %}
-    and has
-  {%- endif %}
-  {%- if referencesPending | length > 0 %}
-    requested {{ referencesPending | length }}
+  {%- if referencesReceived | length > 0 and referencesPending | length > 0 %} and has {%- endif %}
+  {%- if referencesPending | length > 0 %} requested {{ referencesPending | length }}
   {%- if referencesReceived | length > 0 and referencesPending | length > 0 %}
     other
   {%- endif %}
-     {{ "reference" if referencesPending | length == 1 else "references" }}
-  {%- endif %}
-.
+     {{ "reference" if referencesPending | length == 1 else "references" }}{%- endif %}.
 </p>
 {% endif %}
 

--- a/app/views/_includes/applications/references.njk
+++ b/app/views/_includes/applications/references.njk
@@ -5,11 +5,25 @@
 {% set referencesReceived = referencesArray | selectattr("comments") %}
 {% set referencesPending = referencesArray | rejectattr("comments") %}
 
+{% if application.status != 'Received' %}
+  <p class="govuk-body">{{ application.personalDetails.name }} has
+
+  {%- if referencesReceived | length > 0 %}
+    received {{ referencesReceived | length }} {{ "reference" if referencesReceived | length == 1 else "references" }}
+  {%- endif %}
+  {%- if referencesReceived | length > 0 and referencesPending | length > 0 %}
+    and
+  {%- endif %}
+  {%- if referencesPending | length > 0 %}
+    requested {{ referencesPending | length }} {{ "reference" if referencesPending | length == 1 else "references" }}
+  {%- endif %}
+.
+</p>
+{% endif %}
+
 {% if referencesReceived | length > 0 %}
   <h2 class="govuk-heading-m">Received references</h2>
   {% for reference in referencesReceived %}
-
-    <h3 class="govuk-heading-s govuk-!-margin-top-4 govuk-!-margin-bottom-2">{{reference.type }} reference from {{  reference.name }}</h3>
 
     {% set relationshipHtml %}
       <p class="govuk-body">{{ reference.relationship.summary | nl2br }}</p>
@@ -23,119 +37,126 @@
 
     {% set safeguardingResponseHtml -%}
       {%- if reference.safeguarding.response == "yes" -%}
-        <p class="govuk-body">Yes</p>
+        <p class="govuk-body">
+          {{ reference.safeguarding.concerns }}
+        </p>
       {%- elif reference.safeguarding.response == "no" -%}
-        <p class="govuk-body">No</p>
+        <p class="govuk-body">No concerns</p>
       {%- endif -%}
     {%- endset %}
 
-    {{ govukSummaryList({
-      rows: [{
-        key: {
-          text: "Name"
+    {% set summaryCardHtml %}
+      {{ govukSummaryList({
+        rows: [{
+          key: {
+            text: "Name"
+          },
+          value: {
+            text: reference.name
+          }
+        }, {
+          key: {
+            text: "Email address"
+          },
+          value: {
+            html: "<a href=\"mailto:" + reference.email + "\">" + reference.email + "</a>"
+          }
+        }, {
+          key: {
+            html: "Type"
+          },
+          value: {
+            html: reference.type
+          }
+        }, {
+          key: {
+            text: "How they are known and for how long"
+          },
+          value: {
+            text: relationshipHtml | safe
+          }
+        }, {
+          key: {
+            text: "Relationship amended by referee"
+          },
+          value: {
+            text: reference.relationship.correction
+          }
+        } if not reference.relationship.validated,
+        {
+          key: {
+            text: "Concerns about " + application.personalDetails.name + " working with children"
+          },
+          value: {
+            html: safeguardingResponseHtml
+          }
         },
-        value: {
-          text: reference.name
-        }
-      }, {
-        key: {
-          text: "Email address"
-        },
-        value: {
-          html: "<a href=\"mailto:" + reference.email + "\">" + reference.email + "</a>"
-        }
-      }, {
-        key: {
-          html: "Type"
-        },
-        value: {
-          html: reference.type
-        }
-      }, {
-        key: {
-          text: "How they are known and for how long"
-        },
-        value: {
-          text: relationshipHtml | safe
-        }
-      }, {
-        key: {
-          text: "Relationship amended by referee"
-        },
-        value: {
-          text: reference.relationship.correction
-        }
-      } if not reference.relationship.validated,
-      {
-        key: {
-          text: "Does referee know of any reason why this candidate should not work with children?"
-        },
-        value: {
-          html: safeguardingResponseHtml
-        }
-      },
-      {
-        key: {
-          text: "Reason(s) given by referee why this candidate should not work with children"
-        },
-        value: {
-          html: reference.safeguarding.concerns | nl2br
-        }
-      } if reference.safeguarding.response == "yes",
-      {
-        key: {
-          html: "Reference"
-        },
-        value: {
-          html: reference.comments | nl2br
-        }
-      }]
-    }) }}
+        {
+          key: {
+            html: "Reference"
+          },
+          value: {
+            html: reference.comments | nl2br
+          }
+        }]
+      }) }}
+    {% endset %}
+
+    {{appSummaryCard({
+      titleText: reference.type + " reference from " + reference.name,
+      classes: "govuk-!-margin-bottom-6",
+      html: summaryCardHtml
+    })}}
 
   {% endfor %}
 {% endif %}
 
 
 {% if referencesPending | length > 0 %}
-  <h2 class="govuk-heading-m">Requested references</h2>
+  {% if application.status != 'Received' %}
+    <h2 class="govuk-heading-m">Requested references</h2>
+  {% endif %}
   {% for reference in referencesPending %}
 
-    {{ reference | dump }}
+    {% set summaryCardHtml %}
+      {{ govukSummaryList({
+        rows: [{
+          key: {
+            text: "Name"
+          },
+          value: {
+            text: reference.name
+          }
+        }, {
+          key: {
+            text: "Email address"
+          },
+          value: {
+            html: "<a href=\"mailto:" + reference.email + "\">" + reference.email + "</a>"
+          }
+        }, {
+          key: {
+            html: "Type"
+          },
+          value: {
+            html: reference.type
+          }
+        }, {
+          key: {
+            text: "How they are known and for how long"
+          },
+          value: {
+            text: reference.relationship.summary | nl2br
+          }
+        }]
+      }) }}
+    {% endset %}
 
-
-    <h3 class="govuk-heading-s govuk-!-margin-top-4 govuk-!-margin-bottom-2">{{reference.type }} reference from {{  reference.name }}</h3>
-
-    {{ govukSummaryList({
-      rows: [{
-        key: {
-          text: "Name"
-        },
-        value: {
-          text: reference.name
-        }
-      }, {
-        key: {
-          text: "Email address"
-        },
-        value: {
-          html: "<a href=\"mailto:" + reference.email + "\">" + reference.email + "</a>"
-        }
-      }, {
-        key: {
-          html: "Type"
-        },
-        value: {
-          html: reference.type
-        }
-      }, {
-        key: {
-          text: "How they are known and for how long"
-        },
-        value: {
-          text: reference.relationship.summary | nl2br
-        }
-      }]
-    }) }}
+    {{appSummaryCard({
+      titleText: reference.type + " reference from " + reference.name,
+      classes: "govuk-!-margin-bottom-6",
+      html: summaryCardHtml
+    })}}
 
   {% endfor %}
 {% endif %}

--- a/app/views/_includes/applications/sub-nav.njk
+++ b/app/views/_includes/applications/sub-nav.njk
@@ -17,7 +17,7 @@
     html: 'References' + '<span class="govuk-visually-hidden">'+application.personalDetails.name+'</span>',
     href: '/applications/'+application.id+'/references',
     active: (subNavId == "references")
-  } if application.status == 'Conditions pending' or application.status == 'Conditions not met' or application.status == 'Recruited', {
+  }, {
     html: 'Notes' + '<span class="govuk-visually-hidden">'+application.personalDetails.name+'</span>',
     href: '/applications/'+application.id+'/notes',
     active: (subNavId == "notes")

--- a/app/views/applications/references/index.njk
+++ b/app/views/applications/references/index.njk
@@ -27,16 +27,8 @@
       </h2>
 
       {% if application.status == 'Received' %}
-        <p class="govuk-body">References should only be used for safeguarding purposes. They should not be used to assess the quality of candidates.</p>
+        <p class="govuk-body">References will be requested when the candidate accepts an offer. Do not contact these people before then.</p>
 
-        <p class="govuk-body">References will be requested when the candidate accepts an offer. Do not contact the people who can give references before then.</p>
-
-        <hr>
-
-        <p class="govuk-body">Do not contact these people before the candidate has accepted an offer.</p>
-
-
-        {# <p class="govuk-body">You must not contact these references before an offer is accepted.</p> #}
       {% endif %}
     </div>
   </div>

--- a/app/views/applications/references/index.njk
+++ b/app/views/applications/references/index.njk
@@ -20,47 +20,13 @@
   {% include "_includes/applications/sub-nav.njk" %}
 
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-grid-column-full">
 
       <h2 class="govuk-heading-l govuk-!-margin-bottom govuk-!-font-size-36">
         References
       </h2>
 
-
-      <p class="govuk-body">The candidate has received 2 references.</p>
-      {#
-      {% if not application.references.first %}
-        <p class="govuk-body">The candidate has not requested any references yet.</p>
-
-      {% elif application.references.first and not application.references.second %}
-
-        <p class="govuk-body">The candidate has received 1 reference.</p>
-
-        <p class="govuk-body">They have not yet received references from:</p>
-
-        <ul class="govuk-list govuk-list--bullet">
-          <li>1 professional reference requested on 3 June 2022</li>
-          <li>1 character reference requested on 5 June 2022</li>
-        </ul>
-
-      {% elif application.references.first and application.references.second and not application.references.third %}
-
-        <p class="govuk-body">The candidate has received 2 references.</p>
-
-        <p class="govuk-body">They have not yet received references from:</p>
-
-        <ul class="govuk-list govuk-list--bullet">
-          <li>1 professional reference requested on 3 June 2022</li>
-        </ul>
-
-      {% elif application.references.first and application.references.second and application.references.third %}
-
-        <p class="govuk-body">The candidate has received 3 references.</p>
-
-      {% endif %}
- #}
       {% include "_includes/applications/references.njk" %}
-
 
     </div>
   </div>

--- a/app/views/applications/references/index.njk
+++ b/app/views/applications/references/index.njk
@@ -20,7 +20,7 @@
   {% include "_includes/applications/sub-nav.njk" %}
 
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full">
+    <div class="govuk-grid-column-two-thirds">
 
       <h2 class="govuk-heading-l govuk-!-margin-bottom govuk-!-font-size-36">
         References
@@ -33,6 +33,10 @@
 
         {# <p class="govuk-body">You must not contact these references before an offer is accepted.</p> #}
       {% endif %}
+    </div>
+  </div>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
 
       {% include "_includes/applications/references.njk" %}
 

--- a/app/views/applications/references/index.njk
+++ b/app/views/applications/references/index.njk
@@ -29,7 +29,12 @@
       {% if application.status == 'Received' %}
         <p class="govuk-body">References should only be used for safeguarding purposes. They should not be used to assess the quality of candidates.</p>
 
-        <p class="govuk-body">References will be requested when the candidate accepts an offer. Do not contact these people before then.</p>
+        <p class="govuk-body">References will be requested when the candidate accepts an offer. Do not contact the people who can give references before then.</p>
+
+        <hr>
+
+        <p class="govuk-body">Do not contact these people before the candidate has accepted an offer.</p>
+
 
         {# <p class="govuk-body">You must not contact these references before an offer is accepted.</p> #}
       {% endif %}

--- a/app/views/applications/references/index.njk
+++ b/app/views/applications/references/index.njk
@@ -27,7 +27,7 @@
       </h2>
 
       {% if application.status == 'Received' %}
-        <p class="govuk-body">References will be requested when the candidate accepts an offer. Do not contact these people before then.</p>
+        <p class="govuk-body">References will be requested when the candidate accepts an offer. Do not contact these people before then without permission from the candidate.</p>
 
       {% endif %}
     </div>

--- a/app/views/applications/references/index.njk
+++ b/app/views/applications/references/index.njk
@@ -26,6 +26,14 @@
         References
       </h2>
 
+      {% if application.status == 'Received' %}
+        <p class="govuk-body">References should only be used for safeguarding purposes. They should not be used to assess the quality of candidates.</p>
+
+        <p class="govuk-body">References will be requested when the candidate accepts an offer. Do not contact these people before then.</p>
+
+        {# <p class="govuk-body">You must not contact these references before an offer is accepted.</p> #}
+      {% endif %}
+
       {% include "_includes/applications/references.njk" %}
 
     </div>

--- a/scripts/generate-applications.js
+++ b/scripts/generate-applications.js
@@ -212,7 +212,7 @@ const generateFakeApplication = (params = {}) => {
     englishLanguageQualification,
     otherQualifications,
     personalStatement: params.personalStatement || generatePersonalStatement(),
-    references: generateReferences(status),
+    references: params.references || generateReferences(status),
     miscellaneous: params.miscellaneous || faker.lorem.paragraph(),
     safeguarding: params.safeguarding || generateSafeguarding(),
     disability: params.disability || generateDisability()
@@ -252,7 +252,7 @@ const generateFakeApplications = () => {
     studyMode: 'Full time',
     provider: user.organisation.name,
     id: '618451',
-    status: 'Interviewing',
+    status: 'Received',
     assignedUsers: [],
     cycle: CycleHelper.CURRENT_CYCLE.code,
     subject: [
@@ -271,7 +271,6 @@ const generateFakeApplications = () => {
       ],
       isInternationalCandidate: false
     },
-    "submittedDate": "2022-06-01T14:50:44.481+01:00",
     "interviews": {
       "items": [
         {
@@ -486,7 +485,15 @@ const generateFakeApplications = () => {
     },
     otherQualifications: null,
     "references": {
-      "first": {
+      "52523": {
+        "type": "Academic",
+        "name": "Josie Blaine",
+        "email": "madie.olson58@birminghamhigh.birmingham.sch.uk",
+        "relationship": {
+          "summary": "Lecturer at my university."
+        }
+      },
+      "12421": {
         "type": "School based",
         "name": "Madie Olson",
         "email": "madie.olson58@birminghamhigh.birmingham.sch.uk",
@@ -500,7 +507,7 @@ const generateFakeApplications = () => {
         },
         "comments": "Sandra joined our school in September 2017 as a teaching assistant. In the first year, she was assigned to assist one student who has complex medical needs. \n\nAs a result of his illness, this student missed a lot of classes and needed support to catch up. Sandra forged a good relationship with this student and completed training to make sure she could support his healthcare needs. \n\nSandra showed that she was able to provide support in subjects across the curriculum up to GCSE. This year, she has widened her role to include supporting other students with a variety of SEND needs such as learning difficulties and ADHD. \n\nShe works well with teaching staff to ensure that the curriculum is accessible for the students. She is able to give constructive written feedback on learner progress to inform review paperwork and he has attended meetings with parents, learners and professionals. \n\nSandra has also supported students on school trips and coached them during sports sessions. During the pandemic, she kept in regular contact with students and their parents. She was able to give subject advice as well as helping with the use of software. \n\nHaving familiarised herself with the demands of working within a secondary school, Sandra now wants to take the next step and train to become a teacher. I feel she has more than enough experience to do so."
       },
-      "second": {
+      "436346": {
         "type": "Academic",
         "name": "Stephon Lesch",
         "email": "stephon66@birmingham.ac.uk",
@@ -510,7 +517,8 @@ const generateFakeApplications = () => {
           "validated": true
         },
         "safeguarding": {
-          "response": "no"
+          "response": "yes",
+          "concerns": "There was an allegation that Sandra behaved innappropriately with another student. This was not substantiated."
         },
         "comments": "I can confirm that Sandra performed very well in her studies. I have high hopes for the continued development of her career and think she would be well suited for further academic or professional studies, including a vocation such as teaching.\n\nSandra received praise from several tutors during her undergraduate career and was one of the strongest students in her peer group. Her tutors reported that she had a clear and strong motivation to do well in her chosen career. She also had ample experience of the work environment, including the world of journalism.\n\nIn the classes which I taught, Sandra was been attentive, well-read and very well prepared. She always performed the required reading before seminars and participated with strongly reasoned arguments. She was also able to express herself with great passion and clarity, which are useful attributes for teaching. \n\nThis clarity of expression was also reflected in good coursework marks, indicating a strong level of analytical ability based on sound research skills.\n\nI do not know of any reason why Sandra would not make an excellent teacher. I have no doubts about her honesty or integrity or any of the other personal qualities required when working with children. I would strongly recommend her as a candidate."
       }

--- a/scripts/generate-applications.js
+++ b/scripts/generate-applications.js
@@ -212,7 +212,7 @@ const generateFakeApplication = (params = {}) => {
     englishLanguageQualification,
     otherQualifications,
     personalStatement: params.personalStatement || generatePersonalStatement(),
-    references: params.references || generateReferences(),
+    references: generateReferences(status),
     miscellaneous: params.miscellaneous || faker.lorem.paragraph(),
     safeguarding: params.safeguarding || generateSafeguarding(),
     disability: params.disability || generateDisability()
@@ -237,11 +237,13 @@ const generateFakeApplications = () => {
 //     status: 'Received',
 //     cycle: CycleHelper.CURRENT_CYCLE.code
 //   }))
-//
-//   applications.push(generateFakeApplication({
-//     status: 'Received',
-//     cycle: CycleHelper.CURRENT_CYCLE.code
-//   }))
+
+  applications.push(generateFakeApplication({
+    id: '46436',
+    status: 'Received',
+    assignedUsers: [],
+    cycle: CycleHelper.CURRENT_CYCLE.code
+  }))
 
 
   applications.push(generateFakeApplication({
@@ -379,6 +381,24 @@ const generateFakeApplications = () => {
       vocation: "The influence teachers have on young people cannot be understated. My memories of being a student are a testament to that, as my decision to become a teacher has been directly influenced by the positive experiences I had at secondary school.\n\nI feel I have the potential to inspire young people to reach their full potential, just as my teachers motivated me. I am passionate about supporting children to live a happy and healthy life, as well as helping them to develop the skills they need.\n\nWorking at a museum I’ve discovered that I’m able to listen and communicate well with children. I love to see the confidence a child can gain when they feel comfortable and secure.\n\nI have also recently completed a Level 1 in British Sign Language with the support of the museum where I work. This has helped broaden my communication skills as well as highlighting to me the importance of inclusion in education. This is something I hope to explore further when I train to become a teacher.",
       subjectKnowledge: "My current role as a family workshop leader has strengthened my passion to become a teacher. I have gained experience supporting the teaching of the National Curriculum for history, as well as helping students to get the best out of their time at the museum.\n\nOur summer workshops have been particularly rewarding, as students attend daily for a week and I’ve been able to see them develop their confidence from start to finish.\n\nI feel that my current employment has also given me a range of transferable skills. I currently provide training to new members of staff and have also been asked to update existing members of the team on changes to policies and procedures. Therefore I have to ensure that I am adaptable in my approach as I am aware that people all learn differently."
     },
+    "references": {
+      "first": {
+        "type": "Academic",
+        "name": "Jason Barker",
+        "email": "j.barker@birmingham.ac.uk",
+        "relationship": {
+          "summary": "They are my Personal academic tutor (PAT) at university I have known them since starting university in September 2020."
+        },
+      },
+      "second": {
+        "type": "Professional",
+        "name": "Julie Partridge",
+        "email": "julie912@gmail.com",
+        "relationship": {
+          "summary": "I tutored her child in English. I’ve known her for one year"
+        },
+      }
+    }
   }))
 
 

--- a/scripts/generate-applications.js
+++ b/scripts/generate-applications.js
@@ -500,7 +500,8 @@ const generateFakeApplications = () => {
         "tel": "0500 471823",
         "relationship": {
           "summary": "SENCO lead at Birmingham High School where I’ve been working as a Teaching Assistant since 2017.",
-          "validated": true
+          "validated": false,
+          "how_they_know_candidate": "Sandra is a Teaching Assistant in my school. She joined in 2016."
         },
         "safeguarding": {
           "response": "no"
@@ -518,7 +519,7 @@ const generateFakeApplications = () => {
         },
         "safeguarding": {
           "response": "yes",
-          "concerns": "There was an allegation that Sandra behaved innappropriately with another student. This was not substantiated."
+          "concerns": "There was an allegation that Sandra behaved inappropriately with another student. This was not substantiated."
         },
         "comments": "I can confirm that Sandra performed very well in her studies. I have high hopes for the continued development of her career and think she would be well suited for further academic or professional studies, including a vocation such as teaching.\n\nSandra received praise from several tutors during her undergraduate career and was one of the strongest students in her peer group. Her tutors reported that she had a clear and strong motivation to do well in her chosen career. She also had ample experience of the work environment, including the world of journalism.\n\nIn the classes which I taught, Sandra was been attentive, well-read and very well prepared. She always performed the required reading before seminars and participated with strongly reasoned arguments. She was also able to express herself with great passion and clarity, which are useful attributes for teaching. \n\nThis clarity of expression was also reflected in good coursework marks, indicating a strong level of analytical ability based on sound research skills.\n\nI do not know of any reason why Sandra would not make an excellent teacher. I have no doubts about her honesty or integrity or any of the other personal qualities required when working with children. I would strongly recommend her as a candidate."
       }

--- a/scripts/generate-applications.js
+++ b/scripts/generate-applications.js
@@ -506,7 +506,7 @@ const generateFakeApplications = () => {
         "safeguarding": {
           "response": "no"
         },
-        "comments": "Sandra joined our school in September 2017 as a teaching assistant. In the first year, she was assigned to assist one student who has complex medical needs. \n\nAs a result of his illness, this student missed a lot of classes and needed support to catch up. Sandra forged a good relationship with this student and completed training to make sure she could support his healthcare needs. \n\nSandra showed that she was able to provide support in subjects across the curriculum up to GCSE. This year, she has widened her role to include supporting other students with a variety of SEND needs such as learning difficulties and ADHD. \n\nShe works well with teaching staff to ensure that the curriculum is accessible for the students. She is able to give constructive written feedback on learner progress to inform review paperwork and he has attended meetings with parents, learners and professionals. \n\nSandra has also supported students on school trips and coached them during sports sessions. During the pandemic, she kept in regular contact with students and their parents. She was able to give subject advice as well as helping with the use of software. \n\nHaving familiarised herself with the demands of working within a secondary school, Sandra now wants to take the next step and train to become a teacher. I feel she has more than enough experience to do so."
+        "comments": "Sandra joined our school in September 2016 as a Teaching Assistant."
       },
       "436346": {
         "type": "Academic",
@@ -521,7 +521,7 @@ const generateFakeApplications = () => {
           "response": "yes",
           "concerns": "There was an allegation that Sandra behaved inappropriately with another student. This was not substantiated."
         },
-        "comments": "I can confirm that Sandra performed very well in her studies. I have high hopes for the continued development of her career and think she would be well suited for further academic or professional studies, including a vocation such as teaching.\n\nSandra received praise from several tutors during her undergraduate career and was one of the strongest students in her peer group. Her tutors reported that she had a clear and strong motivation to do well in her chosen career. She also had ample experience of the work environment, including the world of journalism.\n\nIn the classes which I taught, Sandra was been attentive, well-read and very well prepared. She always performed the required reading before seminars and participated with strongly reasoned arguments. She was also able to express herself with great passion and clarity, which are useful attributes for teaching. \n\nThis clarity of expression was also reflected in good coursework marks, indicating a strong level of analytical ability based on sound research skills.\n\nI do not know of any reason why Sandra would not make an excellent teacher. I have no doubts about her honesty or integrity or any of the other personal qualities required when working with children. I would strongly recommend her as a candidate."
+        "comments": "Sandra was a student at the University between 2014 and 2017. She graduated with a 2:1 Bachelor of Arts degree in English and journalism."
       }
     },
     schoolExperience: [
@@ -704,7 +704,7 @@ const generateFakeApplications = () => {
         "safeguarding": {
           "response": "no"
         },
-        "comments": "I cannot comment on whether Andy has the potential to teach. I have never met him face to face but we’ve been in contact extensively by email as part of the personal tutoring aspect of his programme. \n\nI can say he has fairly good communication skills and good academic skills overall. \n\nThere have been times where I have thought his professionalism could be improved. I’ve had doubts about his way of handling difficulties which have come up over the course of his degree, particularly in terms of his communication skills. Perhaps this is an area which he can work on further."
+        "comments": "Andy was a student here between 2020 and 2023 studying for a BA in English."
       },
       "second": {
         "type": "Professional",
@@ -718,7 +718,7 @@ const generateFakeApplications = () => {
         "safeguarding": {
           "response": "no"
         },
-        "comments": "I have known Andy for a year. He tutored my 12 year old son in English. He was finding grammar in particular quite difficult but with Andy’s help he is now much more confident.\n\nAndy has always been reliable and shown great communication skills. There have never been any problems with organising dates and times to tutor my son. \n\nI’ve been impressed that Andy has always had clear lesson plans which he’s emailed to me in advance. This has helped to ensure both my son and I were aware of the area which would be taught. But Andy also always left room to amend the lesson if my son needed more attention in a specific area."
+        "comments": "Andy has tutored my 12 year old son in English for the past year."
       }
     },
     schoolExperience: [


### PR DESCRIPTION
We've updated the design to make things a bit clearer.

Changes:

* Moves the references into "summary cards", which gives them a border and a title
* 'Type' row removed, as this is now in the card title
* "How the candidate knows them and how long for" row combines both what the candidate said and what the referee says (if they say it's not correct) or just says it's confirmed.
* "Concerns about the candidate working with children" label updated slightly, and shows either "No concerns" or the concerns given by the referee
* "Reference" contains the actual reference. For carried over references from the past cycle this would say "Does the candidate have the potential to teach?"
* Where the candidate hasn't accepted an offer yet, adds a line of guidance
* Where a candidate has accepted an offer, adds a line summarising how many references in each state. Additional headings separate the different reference states.

## Screenshots

### References before offer is accepted

This includes some guidance about when references are requested and reminding providers not to contact the referees.

![screenshot-localhost_3001-2022 09 21-14_20_44](https://user-images.githubusercontent.com/30665/191514863-da3df469-909a-476d-95c3-7f192a196949.png)

### References after offer has been accepted

#### 2 references received

![refence-received](https://user-images.githubusercontent.com/30665/190670800-f8253487-5883-4f64-8c56-8dc865ec8b4c.png)

#### 2 references received, 1 still pending, safeguarding concern added, relationship updated

![references-requested-and-received](https://user-images.githubusercontent.com/30665/190670931-fb10e2a4-4f2d-4be4-b208-f974fccdcec9.png)
