### PR TITLE
Use node 16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,7 @@
         "glob": "^7.1.4"
       },
       "engines": {
-        "node": ">=14.0.0 <17.0.0"
+        "node": "16.x"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "11.0.0",
   "private": true,
   "engines": {
-    "node": ">=14.0.0 <17.0.0"
+    "node": "16.x"
   },
   "scripts": {
     "generate-data": "node ./scripts/generate-organisations.js && node ./scripts/generate-users.js && node ./scripts/generate-locations.js && node ./scripts/generate-courses.js && node ./scripts/generate-applications.js ",


### PR DESCRIPTION
Think this is now required to avoid this Heroku error preventing deployment:

```

       Resolving node version >=14.0.0 <17.0.0...
       Error: Unknown error installing ">=14.0.0 <17.0.0" of node
-----> Build failed

       We're sorry this build is failing! You can troubleshoot common issues here:
       https://devcenter.heroku.com/articles/troubleshooting-node-deploys

       Some possible problems:

       - Dangerous semver range (>) in engines.node
         https://devcenter.heroku.com/articles/nodejs-support#specifying-a-node-js-version
```