### PR TITLE
SKE course requirements: languages and PE with Ebacc

### DIFF
--- a/app/filters.js
+++ b/app/filters.js
@@ -417,5 +417,10 @@ filters.falsify = (input) => {
     return last
   }
 
+  filters.push = (array, item) => {
+    array.push(item)
+    return array
+  }
+
   return filters
 }

--- a/app/views/_components/offer-panel/template.njk
+++ b/app/views/_components/offer-panel/template.njk
@@ -147,93 +147,105 @@
 
 <h2 class="govuk-heading-m">Conditions</h2>
 
-{% if params.skeCondition %}
+{% if params.skeConditions %}
 
-  {% set reasonHtml %}
-    {% for reason in params.skeCondition.reason %}
-      {{ reason }} <br>
-    {% endfor %}
-  {% endset %}
+  {% for skeCondition in params.skeConditions %}
 
-  {% set skeSummaryList %}
-    {{ govukSummaryList({
-      rows: [
-        {
-          key: {
-            text: "Subject"
+    {% set reasonHtml %}
+      {% for reason in skeCondition.reason %}
+        {{ reason }} <br>
+      {% endfor %}
+    {% endset %}
+
+    {% set skeSummaryList %}
+      {{ govukSummaryList({
+        rows: [
+          {
+            key: {
+              text: "Subject"
+            },
+            value: {
+              text: skeCondition.subject
+            },
+            actions: {
+              items: [
+                {
+                  text: "Change",
+                  href: "/applications/" + params.applicationId + "/offer/ske"
+                }
+              ]
+            } if skeCondition.subject != "Mathematics"
           },
-          value: {
-            text: "Mathematics"
+          {
+            key: {
+              text: "Length"
+            },
+            value: {
+              text: skeCondition.lengthRequired
+            },
+            actions: {
+              items: [
+                {
+                  text: "Change",
+                  href: "/applications/" + params.applicationId + "/offer/ske-length"
+                }
+              ]
+            }
+          },
+          {
+            key: {
+              text: "Reason"
+            },
+            value: {
+              text: reasonHtml | safe
+            },
+            actions: {
+              items: [
+                {
+                  text: "Change",
+                  href: "/applications/" + params.applicationId + "/offer/ske-reason"
+                }
+              ]
+            }
+          } if skeCondition.reason,
+          {
+            key: {
+              text: "Completed"
+            },
+            value: {
+              text: skeCondition.deadline
+            },
+            actions: {
+              items: [
+                {
+                  text: "Change",
+                  href: "/applications/" + params.applicationId + "/offer/ske-length"
+                }
+              ]
+            }
           }
-        },
-        {
-          key: {
-            text: "Length"
-          },
-          value: {
-            text: params.skeCondition.lengthRequired
-          },
-          actions: {
-            items: [
-              {
-                text: "Change",
-                href: "/applications/" + params.applicationId + "/offer/ske-length"
-              }
-            ]
+
+        ]
+
+      }) }}
+    {% endset %}
+
+    {{ appSummaryCard({
+      titleText: "Subject knowledge enhancement course",
+      classes: "govuk-!-margin-bottom-6",
+      html: skeSummaryList,
+      actions: {
+        items: [
+          {
+            text: "Remove condition",
+            href: "/applications/" + params.applicationId + "/offer/ske"
+
           }
-        },
-        {
-          key: {
-            text: "Reason"
-          },
-          value: {
-            text: reasonHtml | safe
-          },
-          actions: {
-            items: [
-              {
-                text: "Change",
-                href: "/applications/" + params.applicationId + "/offer/ske-reason"
-              }
-            ]
-          }
-        },
-        {
-          key: {
-            text: "Completed"
-          },
-          value: {
-            text: params.skeCondition.deadline
-          },
-          actions: {
-            items: [
-              {
-                text: "Change",
-                href: "/applications/" + params.applicationId + "/offer/ske-length"
-              }
-            ]
-          }
-        }
+        ]
+      }
+    })}}
 
-      ]
-
-    }) }}
-  {% endset %}
-
-  {{ appSummaryCard({
-    titleText: "Subject knowledge enhancement course",
-    classes: "govuk-!-margin-bottom-6",
-    html: skeSummaryList,
-    actions: {
-      items: [
-        {
-          text: "Remove condition",
-          href: "/applications/" + params.applicationId + "/offer/ske"
-
-        }
-      ]
-    }
-  })}}
+  {% endfor %}
 
 {% else %}
   {{ govukSummaryList({

--- a/app/views/applications/offer/new/check.njk
+++ b/app/views/applications/offer/new/check.njk
@@ -22,12 +22,39 @@
       </h1>
 
       {% if data.skeRequired == 'yes' %}
-        {% set skeCondition = {
-          reason: data.skeReason,
-          deadline: data.skeDeadline,
-          lengthRequired: data.skeCourseLengthRequired
-        }
-      %}
+        {% set skeConditions = [{
+            subject: "Mathematics",
+            reason: data.skeReason,
+            deadline: data.skeDeadline,
+            lengthRequired: data.skeCourseLengthRequired
+          }]
+        %}
+      {% elif data.skeEbacc %}
+        {% set skeConditions = [{
+            subject: data.skeEbacc,
+            deadline: data.skeDeadline,
+            lengthRequired: "8 weeks"
+          }]
+        %}
+      {% elif data['skeLanguage'] %}
+
+        {% set skeConditions = [] %}
+
+        {% for language in data['skeLanguage'] %}
+
+          {% set reason = data['skeReason-' + language] %}
+          {% set length = data.skeCourseLengthRequired[language] %}
+
+          {% set skeConditions = skeConditions | push({
+              subject: language,
+              reason: reason,
+              deadline: data.skeDeadline,
+              lengthRequired: length
+            ])
+          %}
+
+        {% endfor %}
+
       {% else %}
         {% set skeCondition = false %}
       {% endif %}
@@ -65,7 +92,7 @@
         changeConditions: {
           href: "/applications/" + application.id + "/offer/new?referrer=check"
         },
-        skeCondition: skeCondition,
+        skeConditions: skeConditions,
         applicationId: applicationId
       }) }}
       </div>

--- a/app/views/applications/offer/new/ske-length.njk
+++ b/app/views/applications/offer/new/ske-length.njk
@@ -77,6 +77,21 @@
           }) }}
 
 
+
+        {{ govukTextarea({
+          name: "more-detail",
+          id: "more-detail",
+          label: {
+            text: "Is there anything else you’d like to tell the candidate about doing a SKE course? (optional)",
+            classes: "govuk-label--m"
+          },
+          hint: {
+            text: "For example, if you recommend a particlar SKE course provider."
+          }
+
+        }) }}
+
+
       {{ govukButton({
         text: "Continue"
       }) }}

--- a/app/views/applications/offer/new/ske-length.njk
+++ b/app/views/applications/offer/new/ske-length.njk
@@ -86,7 +86,7 @@
             classes: "govuk-label--m"
           },
           hint: {
-            text: "For example, if you recommend a particlar SKE course provider."
+            text: "For example, if you recommend a particular SKE course provider."
           }
 
         }) }}

--- a/app/views/applications/offer/new/ske-length.njk
+++ b/app/views/applications/offer/new/ske-length.njk
@@ -16,9 +16,101 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <span class="govuk-caption-l">{{ caption }}</span>
+      <form action="/applications/{{ applicationId }}/offer/ske-length-answer" method="post" accept-charset="UTF-8" novalidate>
+
+      {% if data.skeLanguage and data.skeLanguage | length > 1 %}
+
+        <h1 class="govuk-heading-l">Subject knowledge enhancement (SKE) course requirements</h1>
+
+        {% for language in data.skeLanguage %}
+          {% if language != '_unchecked' %}
+
+            {{ govukRadios({
+              name: "skeCourseLengthRequired[" + language + "]",
+              fieldset: {
+                legend: {
+                  text: "How long must their SKE course in " + language + " be?",
+                  classes: "govuk-fieldset__legend--m"
+                }
+              },
+              items: [
+                {
+                  value: "8 weeks",
+                  text: "8 weeks"
+                },
+                {
+                  value: "12 weeks",
+                  text: "12 weeks"
+                },
+                {
+                  value: "16 weeks",
+                  text: "16 weeks"
+                },
+                {
+                  value: "20 weeks",
+                  text: "20 weeks"
+                },
+                {
+                  value: "24 weeks",
+                  text: "24 weeks"
+                },
+                {
+                  value: "28 weeks",
+                  text: "28 weeks"
+                }
+              ]
+            }) }}
+
+          {% endif %}
+        {% endfor %}
+
+        {{ govukRadios({
+          name: "skeDeadline",
+          fieldset: {
+            legend: {
+              text: "Do their SKE courses have to be completed before their training course starts, in September 2023?",
+              classes: "govuk-fieldset__legend--m"
+            }
+          },
+          items: [
+            {
+              value: "Must be completed before training starts",
+              text: "Yes"
+            },
+            {
+              value: "Can be completed during training course",
+              text: "No, so long as they’ve started it by then"
+            }
+          ]
+        }) }}
+
+      {% elif data.skeEbacc %}
+
+
+          {{ govukRadios({
+            name: "skeDeadline",
+            fieldset: {
+              legend: {
+                text: "Does their 8 week " + data.skeEbacc + " SKE course have to be completed before their training course starts, in September 2023?",
+                classes: "govuk-fieldset__legend--l",
+                isPageHeading: true
+              }
+            },
+            items: [
+              {
+                value: "Must be completed before training starts",
+                text: "Yes"
+              },
+              {
+                value: "Can be completed during training course",
+                text: "No, so long as they’ve started it by then"
+              }
+            ]
+          }) }}
+
+      {% else %}
       <h1 class="govuk-heading-l">Subject knowledge enhancement (SKE) course requirements</h1>
 
-      <form action="/applications/{{ applicationId }}/offer/ske-length-answer" method="post" accept-charset="UTF-8" novalidate>
 
         {{ govukRadios({
           name: "skeCourseLengthRequired",
@@ -77,7 +169,7 @@
           }) }}
 
 
-
+{#
         {{ govukTextarea({
           name: "more-detail",
           id: "more-detail",
@@ -89,8 +181,9 @@
             text: "For example, if you recommend a particular SKE course provider."
           }
 
-        }) }}
+        }) }} #}
 
+      {% endif %}
 
       {{ govukButton({
         text: "Continue"

--- a/app/views/applications/offer/new/ske-reason.njk
+++ b/app/views/applications/offer/new/ske-reason.njk
@@ -5,7 +5,15 @@
 {% set heading = 'Conditions of offer' %}
 {% set title = heading + ' - ' + caption %}
 {% set firstSubject = application.subject | first %}
-{% set skeSubject = firstSubject.name %}
+
+{% if data.skeLanguage and data.skeLanguage | length == 1 %}
+
+  {% set firstLanguage = data.skeLanguage | first %}
+
+  {% set skeSubject = firstLanguage %}
+{% else %}
+  {% set skeSubject = firstSubject.name %}
+{% endif %}
 
 {% block beforeContent %}
   {{ govukBackLink({
@@ -19,32 +27,88 @@
     <div class="govuk-grid-column-two-thirds">
       <span class="govuk-caption-l">{{ caption }}</span>
 
-
       <form action="/applications/{{ applicationId }}/offer/ske-reason-answer" method="post" accept-charset="UTF-8" novalidate>
 
-        {{ govukCheckboxes({
-          name: "skeReason",
-          fieldset: {
-            legend: {
-              text: "Why do they need to take a subject knowledge enhancement (SKE) course?",
-              isPageHeading: true,
-              classes: "govuk-fieldset__legend--l"
-            }
-          },
-          hint: {
-            text: "Select at least 1 option for the candidate to receive the SKE course bursary of £175 a week. We’ll show your answer to the candidate."
-          },
-          items: [
-            {
-              value: "Their degree subject was not " + skeSubject,
-              text: "Their degree subject was not " + skeSubject
+        {% if data.skeLanguage and data.skeLanguage | length > 1 %}
+          <h1 class="govuk-heading-l">Reasons for needing to take a subject knowledge enhancement course</h1>
+
+          {% for language in data.skeLanguage %}
+            {% if language != '_unchecked' %}
+
+              {{ govukCheckboxes({
+                name: "skeReason-" + language,
+                fieldset: {
+                  legend: {
+                    text: "Why do they need to take a course in " + language + "?",
+                    isPageHeading: true,
+                    classes: "govuk-fieldset__legend--m"
+                  }
+                },
+                items: [
+                  {
+                    value: "Their degree subject was not " + language,
+                    text: "Their degree subject was not " + language
+                  },
+                  {
+                    value: "They have not used their degree knowledge for 5 years or more",
+                    text: "They have not used their degree knowledge for 5 years or more"
+                  }
+                ]
+              }) }}
+            {% endif %}
+
+          {% endfor %}
+
+        {% elif data.skeEbacc %}
+
+          {{ govukCheckboxes({
+            name: "skeReason[" + data.skeEbacc + "]",
+            fieldset: {
+              legend: {
+                text: "Why do they need to take a subject knowledge enhancement (SKE) course in " + data.skeEbacc + "?",
+                isPageHeading: true,
+                classes: "govuk-fieldset__legend--l"
+              }
             },
-            {
-              value: "They have not used their degree knowledge for 5 years or more",
-              text: "They have not used their degree knowledge for 5 years or more"
-            }
-          ]
-        }) }}
+            items: [
+              {
+                value: "Their degree subject was not " + data.skeEbacc,
+                text: "Their degree subject was not " + data.skeEbacc
+              },
+              {
+                value: "They have not used their degree knowledge for 5 years or more",
+                text: "They have not used their degree knowledge for 5 years or more"
+              }
+            ]
+          }) }}
+
+        {% else %}
+
+          {{ govukCheckboxes({
+            name: "skeReason",
+            fieldset: {
+              legend: {
+                text: "Why do they need to take a subject knowledge enhancement (SKE) course?",
+                isPageHeading: true,
+                classes: "govuk-fieldset__legend--l"
+              }
+            },
+            hint: {
+              text: "Select at least 1 option for the candidate to receive the SKE course bursary of £175 a week. We’ll show your answer to the candidate."
+            },
+            items: [
+              {
+                value: "Their degree subject was not " + skeSubject,
+                text: "Their degree subject was not " + skeSubject
+              },
+              {
+                value: "They have not used their degree knowledge for 5 years or more",
+                text: "They have not used their degree knowledge for 5 years or more"
+              }
+            ]
+          }) }}
+
+        {% endif %}
 
         {{ govukButton({
           text: "Continue"

--- a/app/views/applications/offer/new/ske.njk
+++ b/app/views/applications/offer/new/ske.njk
@@ -32,7 +32,7 @@
       {% if firstSubject.name == "French" %}
 
         {{ govukCheckboxes({
-          name: "skeRequired",
+          name: "skeLanguage",
           fieldset: {
             legend: {
               text: "Do you require them to take a subject knowledge enhancement course in any of these languages?",
@@ -72,8 +72,10 @@
 
       {% elif firstSubject.name == "PE with Ebacc" %}
 
+        <input type="hidden" name="skeRequired" value="">
+        <input type="hidden" name="skeReason" value="">
         {{ govukRadios({
-          name: "skeRequired",
+          name: "skeEbacc",
           fieldset: {
             legend: {
               text: "Do you require them to take an 8 week subject knowledge enhancement course in an Ebacc subject?",

--- a/app/views/applications/offer/new/ske.njk
+++ b/app/views/applications/offer/new/ske.njk
@@ -7,6 +7,7 @@
 {% set firstSubject = application.subject | first %}
 {% set skeSubject = firstSubject.name %}
 
+
 {% block pageNavigation %}
 {% endblock %}
 
@@ -28,11 +29,109 @@
 -->
       <form action="/applications/{{ applicationId }}/offer/ske-answer" method="post" accept-charset="UTF-8" novalidate>
 
+      {% if firstSubject.name == "French" %}
+
+        {{ govukCheckboxes({
+          name: "skeRequired",
+          fieldset: {
+            legend: {
+              text: "Do you require them to take a subject knowledge enhancement course in any of these languages?",
+              isPageHeading: true,
+              classes: "govuk-fieldset__legend--l"
+            }
+          },
+          hint: {
+            text: "You can select a maximum of 2"
+          },
+          items: [
+            {
+              value: "French",
+              text: "French"
+            },
+            {
+              value: "Spanish",
+              text: "Spanish"
+            },
+            {
+              value: "German",
+              text: "German"
+            },
+            {
+              value: "Ancient languages",
+              text: "Ancient languages"
+            },
+            {
+              divider: "or"
+            },
+            {
+              value: "no",
+              text: "No, a suject knowledge enhancement course is not required"
+            }
+          ]
+        }) }}
+
+      {% elif firstSubject.name == "PE with Ebacc" %}
+
         {{ govukRadios({
           name: "skeRequired",
           fieldset: {
             legend: {
-              text: "Do you require them to take a subject knowledge enhancement course in " + (skeSubject | lower) + "?",
+              text: "Do you require them to take an 8 week subject knowledge enhancement course in an Ebacc subject?",
+              isPageHeading: true,
+              classes: "govuk-fieldset__legend--l"
+            }
+          },
+          items: [
+            {
+              value: "Biology",
+              text: "Biology"
+            },
+            {
+              value: "Chemistry",
+              text: "Chemistry"
+            },
+            {
+              value: "English",
+              text: "English"
+            },
+            {
+              value: "Mathematics",
+              text: "Mathematics"
+            },
+            {
+              value: "Physics",
+              text: "Physics"
+            },
+            {
+              value: "French",
+              text: "French"
+            },
+            {
+              value: "Spanish",
+              text: "Spanish"
+            },
+            {
+              value: "German",
+              text: "German"
+            },
+            {
+              divider: "or"
+            },
+            {
+              value: "no",
+              text: "No, a suject knowledge enhancement course is not required"
+            }
+          ]
+        }) }}
+
+
+      {% else %}
+
+        {{ govukRadios({
+          name: "skeRequired",
+          fieldset: {
+            legend: {
+              text: "Do you require them to take a subject knowledge enhancement course in " + (skeSubject) + "?",
               isPageHeading: true,
               classes: "govuk-fieldset__legend--l"
             }
@@ -49,6 +148,7 @@
           ]
         }) }}
 
+      {% endif %}
 
         {{ govukButton({
           text: "Continue"

--- a/app/views/applications/offer/new/ske.njk
+++ b/app/views/applications/offer/new/ske.njk
@@ -65,7 +65,7 @@
             },
             {
               value: "no",
-              text: "No, a suject knowledge enhancement course is not required"
+              text: "No, a subject knowledge enhancement course is not required"
             }
           ]
         }) }}
@@ -119,7 +119,7 @@
             },
             {
               value: "no",
-              text: "No, a suject knowledge enhancement course is not required"
+              text: "No, a subject knowledge enhancement course is not required"
             }
           ]
         }) }}

--- a/app/views/applications/offer/show.njk
+++ b/app/views/applications/offer/show.njk
@@ -67,7 +67,7 @@
           fundingType: {
             value: application.offer.fundingType
           },
-          skeCondition: application.offer.skeCondition,
+          skeConditions: application.offer.skeConditions,
           changeConditions: {
             href: "/applications/" + application.id + "/offer/edit/conditions?referrer=offer"
           } if application.status == "Offered",

--- a/scripts/generate-applications.js
+++ b/scripts/generate-applications.js
@@ -612,6 +612,60 @@ const generateFakeApplications = () => {
   }))
 
 
+  applications.push(generateFakeApplication({
+    id: '57261',
+    status: 'Received',
+    course: 'French with Spanish (FS23)',
+    assignedUsers: [],
+    cycle: CycleHelper.CURRENT_CYCLE.code,
+    provider: user.organisation.name,
+    subject: [
+      {
+        "code": "F1",
+        "name": "French"
+      },
+      {
+        "code": "S1",
+        "name": "Spanish"
+      }
+    ],
+    personalDetails: {
+      givenName: 'Michelle',
+      familyName: 'Aragon',
+      sex: 'Female',
+      dateOfBirth: '1994-01-03',
+      nationalities: [
+        'British'
+      ],
+      isInternationalCandidate: false
+    }
+  }))
+
+applications.push(generateFakeApplication({
+    id: '3464',
+    status: 'Received',
+    course: 'PE with Ebacc (PE13)',
+    assignedUsers: [],
+    cycle: CycleHelper.CURRENT_CYCLE.code,
+    provider: user.organisation.name,
+    subject: [
+      {
+        "code": "F1",
+        "name": "PE with Ebacc"
+      }
+    ],
+    personalDetails: {
+      givenName: 'John',
+      familyName: 'Routledge',
+      sex: 'Males',
+      dateOfBirth: '1994-01-03',
+      nationalities: [
+        'British'
+      ],
+      isInternationalCandidate: false
+    }
+  }))
+
 
   return applications
 }


### PR DESCRIPTION
The previous iteration focused on Maths courses only, and made the assumption that only a maths SKE course could be required. We think this holds true for maths, but for other courses it’s not quite so simple...

For language courses, providers can require 2 different SKE courses in 2 different languages.  In theory we could possibly infer which 2 languages from the language subjects attached to the course in Find, but in practice a fair number of courses on Find just have "Modern languages" as the subject, so we might need to ask...

➡️ [Preview](https://manage-itt-pr-616.herokuapp.com/start)

## Languages courses

There only seem to be SKE courses for 3 modern languages, plus "Ancient languages", assuming the [course directory](https://www.gov.uk/government/publications/subject-knowledge-enhancement-course-directory/subject-knowledge-enhancement-ske-course-directory#languages) is up to date.

<img width="864" alt="Screenshot 2022-11-11 at 15 52 52" src="https://user-images.githubusercontent.com/30665/201377703-5234bc59-f027-470b-b8eb-203c2adaaf55.png">

If they select 2 languages, then 2 "reasons" are asked for:

<img width="917" alt="Screenshot 2022-11-14 at 13 42 57" src="https://user-images.githubusercontent.com/30665/201675193-ae1271aa-81cb-496a-bdb4-5bf48317564f.png">

If they select 2 languages, then 2 course lengths are asked for, but the deadline is only asked for once (and assumed to apply to both):

<img width="755" alt="Screenshot 2022-11-14 at 13 43 35" src="https://user-images.githubusercontent.com/30665/201675330-7211f98b-b3b1-40ba-ace7-650af738db98.png">

The check your answers page then shows 2 SKE course conditions, with the subjects being editable:

<img width="680" alt="Screenshot 2022-11-14 at 13 44 22" src="https://user-images.githubusercontent.com/30665/201675498-25d45505-34b7-4198-b033-c6b86f939b2b.png">

## PE with Ebacc

For these courses, a SKE course can be required for the [Ebacc subject](https://www.gov.uk/government/publications/english-baccalaureate-ebacc/english-baccalaureate-ebacc) - but only up to 8 weeks

<img width="897" alt="Screenshot 2022-11-11 at 15 44 00" src="https://user-images.githubusercontent.com/30665/201378384-fba5c685-0ee2-4856-ad4d-d4ebe59aaa4f.png">

The 'reasons' page is the same, for now (but maybe the reasons could be different?), except for a wording change in the question:

<img width="645" alt="Screenshot 2022-11-14 at 13 45 04" src="https://user-images.githubusercontent.com/30665/201675635-b59c6fd3-59ca-4c81-95ef-c5cd08a3eeaf.png">

The course length question is not asked (as it has to be 8 weeks) so just the deadline question is asked:

<img width="803" alt="Screenshot 2022-11-14 at 13 45 49" src="https://user-images.githubusercontent.com/30665/201675803-a15a4fa6-30fb-463b-adc7-93ea0adf84c2.png">

The conditions box shows the subject as editable:

<img width="702" alt="Screenshot 2022-11-14 at 13 46 32" src="https://user-images.githubusercontent.com/30665/201675959-13301924-bdc8-4539-af05-fef0fa07e511.png">
