### PR TITLE
Changed content to match production

### DIFF
--- a/app/views/applications/offer/new/conditions.njk
+++ b/app/views/applications/offer/new/conditions.njk
@@ -63,9 +63,18 @@
 
         <h2 class="govuk-heading-m">References</h2>
 
-        <p class="govuk-body">Candidates will be able to request references if they accept your offer. They’ll be advised that they need to receive 2 references.</p>
+        <p class="govuk-body">The candidate will confirm which references they want to request when they accept your offer.</p>
 
-        <p class="govuk-body">If you have specific reference requirements, you can add them as an offer condition below.</p>
+        <p class="govuk-body">They’ll be told they need 2 references including:</p>
+
+        <ul class="govuk-list govuk-list--bullet">
+
+          <li>an academic tutor if they have graduated in the past 5 years or are still studying</li>
+          <li>the headteacher if they’ve been working in a school</li>
+
+        </ul>
+
+        <p class="govuk-body">Add a further condition if you have other requirements for references.</p>
 
         <div class="app-add-another">
 


### PR DESCRIPTION
The conditions of offer page had an early version of the new references content. I've changed it to match production.