### PR TITLE
Add course subject to SKE course condition summary

### DIFF
--- a/app/views/_components/offer-panel/template.njk
+++ b/app/views/_components/offer-panel/template.njk
@@ -160,22 +160,6 @@
       rows: [
         {
           key: {
-            text: "Reason"
-          },
-          value: {
-            text: reasonHtml | safe
-          },
-          actions: {
-            items: [
-              {
-                text: "Change",
-                href: "/applications/" + params.applicationId + "/offer/ske-reason"
-              }
-            ]
-          }
-        },
-        {
-          key: {
             text: "Subject"
           },
           value: {
@@ -194,6 +178,22 @@
               {
                 text: "Change",
                 href: "/applications/" + params.applicationId + "/offer/ske-length"
+              }
+            ]
+          }
+        },
+        {
+          key: {
+            text: "Reason"
+          },
+          value: {
+            text: reasonHtml | safe
+          },
+          actions: {
+            items: [
+              {
+                text: "Change",
+                href: "/applications/" + params.applicationId + "/offer/ske-reason"
               }
             ]
           }

--- a/app/views/_components/offer-panel/template.njk
+++ b/app/views/_components/offer-panel/template.njk
@@ -176,6 +176,14 @@
         },
         {
           key: {
+            text: "Subject"
+          },
+          value: {
+            text: "Mathematics"
+          }
+        },
+        {
+          key: {
             text: "Length"
           },
           value: {


### PR DESCRIPTION
One participant was nervous that, because we didn't mention the subject in the SKE course condition summary, this wouldn't get specified to trainees and so they might go off and try and do a SKE course in a different subject.

Adding this row (uneditable) may help to reassure them that the subject will be specified.

## Screenshot

<img width="680" alt="Screenshot 2022-11-04 at 15 33 26" src="https://user-images.githubusercontent.com/30665/200015007-40ce4fc0-e7e9-47ce-ba2c-348ec7677420.png">
