### PR TITLE
Update reject flow to pull out ITT criteria onto separate page

### DIFF
--- a/app/routes/reject-application.js
+++ b/app/routes/reject-application.js
@@ -4,12 +4,15 @@ const content = require('../data/content')
 module.exports = router => {
   router.get('/applications/:applicationId/reject', (req, res) => {
     res.render('applications/reject/index', {
-      application: req.session.data.applications.find(app => app.id === req.params.applicationId)
+      application: req.session.data.applications.find(app => app.id === req.params.applicationId),
+      applicationId: req.params.applicationId
     })
   })
 
-  router.post('/applications/:applicationId/reject', (req, res) => {
-    res.redirect(`/applications/${req.params.applicationId}/reject/check`)
+  router.get('/applications/:applicationId/reject/other', (req, res) => {
+    res.render('applications/reject/other', {
+      application: req.session.data.applications.find(app => app.id === req.params.applicationId)
+    })
   })
 
   router.get('/applications/:applicationId/reject/check', (req, res) => {

--- a/app/views/applications/reject/index.njk
+++ b/app/views/applications/reject/index.njk
@@ -33,12 +33,10 @@
 
       <form method="post" action="/applications/{{ applicationId }}/reject/other">
 
-      <h1 class="govuk-heading-l">ITT criteria</h1>
-
-      <p class="govuk-body">Contact <a href="#" class="govuk-link">becomingateacher@digital.education.gov.uk</a> if you are unsure whether the candidate meets the criteria.</p>
+      <h1 class="govuk-heading-l">Intial teacher training (ITT) criteria</h1>
 
       <h2 class="govuk-heading-m">Degree</h2>
-      <p class="govuk-body">They must have degree comprising of 300 HE credit points, of which 60 must be at level 6 of the QCF. Applicants with a foundation degree will need to supplement this qualification with at least 60 credits at level 6 (HE level 3) in order to attain an equivalent single qualification.</p>
+      <p class="govuk-body">Candidates must have degree comprising of 300 HE credit points, of which 60 must be at level 6 of the QCF. Applicants with a foundation degree will need to supplement this qualification with at least 60 credits at level 6 (HE level 3) in order to attain an equivalent single qualification.</p>
 
       <h2 class="govuk-heading-m">GCSE standard</h2>
       <p class="govuk-body">You can give candidates without a qualification the opportunity to show they meet the required standard by taking an equivalence test or giving other evidence they meet the standard.</p>
@@ -49,7 +47,7 @@
         name: "waste",
         fieldset: {
           legend: {
-            text: "Does " + name + " meet the criteria?",
+            text: "Does " + name + " meet the ITT criteria?",
             isPageHeading: true,
             classes: "govuk-fieldset__legend--m"
           }
@@ -61,19 +59,21 @@
           },
           {
             value: "mines",
-            text: "They meet the maths standard of GCSE C/4"
+            text: "They have a maths GCSE at minimum grade 4 or C, or equivalent"
           },
           {
             value: "farm",
-            text: "They meet the science standard of GCSE C/4"
+            text: "They have an English GCSE at minimum grade 4 or C, or equivalent"
           },
           {
             value: "farm",
-            text: "They meet the English standard of GCSE C/4"
+            text: "They have a science GCSE at minimum grade 4 or C, or equivalent"
           }
 
         ]
       }) }}
+
+      <p class="govuk-body">Contact <a href="#" class="govuk-link">becomingateacher@digital.education.gov.uk</a> if you're unsure whether the candidate meets the criteria.</p>
 
         {{ govukButton({
           text: "Continue"

--- a/app/views/applications/reject/index.njk
+++ b/app/views/applications/reject/index.njk
@@ -31,129 +31,55 @@
         {{heading}}
       {% endset %}
 
-      <form method="post">
+      <form method="post" action="/applications/{{ applicationId }}/reject/other">
 
-        {% set qualificationReasonsHtml %}
-          {% include "_includes/reasons/qualifications.njk" %}
-        {% endset %}
+      <h1 class="govuk-heading-l">ITT criteria</h1>
 
-        {% set personalStatementReasonsHtml %}
-          {% include "_includes/reasons/personal-statement.njk" %}
-        {% endset %}
+      <p class="govuk-body">Contact <a href="#" class="govuk-link">becomingateacher@digital.education.gov.uk</a> if you are unsure whether the candidate meets the criteria.</p>
 
-        {% set teachingKnowledgeReasonsHtml %}
-          {% include "_includes/reasons/teaching-knowledge.njk" %}
-        {% endset %}
+      <h2 class="govuk-heading-m">Degree</h2>
+      <p class="govuk-body">They must have degree comprising of 300 HE credit points, of which 60 must be at level 6 of the QCF. Applicants with a foundation degree will need to supplement this qualification with at least 60 credits at level 6 (HE level 3) in order to attain an equivalent single qualification.</p>
 
-        {% set communicationReasonsHtml %}
-          {% include "_includes/reasons/communication.njk" %}
-        {% endset %}
+      <h2 class="govuk-heading-m">GCSE standard</h2>
+      <p class="govuk-body">You can give candidates without a qualification the opportunity to show they meet the required standard by taking an equivalence test or giving other evidence they meet the standard.</p>
 
-        {% set referencesHtml %}
-          {{appRejectionDetails({ category: 'references', reason: 'details', data: data })}}
-        {% endset %}
 
-        {% set safeguardingHtml %}
-          {{appRejectionDetails({ category: 'safeguarding', reason: 'details', data: data })}}
-        {% endset %}
-
-        {% set sponsorshipHtml %}
-          {{appRejectionDetails({ category: 'sponsorship', reason: 'details', data: data })}}
-        {% endset %}
-
-        {% set otherDetailsHtml %}
-          {{appRejectionDetails({ category: 'other', reason: 'details', data: data })}}
-        {% endset %}
-
-        {{ govukCheckboxes({
-          idPrefix: "rejection-categories",
-          name: "rejection[categories]",
-          fieldset: {
-            legend: {
-              html: h1,
-              isPageHeading: true,
-              classes: "govuk-fieldset__legend--l"
-            }
+      {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
+      {{ govukCheckboxes({
+        name: "waste",
+        fieldset: {
+          legend: {
+            text: "Does " + name + " meet the criteria?",
+            isPageHeading: true,
+            classes: "govuk-fieldset__legend--m"
+          }
+        },
+        items: [
+          {
+            value: "carcasses",
+            text: "They have a degree or equivalent"
           },
-          items: [
-            {
-              value: "Qualifications",
-              text: "Qualifications",
-              checked: checked("['rejection']['categories']", "Qualifications"),
-              conditional: {
-                html: qualificationReasonsHtml
-              }
-            },
-            {
-              value: "Personal statement",
-              text: "Personal statement",
-              checked: checked("['rejection']['categories']", "Personal statement"),
-              conditional: {
-                html: personalStatementReasonsHtml
-              }
-            },
-            {
-              value: "Teaching knowledge and ability",
-              text: "Teaching knowledge and ability",
-              checked: checked("['rejection']['categories']", "Teaching knowledge and ability"),
-              conditional: {
-                html: teachingKnowledgeReasonsHtml
-              }
-            },
-            {
-              value: "Communication, attendance and scheduling",
-              text: "Communication, attendance and scheduling",
-              checked: checked("['rejection']['categandies']", "Communication, attendance or scheduling"),
-              conditional: {
-                html: communicationReasonsHtml
-              }
-            },
-            {
-              value: "References",
-              text: "References",
-              checked: checked("['rejection']['categories']", "References"),
-              conditional: {
-                html: referencesHtml
-              }
-            },
-            {
-              value: "Safeguarding",
-              text: "Safeguarding",
-              checked: checked("['rejection']['categories']", "Safeguarding"),
-              conditional: {
-                html: safeguardingHtml
-              }
-            },
-            {
-              value: "Visa sponsorship",
-              text: "Visa sponsorship",
-              checked: checked("['rejection']['categories']", "Visa sponsorship"),
-              conditional: {
-                html: sponsorshipHtml
-              }
-            },
-            {
-              value: "Course full",
-              text: "Course full",
-              checked: checked("['rejection']['categories']", "Course full")
-            },
-            {
-              value: "Other",
-              text: "Other",
-              checked: checked("['rejection']['categories']", "Other"),
-              conditional: {
-                html: otherDetailsHtml
-              }
-            }
-          ]
-        }) }}
+          {
+            value: "mines",
+            text: "They meet the maths standard of GCSE C/4"
+          },
+          {
+            value: "farm",
+            text: "They meet the science standard of GCSE C/4"
+          },
+          {
+            value: "farm",
+            text: "They meet the English standard of GCSE C/4"
+          }
+
+        ]
+      }) }}
 
         {{ govukButton({
           text: "Continue"
         }) }}
       </form>
 
-      <p class="govuk-body"><a class="govuk-link--no-visited-state" href="/applications/{{ application.id }}">Cancel</a></p>
     </div>
   </div>
 {% endblock %}

--- a/app/views/applications/reject/other.njk
+++ b/app/views/applications/reject/other.njk
@@ -1,0 +1,146 @@
+{% extends "_layout.njk" %}
+
+{% set primaryNavId = 'applications' %}
+{% set name = application.personalDetails.name %}
+
+{% if application.status == "Rejected" %}
+  {% set caption = content.giveFeedback.caption + ' - ' + name %}
+  {% set heading = "Reasons the application was rejected" %}
+{% else %}
+  {% set caption = content.rejectApplication.caption + ' - ' + name %}
+  {% set heading = "Tell " + name + " why you are rejecting their application" %}
+{% endif %}
+{% set title = heading + ' - ' + caption %}
+
+{% block pageNavigation %}
+  {% set backUrl = "/applications/" + application.id + "/decision" %}
+  {% if application.status == "Rejected" %}
+    {% set backUrl = "/applications/" + application.id %}
+  {% endif %}
+
+  {{ govukBackLink({
+    href: backUrl
+  }) }}
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {% set h1 %}
+        {{heading}}
+      {% endset %}
+
+      <form method="post">
+
+        {% set qualificationReasonsHtml %}
+          {% include "_includes/reasons/qualifications.njk" %}
+        {% endset %}
+
+        {% set personalStatementReasonsHtml %}
+          {% include "_includes/reasons/personal-statement.njk" %}
+        {% endset %}
+
+        {% set teachingKnowledgeReasonsHtml %}
+          {% include "_includes/reasons/teaching-knowledge.njk" %}
+        {% endset %}
+
+        {% set communicationReasonsHtml %}
+          {% include "_includes/reasons/communication.njk" %}
+        {% endset %}
+
+        {% set safeguardingHtml %}
+          {{appRejectionDetails({ category: 'safeguarding', reason: 'details', data: data })}}
+        {% endset %}
+
+        {% set sponsorshipHtml %}
+          {{appRejectionDetails({ category: 'sponsorship', reason: 'details', data: data })}}
+        {% endset %}
+
+        {% set otherDetailsHtml %}
+          {{appRejectionDetails({ category: 'other', reason: 'details', data: data })}}
+        {% endset %}
+
+        {{ govukCheckboxes({
+          idPrefix: "rejection-categories",
+          name: "rejection[categories]",
+          fieldset: {
+            legend: {
+              html: h1,
+              isPageHeading: true,
+              classes: "govuk-fieldset__legend--l"
+            }
+          },
+          items: [
+            {
+              value: "Qualifications",
+              text: "Qualifications",
+              checked: checked("['rejection']['categories']", "Qualifications"),
+              conditional: {
+                html: qualificationReasonsHtml
+              }
+            },
+            {
+              value: "Personal statement",
+              text: "Personal statement",
+              checked: checked("['rejection']['categories']", "Personal statement"),
+              conditional: {
+                html: personalStatementReasonsHtml
+              }
+            },
+            {
+              value: "Teaching knowledge and ability",
+              text: "Teaching knowledge and ability",
+              checked: checked("['rejection']['categories']", "Teaching knowledge and ability"),
+              conditional: {
+                html: teachingKnowledgeReasonsHtml
+              }
+            },
+            {
+              value: "Communication, attendance and scheduling",
+              text: "Communication, attendance and scheduling",
+              checked: checked("['rejection']['categandies']", "Communication, attendance or scheduling"),
+              conditional: {
+                html: communicationReasonsHtml
+              }
+            },
+            {
+              value: "Safeguarding",
+              text: "Safeguarding",
+              checked: checked("['rejection']['categories']", "Safeguarding"),
+              conditional: {
+                html: safeguardingHtml
+              }
+            },
+            {
+              value: "Visa sponsorship",
+              text: "Visa sponsorship",
+              checked: checked("['rejection']['categories']", "Visa sponsorship"),
+              conditional: {
+                html: sponsorshipHtml
+              }
+            },
+            {
+              value: "Course full",
+              text: "Course full",
+              checked: checked("['rejection']['categories']", "Course full")
+            },
+            {
+              value: "Other",
+              text: "Other",
+              checked: checked("['rejection']['categories']", "Other"),
+              conditional: {
+                html: otherDetailsHtml
+              }
+            }
+          ]
+        }) }}
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+      </form>
+
+      <p class="govuk-body"><a class="govuk-link--no-visited-state" href="/applications/{{ application.id }}">Cancel</a></p>
+    </div>
+  </div>
+{% endblock %}


### PR DESCRIPTION
This is a sketch of how we might pull out the ITT criteria from the existing "reject" flow onto a separate page, so that we can help encourage providers to get in contact with us if they are not sure if a candidate meets the criteria.

We’re also looking at alternative designs which take a different approach.

## Screenshots

### ITT criteria page

The content here comes from the ITT criteria policy publication - and would likely be rewritten once we had a better understanding of what it actually means

![screenshot-localhost_3001-2023 01 20-14_02_50](https://user-images.githubusercontent.com/30665/213728248-15752060-1efb-4b1d-9144-c44c18e87d90.png)


### Other reasons for rejection

This is unchanged, except that the qualification reasons which represent the ITT criteria could now be removed.

![screenshot-localhost_3001-2023 01 20-14_14_11](https://user-images.githubusercontent.com/30665/213728499-2fbb5b24-3f92-472c-96af-bebd591c55e1.png)


