### PR TITLE
Make SKE course reasons clearer

### DIFF
--- a/app/views/applications/offer/new/ske-reason.njk
+++ b/app/views/applications/offer/new/ske-reason.njk
@@ -31,10 +31,13 @@
               classes: "govuk-fieldset__legend--l"
             }
           },
+          hint: {
+            text: "At least 1 must be selected for the candidate to receive a bursary. We’ll show your answer to the candidate."
+          },
           items: [
             {
-              value: "Their degree is not in " + skeSubject,
-              text: "Their degree is not in " + skeSubject
+              value: "Their degree subject was not " + skeSubject,
+              text: "Their degree subject was not " + skeSubject
             },
             {
               value: "They have not used their degree knowledge for 5 years or more",


### PR DESCRIPTION
One research participant found that that "Their degree is not in Mathematics" was too ambiguous, and discussed how the content of the degree, and which modules were taken, was what mattered.

This change attempts to make it clearer that these reasons are tied to the SKE bursary criteria, and that the first option is based on whether the degree subject exactly matches or not (which we think is the criteria).