### PR TITLE
Make hint text about SKE bursary clearer

### DIFF
--- a/app/views/applications/offer/new/ske-reason.njk
+++ b/app/views/applications/offer/new/ske-reason.njk
@@ -32,7 +32,7 @@
             }
           },
           hint: {
-            text: "Select at least 1 option for the candidate to receive a bursary. We’ll show your answer to the candidate."
+            text: "Select at least 1 option for the candidate to receive the SKE course bursary of £175 a week. We’ll show your answer to the candidate."
           },
           items: [
             {

--- a/app/views/applications/offer/new/ske-reason.njk
+++ b/app/views/applications/offer/new/ske-reason.njk
@@ -26,7 +26,7 @@
           name: "skeReason",
           fieldset: {
             legend: {
-              text: "Why do they need to take a subject knowledge enhancement course?",
+              text: "Why do they need to take a subject knowledge enhancement (SKE) course?",
               isPageHeading: true,
               classes: "govuk-fieldset__legend--l"
             }


### PR DESCRIPTION
Made the hint text about the candidate receiving a bursary clearer to say that its a SKE bursary rather than confusion over ITT or SKE bursary.
<img width="675" alt="Screenshot 2022-11-11 at 09 59 34" src="https://user-images.githubusercontent.com/68232608/201316027-7fc8ec8d-185d-4702-b1a9-01894b77831c.png">
