### PR TITLE
Update reject flow with a page per ITT criteria

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -420,3 +420,10 @@ $statuses: (
 .app-no-spacing-after-last-paragraph p:last-child {
   margin-bottom: 0;
 }
+
+.app-email-preview {
+  margin-top: 20px;
+  border: 5px solid #b1b4b6;
+  padding: 20px;
+  margin-bottom: 30px;
+}

--- a/app/filters.js
+++ b/app/filters.js
@@ -422,5 +422,13 @@ filters.falsify = (input) => {
     return array
   }
 
+  /**
+   * Get number of days from today’s date
+   * @type {String} str
+   */
+  filters.includes = (array, item) => {
+    return array.includes(item)
+  }
+
   return filters
 }

--- a/app/filters.js
+++ b/app/filters.js
@@ -427,7 +427,8 @@ filters.falsify = (input) => {
    * @type {String} str
    */
   filters.includes = (array, item) => {
-    return array.includes(item)
+
+    return array && array.includes(item)
   }
 
   return filters

--- a/app/routes/applications.js
+++ b/app/routes/applications.js
@@ -156,8 +156,6 @@ module.exports = router => {
           (degree.type == 'BA')
       })
 
-      console.log(application.gcse.english)
-
       const hasEnglishGCSE = (
         application.gcse.english.type == 'GCSE' &&
         application.gcse.english.country == 'United Kingdom' &&

--- a/app/routes/applications.js
+++ b/app/routes/applications.js
@@ -149,7 +149,7 @@ module.exports = router => {
     } else if (decision === '2') {
       res.redirect(`/applications/${applicationId}/offer/new/course?referrer=decision`)
     } else {
-      res.redirect(`/applications/${applicationId}/reject`)
+      res.redirect(`/applications/${applicationId}/reject/degree`)
     }
   })
 

--- a/app/routes/reject-application.js
+++ b/app/routes/reject-application.js
@@ -29,7 +29,9 @@ module.exports = router => {
 
 
   router.get('/applications/:applicationId/reject/reasons', (req, res) => {
+    const applicationId = req.params.applicationId
     res.render('applications/reject/reasons', {
+      applicationId: applicationId,
       application: req.session.data.applications.find(app => app.id === req.params.applicationId)
     })
   })

--- a/app/routes/reject-application.js
+++ b/app/routes/reject-application.js
@@ -28,8 +28,20 @@ module.exports = router => {
   })
 
 
-  router.get('/applications/:applicationId/reject/other', (req, res) => {
-    res.render('applications/reject/other', {
+  router.get('/applications/:applicationId/reject/reasons', (req, res) => {
+    res.render('applications/reject/reasons', {
+      application: req.session.data.applications.find(app => app.id === req.params.applicationId)
+    })
+  })
+
+  router.get('/applications/:applicationId/reject/other-reasons', (req, res) => {
+    res.render('applications/reject/other-reasons', {
+      application: req.session.data.applications.find(app => app.id === req.params.applicationId)
+    })
+  })
+
+  router.get('/applications/:applicationId/reject/recommend', (req, res) => {
+    res.render('applications/reject/recommend', {
       application: req.session.data.applications.find(app => app.id === req.params.applicationId)
     })
   })

--- a/app/routes/reject-application.js
+++ b/app/routes/reject-application.js
@@ -97,6 +97,7 @@ module.exports = router => {
     const rejection = req.session.data.rejection
 
     const hasScienceGCSE = (
+      application.gcse.science &&
       application.gcse.science.type == 'GCSE' &&
       application.gcse.science.country == 'United Kingdom' &&
       (

--- a/app/routes/reject-application.js
+++ b/app/routes/reject-application.js
@@ -2,15 +2,45 @@ const ApplicationHelper = require('../data/helpers/application')
 const content = require('../data/content')
 
 module.exports = router => {
-  router.get('/applications/:applicationId/reject', (req, res) => {
-    res.render('applications/reject/index', {
+
+  router.get('/applications/:applicationId/reject/degree', (req, res) => {
+    res.render('applications/reject/degree', {
       application: req.session.data.applications.find(app => app.id === req.params.applicationId)
     })
   })
 
-  router.post('/applications/:applicationId/reject', (req, res) => {
-    res.redirect(`/applications/${req.params.applicationId}/reject/check`)
+  router.get('/applications/:applicationId/reject/maths', (req, res) => {
+    res.render('applications/reject/maths', {
+      application: req.session.data.applications.find(app => app.id === req.params.applicationId)
+    })
   })
+
+  router.get('/applications/:applicationId/reject/english', (req, res) => {
+    res.render('applications/reject/english', {
+      application: req.session.data.applications.find(app => app.id === req.params.applicationId)
+    })
+  })
+
+  router.get('/applications/:applicationId/reject/science', (req, res) => {
+    res.render('applications/reject/science', {
+      application: req.session.data.applications.find(app => app.id === req.params.applicationId)
+    })
+  })
+
+
+  router.get('/applications/:applicationId/reject/other', (req, res) => {
+    res.render('applications/reject/other', {
+      application: req.session.data.applications.find(app => app.id === req.params.applicationId)
+    })
+  })
+
+  // router.get('/applications/:applicationId/reject', (req, res) => {
+  //   res.render('applications/reject/index', {
+  //     application: req.session.data.applications.find(app => app.id === req.params.applicationId),
+  //     applicationId: req.params.applicationId
+  //   })
+  // })
+
 
   router.get('/applications/:applicationId/reject/check', (req, res) => {
     const applicationId = req.params.applicationId

--- a/app/routes/reject-application.js
+++ b/app/routes/reject-application.js
@@ -96,14 +96,26 @@ module.exports = router => {
 
     const rejection = req.session.data.rejection
 
+    const hasScienceGCSE = (
+      application.gcse.science.type == 'GCSE' &&
+      application.gcse.science.country == 'United Kingdom' &&
+      (
+       ["A", "B", "C"].includes(application.gcse.science.grade[0].grade)
+      )
+    )
+
     const metDegreeCriteria = (rejection.degreeCriteria == 'met')
     const metEnglishCriteria = (rejection.englishCriteria == 'met-qualification' || rejection.englishCriteria == 'met-standard')
     const metMathsCriteria = (rejection.mathsCriteria == 'met-qualification' || rejection.mathsCriteria == 'met-standard')
 
     const metAllITTCriteria = (metDegreeCriteria && metEnglishCriteria && metMathsCriteria)
 
+    /* If it’s a primary course and they don’t have a GCSE in a Science of C/4 or above */
+    if (application.subject[0].name == "Primary" && !hasScienceGCSE) {
+
+      res.redirect(`/applications/${applicationId}/reject/science`)
     /* If they met the degree, English and maths criteria */
-    if (metAllITTCriteria) {
+    } else if (metAllITTCriteria) {
       res.redirect(`/applications/${applicationId}/reject/reasons`)
 
     /* If they didn’t meet one of the ITT criteria */
@@ -121,6 +133,30 @@ module.exports = router => {
     })
   })
 
+  router.post('/applications/:applicationId/reject/science-answer', (req, res) => {
+    const applicationId = req.params.applicationId
+    const application = req.session.data.applications.find(app => app.id === applicationId)
+
+    const rejection = req.session.data.rejection
+
+    const metDegreeCriteria = (rejection.degreeCriteria == 'met')
+    const metEnglishCriteria = (rejection.englishCriteria == 'met-qualification' || rejection.englishCriteria == 'met-standard')
+    const metMathsCriteria = (rejection.mathsCriteria == 'met-qualification' || rejection.mathsCriteria == 'met-standard')
+    const metScienceCriteria = (rejection.scienceCriteria == 'met-qualification' || rejection.scienceCriteria == 'met-standard')
+
+
+    const metAllITTCriteria = (metDegreeCriteria && metEnglishCriteria && metMathsCriteria && metScienceCriteria)
+
+    /* If they met the degree, English, maths and science criteria */
+    if (metAllITTCriteria) {
+      res.redirect(`/applications/${applicationId}/reject/reasons`)
+
+    /* If they didn’t meet one of the ITT criteria */
+    } else {
+      res.redirect(`/applications/${applicationId}/reject/other-reasons`)
+    }
+
+  })
 
   router.get('/applications/:applicationId/reject/reasons', (req, res) => {
     const applicationId = req.params.applicationId

--- a/app/routes/reject-application.js
+++ b/app/routes/reject-application.js
@@ -69,30 +69,15 @@ module.exports = router => {
     const applicationId = req.params.applicationId
     const application = req.session.data.applications.find(app => app.id === applicationId)
 
-    ApplicationHelper.getUpcomingInterviews(application).forEach((interview) => {
-      ApplicationHelper.cancelInterview({ application, interview, cancellationReason: "Your application was unsuccessful." })
+    application.status = 'Rejected'
+    application.rejectedDate = application.rejectedFeedbackDate = new Date().toISOString()
+    application.rejectedReasons = JSON.parse(JSON.stringify(req.session.data.rejection))
+    req.flash('success', content.rejectApplication.successMessage)
+    ApplicationHelper.addEvent(application, {
+      "title": content.rejectApplication.event.title,
+      "user": "Ben Brown",
+      "date": new Date().toISOString()
     })
-
-    if(application.status == "Rejected") {
-      application.rejectedReasons = ApplicationHelper.getRejectReasons(req.session.data.rejection)
-      application.rejectedFeedbackDate = new Date().toISOString()
-      req.flash('success', content.giveFeedback.successMessage)
-      ApplicationHelper.addEvent(application, {
-        "title": content.giveFeedback.event.title,
-        "user": "Ben Brown",
-        "date": new Date().toISOString()
-      })
-    } else {
-      application.status = 'Rejected'
-      application.rejectedDate = application.rejectedFeedbackDate = new Date().toISOString()
-      application.rejectedReasons = ApplicationHelper.getRejectReasons(req.session.data.rejection)
-      req.flash('success', content.rejectApplication.successMessage)
-      ApplicationHelper.addEvent(application, {
-        "title": content.rejectApplication.event.title,
-        "user": "Ben Brown",
-        "date": new Date().toISOString()
-      })
-    }
 
     delete req.session.data.rejection
     res.redirect(`/applications/${applicationId}/feedback`)

--- a/app/routes/reject-application.js
+++ b/app/routes/reject-application.js
@@ -9,10 +9,44 @@ module.exports = router => {
     })
   })
 
-  router.get('/applications/:applicationId/reject/maths', (req, res) => {
-    res.render('applications/reject/maths', {
-      application: req.session.data.applications.find(app => app.id === req.params.applicationId)
-    })
+  router.post('/applications/:applicationId/reject/degree-answer', (req, res) => {
+    const applicationId = req.params.applicationId
+    const application = req.session.data.applications.find(app => app.id === applicationId)
+
+
+    const hasMathsGCSE = (
+      application.gcse.maths.type == 'GCSE' &&
+      application.gcse.maths.country == 'United Kingdom' &&
+      (
+       ["A", "B", "C"].includes(application.gcse.maths.grade[0].grade)
+      )
+    )
+
+    const hasEnglishGCSE = (
+      application.gcse.english.type == 'GCSE' &&
+      application.gcse.english.country == 'United Kingdom' &&
+      (
+       ["A", "B", "C"].includes(application.gcse.english.grade[0].grade)
+      )
+    )
+
+    /* If they don't have an English GCSE C/4 or above */
+    if (!hasEnglishGCSE) {
+      res.redirect(`/applications/${applicationId}/reject/english`)
+
+    /* If they don’t have a Maths GCSE C/4 or above */
+    } else if (!hasMathsGCSE) {
+      res.redirect(`/applications/${applicationId}/reject/maths`)
+
+    /* If they meet the degree criteria and have English and maths GCSEs */
+    } else if (hasMathsGCSE && hasEnglishGCSE) {
+      res.redirect(`/applications/${applicationId}/reject/reasons`)
+
+    /* If they didn’t meet the degree criteria but have English and maths GCSEs */
+    } else {
+      res.redirect(`/applications/${applicationId}/reject/other-reasons`)
+    }
+
   })
 
   router.get('/applications/:applicationId/reject/english', (req, res) => {
@@ -21,7 +55,67 @@ module.exports = router => {
     })
   })
 
+  router.post('/applications/:applicationId/reject/english-answer', (req, res) => {
+    const applicationId = req.params.applicationId
+    const application = req.session.data.applications.find(app => app.id === applicationId)
+
+
+    const hasMathsGCSE = (
+      application.gcse.maths.type == 'GCSE' &&
+      application.gcse.maths.country == 'United Kingdom' &&
+      (
+       ["A", "B", "C"].includes(application.gcse.maths.grade[0].grade)
+      )
+    )
+
+
+    /* If they don’t have a Maths GCSE C/4 or above */
+    if (!hasMathsGCSE) {
+      res.redirect(`/applications/${applicationId}/reject/maths`)
+
+    /* If they meet the degree criteria and the English criteria and has a math GCSEs */
+    } else if (hasMathsGCSE) {
+      res.redirect(`/applications/${applicationId}/reject/reasons`)
+
+    /* If they didn’t meet the degree criteria or the English criteria */
+    } else {
+      res.redirect(`/applications/${applicationId}/reject/other-reasons`)
+    }
+
+  })
+
+  router.get('/applications/:applicationId/reject/maths', (req, res) => {
+    res.render('applications/reject/maths', {
+      application: req.session.data.applications.find(app => app.id === req.params.applicationId)
+    })
+  })
+
+  router.post('/applications/:applicationId/reject/maths-answer', (req, res) => {
+    const applicationId = req.params.applicationId
+    const application = req.session.data.applications.find(app => app.id === applicationId)
+
+    const rejection = req.session.data.rejection
+
+    const metDegreeCriteria = (rejection.metDegreeCriteria == 'met')
+    const metEnglishCriteria = (rejection.englishCriteria == 'met-qualifications' || rejection.englishCriteria == 'met-standard')
+    const metMathsCriteria = (rejection.mathsCriteria == 'met-qualifications' || rejection.mathsCriteria == 'met-standard')
+
+    const metAllITTCriteria = (metDegreeCriteria && metEnglishCriteria && metMathsCriteria)
+
+    /* If they met the degree, English and maths criteria */
+    if (metAllITTCriteria) {
+      res.redirect(`/applications/${applicationId}/reject/reasons`)
+
+    /* If they didn’t meet one of the ITT criteria */
+    } else {
+      res.redirect(`/applications/${applicationId}/reject/other-reasons`)
+    }
+
+  })
+
   router.get('/applications/:applicationId/reject/science', (req, res) => {
+    const applicationId = req.params.applicationId
+
     res.render('applications/reject/science', {
       application: req.session.data.applications.find(app => app.id === req.params.applicationId)
     })
@@ -37,7 +131,10 @@ module.exports = router => {
   })
 
   router.get('/applications/:applicationId/reject/other-reasons', (req, res) => {
+    const applicationId = req.params.applicationId
+
     res.render('applications/reject/other-reasons', {
+      applicationId: applicationId,
       application: req.session.data.applications.find(app => app.id === req.params.applicationId)
     })
   })
@@ -47,13 +144,6 @@ module.exports = router => {
       application: req.session.data.applications.find(app => app.id === req.params.applicationId)
     })
   })
-
-  // router.get('/applications/:applicationId/reject', (req, res) => {
-  //   res.render('applications/reject/index', {
-  //     application: req.session.data.applications.find(app => app.id === req.params.applicationId),
-  //     applicationId: req.params.applicationId
-  //   })
-  // })
 
 
   router.get('/applications/:applicationId/reject/check', (req, res) => {

--- a/app/routes/reject-application.js
+++ b/app/routes/reject-application.js
@@ -96,9 +96,9 @@ module.exports = router => {
 
     const rejection = req.session.data.rejection
 
-    const metDegreeCriteria = (rejection.metDegreeCriteria == 'met')
-    const metEnglishCriteria = (rejection.englishCriteria == 'met-qualifications' || rejection.englishCriteria == 'met-standard')
-    const metMathsCriteria = (rejection.mathsCriteria == 'met-qualifications' || rejection.mathsCriteria == 'met-standard')
+    const metDegreeCriteria = (rejection.degreeCriteria == 'met')
+    const metEnglishCriteria = (rejection.englishCriteria == 'met-qualification' || rejection.englishCriteria == 'met-standard')
+    const metMathsCriteria = (rejection.mathsCriteria == 'met-qualification' || rejection.mathsCriteria == 'met-standard')
 
     const metAllITTCriteria = (metDegreeCriteria && metEnglishCriteria && metMathsCriteria)
 

--- a/app/views/_includes/applications/gcses.njk
+++ b/app/views/_includes/applications/gcses.njk
@@ -6,7 +6,7 @@
       {% set gradesHtml %}
         <ul class="govuk-list">
         {% for grade in item.grade %}
-          <li>{{ grade.grade }}{% if grade.exam %} ({{ grade.exam }}){% endif %}</li>
+          <li>{{ grade.grade }}{% if grade.subject %} ({{ grade.subject }}){% endif %}</li>
         {% endfor %}
         </ul>
       {% endset %}

--- a/app/views/_includes/candidate-feedback.njk
+++ b/app/views/_includes/candidate-feedback.njk
@@ -14,15 +14,15 @@
     {% endif %}
 
     {% if rejectionReasons.englishCriteria == 'not-met' %}
-      <p class="govuk-body">You do not have a qualification that’s equivalent to an English GCSE at grade 4 ( C) or above. We also cannot offer an equivalency test.</p>
+      <p class="govuk-body">You do not have an English GCSE at grade 4(C) or above, or an equivalent qualification. We also cannot offer an equivalency test.</p>
     {% endif %}
 
     {% if rejectionReasons.mathsCriteria == 'not-met' %}
-      <p class="govuk-body">You do not have a qualification that’s equivalent to a maths GCSE at grade 4 ( C) or above. We also cannot offer an equivalency test.</p>
+      <p class="govuk-body">You do not have a maths GCSE at grade 4(C) or above, or an equivalent qualification. We also cannot offer an equivalency test.</p>
     {% endif %}
 
     {% if rejectionReasons.scienceCriteria == 'not-met' %}
-      <p class="govuk-body">You do not have a qualification that’s equivalent to a GCSE in a science subject at grade 4 ( C) or above. We also cannot offer an equivalency test.</p>
+      <p class="govuk-body">You do not have a GCSE in a science subject at grade 4(C) or above, or an equivalent qualification. We also cannot offer an equivalency test.</p>
     {% endif %}
 
     {% if rejectionReasons.categories | includes("degree-subject") %}

--- a/app/views/_includes/candidate-feedback.njk
+++ b/app/views/_includes/candidate-feedback.njk
@@ -21,6 +21,10 @@
       <p class="govuk-body">You do not have an GCSE in Maths at grade C (4) or above, or equivalent, and we are not able to offer you an equivalency test.</p>
     {% endif %}
 
+    {% if rejectionReasons.scienceCriteria == 'not-met' %}
+      <p class="govuk-body">You do not have an GCSE in a science at grade C (4) or above, or equivalent, and we are not able to offer you an equivalency test.</p>
+    {% endif %}
+
     {% if rejectionReasons.categories | includes("degree-subject") %}
       <p class="govuk-body govuk-!-margin-bottom-1">Subject knowledge:</p>
       <p class="govuk-body">{{ rejectionReasons.degreeSubjectDetails }}</p>

--- a/app/views/_includes/candidate-feedback.njk
+++ b/app/views/_includes/candidate-feedback.njk
@@ -10,23 +10,23 @@
   <div class="govuk-inset-text">
 
     {% if rejectionReasons.degreeCriteria == 'not-met' %}
-      <p class="govuk-body">You do not have an undergraduate degree, or equivalent.</p>
+      <p class="govuk-body">You do not have an undergraduate degree or a qualification that meets the same standard.</p>
     {% endif %}
 
     {% if rejectionReasons.englishCriteria == 'not-met' %}
-      <p class="govuk-body">You do not have an GCSE in English at grade C (4) or above, or equivalent, and we are not able to offer you an equivalency test.</p>
+      <p class="govuk-body">You do not have a qualification that’s equivalent to an English GCSE at grade 4 ( C) or above. We also cannot offer an equivalency test.</p>
     {% endif %}
 
     {% if rejectionReasons.mathsCriteria == 'not-met' %}
-      <p class="govuk-body">You do not have an GCSE in Maths at grade C (4) or above, or equivalent, and we are not able to offer you an equivalency test.</p>
+      <p class="govuk-body">You do not have a qualification that’s equivalent to a maths GCSE at grade 4 ( C) or above. We also cannot offer an equivalency test.</p>
     {% endif %}
 
     {% if rejectionReasons.scienceCriteria == 'not-met' %}
-      <p class="govuk-body">You do not have an GCSE in a science at grade C (4) or above, or equivalent, and we are not able to offer you an equivalency test.</p>
+      <p class="govuk-body">You do not have a qualification that’s equivalent to a GCSE in a science subject at grade 4 ( C) or above. We also cannot offer an equivalency test.</p>
     {% endif %}
 
     {% if rejectionReasons.categories | includes("degree-subject") %}
-      <p class="govuk-body govuk-!-margin-bottom-1">Subject knowledge:</p>
+      <p class="govuk-body govuk-!-margin-bottom-1">Knowledge of the subject you want to teach:</p>
       <p class="govuk-body">{{ rejectionReasons.degreeSubjectDetails }}</p>
     {% endif %}
 
@@ -41,7 +41,7 @@
     {% endif %}
 
     {% if rejectionReasons.categories | includes("communication") %}
-      <p class="govuk-body govuk-!-margin-bottom-1">We could not get in touch with you:</p>
+      <p class="govuk-body govuk-!-margin-bottom-1">Could not contact you:</p>
       <p class="govuk-body">{{ rejectionReasons.communicationDetails }}</p>
     {% endif %}
 
@@ -51,12 +51,12 @@
     {% endif %}
 
     {% if rejectionReasons.categories | includes("interview-performance") %}
-      <p class="govuk-body govuk-!-margin-bottom-1">Interview:</p>
+      <p class="govuk-body govuk-!-margin-bottom-1">Feedback on your interview:</p>
       <p class="govuk-body">{{ rejectionReasons.interviewPerformanceDetails }}</p>
     {% endif %}
 
     {% if rejectionReasons.categories | includes("safeguarding") %}
-      <p class="govuk-body govuk-!-margin-bottom-1">Safeguarding:</p>
+      <p class="govuk-body govuk-!-margin-bottom-1">Safeguarding concerns:</p>
       <p class="govuk-body">{{ rejectionReasons.safeguardingDetails }}</p>
     {% endif %}
 
@@ -64,6 +64,12 @@
       <p class="govuk-body govuk-!-margin-bottom-1">Visa sponsorship:</p>
       <p class="govuk-body">{{ rejectionReasons.visaSponsorshipDetails }}</p>
     {% endif %}
+
+        {% if rejectionReasons.categories | includes("course-full") %}
+      <p class="govuk-body govuk-!-margin-bottom-1">The course is full:</p>
+      <p class="govuk-body">{{ rejectionReasons.courseFullDetails }}</p>
+    {% endif %}
+
 
     <p class="govuk-body">{{ rejectionReasons.advice }}</p>
   </div>

--- a/app/views/_includes/candidate-feedback.njk
+++ b/app/views/_includes/candidate-feedback.njk
@@ -8,6 +8,19 @@
   <p class="govuk-body">They’ve given the following feedback to explain their decision:</p>
 
   <div class="govuk-inset-text">
+
+    {% if rejectionReasons.degreeCriteria == 'not-met' %}
+      <p class="govuk-body">You do not have an undergraduate degree, or equivalent.</p>
+    {% endif %}
+
+    {% if rejectionReasons.englishCriteria == 'not-met' %}
+      <p class="govuk-body">You do not have an GCSE in English at grade C (4) or above, or equivalent, and we are not able to offer you an equivalency test.</p>
+    {% endif %}
+
+    {% if rejectionReasons.mathsCriteria == 'not-met' %}
+      <p class="govuk-body">You do not have an GCSE in Maths at grade C (4) or above, or equivalent, and we are not able to offer you an equivalency test.</p>
+    {% endif %}
+
     {% if rejectionReasons.categories | includes("degree-subject") %}
       <p class="govuk-body govuk-!-margin-bottom-1">Subject knowledge:</p>
       <p class="govuk-body">{{ rejectionReasons.degreeSubjectDetails }}</p>

--- a/app/views/_includes/candidate-feedback.njk
+++ b/app/views/_includes/candidate-feedback.njk
@@ -1,293 +1,55 @@
-{% if showChangeLinks %}
-{% set changeHtml %}
-  <dd class="govuk-summary-list__actions">
-    <a class="govuk-link" href="/applications/{{application.id}}/reject">
-      Change<span class="govuk-visually-hidden"> name</span>
-    </a>
-  </dd>
-{% endset %}
-{% endif %}
+<div class="app-email-preview">
+  <p class="govuk-body">Dear {{ name }},</p>
 
-{{ rejectionReasons | dump }}
+  <p class="govuk-body">Thank you for your application to study {{ application.course }} at {{ application.provider }}.</p>
 
-<dl class="govuk-summary-list">
-  {% set checkboxValue = 'Qualifications' %}
-  {% set category = 'qualifications' %}
-  {% set groupName = category + '-reasons' %}
-  {% if rejectionReasons.categories and checkboxValue in rejectionReasons.categories %}
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        {{checkboxValue}}
-      </dt>
-      <dd class="govuk-summary-list__value">
-        <ul class="govuk-list app-list--spaced">
-        {% set checkboxValue = "No maths GCSE at minimum grade 4 or C, or equivalent" %}
-        {% if rejectionReasons[groupName] and checkboxValue in rejectionReasons[groupName] %}
-          <li>{{checkboxValue}}.</li>
-        {% endif %}
+  <p class="govuk-body">On this occasion, the provider is not offering you a place on this course.</p>
 
-        {% set checkboxValue = "No English GCSE at minimum grade 4 or C, or equivalent" %}
-        {% if rejectionReasons[groupName] and checkboxValue in rejectionReasons[groupName] %}
-          <li>{{checkboxValue}}.</li>
-        {% endif %}
+  <p class="govuk-body">They’ve given the following feedback to explain their decision:</p>
 
-        {% set checkboxValue = "No science GCSE at minimum grade 4 or C, or equivalent" %}
-        {% if rejectionReasons[groupName] and checkboxValue in rejectionReasons[groupName] %}
-          <li>{{checkboxValue}}.</li>
-        {% endif %}
+  <div class="govuk-inset-text">
+    {% if rejectionReasons.categories | includes("degree-subject") %}
+      <p class="govuk-body govuk-!-margin-bottom-1">Subject knowledge:</p>
+      <p class="govuk-body">{{ rejectionReasons.degreeSubjectDetails }}</p>
+    {% endif %}
 
-        {% set checkboxValue = "No bachelor’s degree or equivalent" %}
-        {% if rejectionReasons[groupName] and checkboxValue in rejectionReasons[groupName] %}
-          <li>{{checkboxValue}}.</li>
-        {% endif %}
+    {% if rejectionReasons.categories | includes("degree-class") %}
+      <p class="govuk-body govuk-!-margin-bottom-1">Degree class:</p>
+      <p class="govuk-body">{{ rejectionReasons.degreeClassDetails }}</p>
+    {% endif %}
 
-        {% set checkboxValue = "Degree does not meet course requirements" %}
-        {% if rejectionReasons[groupName] and checkboxValue in rejectionReasons[groupName] %}
-          <li>
-            <p>{{checkboxValue}}:</p>
-            <p>{{rejectionReasons[groupName + '-degree-does-not-meet-course-requirements'] | nl2br | safe}}</p>
-          </li>
-        {% endif %}
+    {% if rejectionReasons.categories | includes("personal-statement") %}
+      <p class="govuk-body govuk-!-margin-bottom-1">Personal statement:</p>
+      <p class="govuk-body">{{ rejectionReasons.personalStatementDetails }}</p>
+    {% endif %}
 
-        {% set checkboxValue = "Could not verify qualifications" %}
-        {% if rejectionReasons[groupName] and checkboxValue in rejectionReasons[groupName] %}
-          <li>
-            <p>{{checkboxValue}}:</p>
-            <p>{{rejectionReasons[groupName + '-could-not-verify-qualifications'] | nl2br | safe}}</p>
-          </li>
-        {% endif %}
+    {% if rejectionReasons.categories | includes("communication") %}
+      <p class="govuk-body govuk-!-margin-bottom-1">We could not get in touch with you:</p>
+      <p class="govuk-body">{{ rejectionReasons.communicationDetails }}</p>
+    {% endif %}
 
-        {% set checkboxValue = "Other" %}
-        {% if rejectionReasons[groupName] and checkboxValue in rejectionReasons[groupName] %}
-          <li>
-            <p>Other:</p>
-            <p>{{rejectionReasons[groupName + '-other'] | nl2br | safe}}</p>
-          </li>
-        {% endif %}
+    {% if rejectionReasons.categories | includes("interview") %}
+      <p class="govuk-body govuk-!-margin-bottom-1">Could not arrange interview:</p>
+      <p class="govuk-body">{{ rejectionReasons.couldNotArrangeInterviewDetails }}</p>
+    {% endif %}
 
-      </ul>
-      </dd>
-      {{changeHtml | safe}}
-    </div>
-  {% endif %}
+    {% if rejectionReasons.categories | includes("interview-performance") %}
+      <p class="govuk-body govuk-!-margin-bottom-1">Interview:</p>
+      <p class="govuk-body">{{ rejectionReasons.interviewPerformanceDetails }}</p>
+    {% endif %}
 
-  {% set checkboxValue = 'Personal statement' %}
-  {% set category = 'personal-statement' %}
-  {% set groupName = category + '-reasons' %}
-  {% if rejectionReasons.categories and checkboxValue in rejectionReasons.categories %}
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        {{checkboxValue}}
-      </dt>
-      <dd class="govuk-summary-list__value">
-        <ul class="govuk-list app-list--spaced">
+    {% if rejectionReasons.categories | includes("safeguarding") %}
+      <p class="govuk-body govuk-!-margin-bottom-1">Safeguarding:</p>
+      <p class="govuk-body">{{ rejectionReasons.safeguardingDetails }}</p>
+    {% endif %}
 
-          {% set checkboxValue = "Quality of writing" %}
-          {% if rejectionReasons[groupName] and checkboxValue in rejectionReasons[groupName] %}
-            <li>
-              <p>{{checkboxValue}}:</p>
-              <p>{{rejectionReasons[groupName + '-quality-of-writing'] | nl2br | safe}}</p>
-            </li>
-          {% endif %}
+    {% if rejectionReasons.categories | includes("visa-sponsorship") %}
+      <p class="govuk-body govuk-!-margin-bottom-1">Visa sponsorship:</p>
+      <p class="govuk-body">{{ rejectionReasons.visaSponsorshipDetails }}</p>
+    {% endif %}
 
-          {% set checkboxValue = "Other" %}
-          {% if rejectionReasons[groupName] and checkboxValue in rejectionReasons[groupName] %}
-            <li>
-              <p>Other:</p>
-              <p>{{rejectionReasons[groupName + '-other'] | nl2br | safe}}</p>
-            </li>
-          {% endif %}
+    <p class="govuk-body">{{ rejectionReasons.advice }}</p>
+  </div>
 
-        </ul>
-      </dd>
-      {{changeHtml | safe}}
-    </div>
-  {% endif %}
-
-  {% set checkboxValue = 'Teaching knowledge and ability' %}
-  {% set category = 'teaching-knowledge' %}
-  {% set groupName = category + '-reasons' %}
-  {% if rejectionReasons.categories and checkboxValue in rejectionReasons.categories %}
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        {{checkboxValue}}
-      </dt>
-      <dd class="govuk-summary-list__value">
-        <ul class="govuk-list app-list--spaced">
-
-          {% set checkboxValue = "Subject knowledge" %}
-          {% if rejectionReasons[groupName] and checkboxValue in rejectionReasons[groupName] %}
-            <li>
-              <p>{{checkboxValue}}:</p>
-              <p>{{rejectionReasons[groupName + '-subject'] | nl2br | safe}}</p>
-            </li>
-          {% endif %}
-
-          {% set checkboxValue = "Safeguarding knowledge" %}
-          {% if rejectionReasons[groupName] and checkboxValue in rejectionReasons[groupName] %}
-            <li>
-              <p>{{checkboxValue}}:</p>
-              <p>{{rejectionReasons[groupName + '-safeguarding'] | nl2br | safe}}</p>
-            </li>
-          {% endif %}
-
-          {% set checkboxValue = "Teaching method knowledge" %}
-          {% if rejectionReasons[groupName] and checkboxValue in rejectionReasons[groupName] %}
-            <li>
-              <p>{{checkboxValue}}:</p>
-              <p>{{rejectionReasons[groupName + '-teaching-method'] | nl2br | safe}}</p>
-            </li>
-          {% endif %}
-
-          {% set checkboxValue = "Teaching role knowledge" %}
-          {% if rejectionReasons[groupName] and checkboxValue in rejectionReasons[groupName] %}
-            <li>
-              <p>{{checkboxValue}}:</p>
-              <p>{{rejectionReasons[groupName + '-teaching-role'] | nl2br | safe}}</p>
-            </li>
-          {% endif %}
-
-          {% set checkboxValue = "Teaching demonstration" %}
-          {% if rejectionReasons[groupName] and checkboxValue in rejectionReasons[groupName] %}
-            <li>
-              <p>{{checkboxValue}}:</p>
-              <p>{{rejectionReasons[groupName + '-teaching-demonstration'] | nl2br | safe}}</p>
-            </li>
-          {% endif %}
-
-          {% set checkboxValue = "Other" %}
-          {% if rejectionReasons[groupName] and checkboxValue in rejectionReasons[groupName] %}
-            <li>
-              <p>Other:</p>
-              <p>{{rejectionReasons[groupName + '-other'] | nl2br | safe}}</p>
-            </li>
-          {% endif %}
-        </ul>
-      </dd>
-      {{changeHtml | safe}}
-    </div>
-  {% endif %}
-
-  {% set checkboxValue = 'Communication, attendance and scheduling' %}
-  {% set category = 'communication' %}
-  {% set groupName = category + '-reasons' %}
-  {% if rejectionReasons.categories and checkboxValue in rejectionReasons.categories %}
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        {{checkboxValue}}
-      </dt>
-      <dd class="govuk-summary-list__value">
-        <ul class="govuk-list app-list--spaced">
-
-          {% set checkboxValue = "Did not reply to messages" %}
-          {% if rejectionReasons[groupName] and checkboxValue in rejectionReasons[groupName] %}
-            <li>
-              <p>{{checkboxValue}}:</p>
-              <p>{{rejectionReasons[groupName + '-did-not-reply-to-messages'] | nl2br | safe}}</p>
-            </li>
-          {% endif %}
-
-          {% set checkboxValue = "Did not attend interview" %}
-          {% if rejectionReasons[groupName] and checkboxValue in rejectionReasons[groupName] %}
-            <li>
-              <p>{{checkboxValue}}:</p>
-              <p>{{rejectionReasons[groupName + '-did-not-attend-interview'] | nl2br | safe}}</p>
-            </li>
-          {% endif %}
-
-          {% set checkboxValue = "Could not arrange interview" %}
-          {% if rejectionReasons[groupName] and checkboxValue in rejectionReasons[groupName] %}
-            <li>
-              <p>{{checkboxValue}}:</p>
-              <p>{{rejectionReasons[groupName + '-could-not-arrange-interview'] | nl2br | safe}}</p>
-            </li>
-          {% endif %}
-
-          {% set checkboxValue = "Other" %}
-          {% if rejectionReasons[groupName] and checkboxValue in rejectionReasons[groupName] %}
-            <li>
-              <p>Other:</p>
-              <p>{{rejectionReasons[groupName + '-other'] | nl2br | safe}}</p>
-            </li>
-          {% endif %}
-
-        </ul>
-      </dd>
-      {{changeHtml | safe}}
-    </div>
-  {% endif %}
-
-  {% set checkboxValue = 'References' %}
-  {% set category = 'references' %}
-  {% set groupName = category + '-reasons' %}
-  {% if rejectionReasons.categories and checkboxValue in rejectionReasons.categories %}
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        {{checkboxValue}}
-      </dt>
-      <dd class="govuk-summary-list__value">
-        <p>{{rejectionReasons[groupName + '-details']}}</p>
-      </dd>
-      {{changeHtml | safe}}
-    </div>
-  {% endif %}
-
-  {% set checkboxValue = 'Safeguarding' %}
-  {% set category = 'safeguarding' %}
-  {% set groupName = category + '-reasons' %}
-  {% if rejectionReasons.categories and checkboxValue in rejectionReasons.categories %}
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        {{checkboxValue}}
-      </dt>
-      <dd class="govuk-summary-list__value">
-        <p>{{rejectionReasons[groupName + '-details'] | nl2br | safe}}</p>
-      </dd>
-      {{changeHtml | safe}}
-    </div>
-  {% endif %}
-
-  {% set checkboxValue = 'Visa sponsorship' %}
-  {% set category = 'sponsorship' %}
-  {% set groupName = category + '-reasons' %}
-  {% if rejectionReasons.categories and checkboxValue in rejectionReasons.categories %}
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        {{checkboxValue}}
-      </dt>
-      <dd class="govuk-summary-list__value">
-        <p>{{rejectionReasons[groupName + '-details'] | nl2br | safe}}</p>
-      </dd>
-      {{changeHtml | safe}}
-    </div>
-  {% endif %}
-
-  {% set checkboxValue = 'Course full' %}
-  {% set category = 'course-full' %}
-  {% if rejectionReasons.categories and checkboxValue in rejectionReasons.categories %}
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        {{checkboxValue}}
-      </dt>
-      <dd class="govuk-summary-list__value">
-        <p>The course is full.</p>
-      </dd>
-      {{changeHtml | safe}}
-    </div>
-  {% endif %}
-
-  {% set checkboxValue = 'Other' %}
-  {% set category = 'other' %}
-  {% set groupName = category + '-reasons' %}
-  {% if rejectionReasons.categories and checkboxValue in rejectionReasons.categories %}
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        {{checkboxValue}}
-      </dt>
-      <dd class="govuk-summary-list__value">
-        <p>{{rejectionReasons[groupName + '-details'] | nl2br | safe}}</p>
-      </dd>
-      {{changeHtml | safe}}
-    </div>
-  {% endif %}
-</dl>
+   <p class="govuk-body">Contact {{ application.provider }} if you would like to talk about their feedback.</p>
+</div>

--- a/app/views/_includes/candidate-feedback.njk
+++ b/app/views/_includes/candidate-feedback.njk
@@ -8,6 +8,8 @@
 {% endset %}
 {% endif %}
 
+{{ rejectionReasons | dump }}
+
 <dl class="govuk-summary-list">
   {% set checkboxValue = 'Qualifications' %}
   {% set category = 'qualifications' %}

--- a/app/views/_includes/reasons/personal-statement.njk
+++ b/app/views/_includes/reasons/personal-statement.njk
@@ -1,5 +1,16 @@
 {% set category = 'personal-statement' %}
 
+{% from "govuk/components/textarea/macro.njk" import govukTextarea %}
+{{ govukTextarea({
+  name: "more-detail",
+  id: "more-detail",
+  label: {
+    text: "Give details",
+    classes: "govuk-label--s"
+  }
+}) }}
+
+{#
 {% set qualityOfWritingHtml %}
   {{appRejectionDetails({ category: category, reason: 'quality-of-writing', data: data })}}
 {% endset %}
@@ -34,4 +45,4 @@
         html: otherHtml
       }
     }]
-}) }}
+}) }} #}

--- a/app/views/_includes/reasons/qualifications.njk
+++ b/app/views/_includes/reasons/qualifications.njk
@@ -22,41 +22,19 @@
     }
   },
   items: [{
-    value: "No maths GCSE at minimum grade 4 or C, or equivalent",
-    html: "No maths GCSE at minimum grade 4 or C, or equivalent",
-    checked: checked("['rejection']['" + category + "-reasons']", "No maths GCSE at minimum grade 4 or C, or equivalent")
-  }, {
-    value: "No English GCSE at minimum grade 4 or C, or equivalent",
-    text: "No English GCSE at minimum grade 4 or C, or equivalent",
-    checked: checked("['rejection']['" + category + "-reasons']", "No English GCSE at minimum grade 4 or C, or equivalent")
-  }, {
-    value: "No science GCSE at minimum grade 4 or C, or equivalent",
-    text: "No science GCSE at minimum grade 4 or C, or equivalent",
-    checked: checked("['rejection']['" + category + "-reasons']", "No science GCSE at minimum grade 4 or C, or equivalent")
-  }, {
-    value: "No bachelor’s degree or equivalent",
-    text: "No bachelor’s degree or equivalent",
-    checked: checked("['rejection']['" + category + "-reasons']", "No bachelor’s degree or equivalent")
-  }, {
-    value: "Degree does not meet course requirements",
-    text: "Degree does not meet course requirements",
+    value: "Degree subject does not meet course requirements",
+    text: "Degree subject does not meet course requirements",
     checked: checked("['rejection']['" + category + "-reasons']", "Degree does not meet course requirements"),
     conditional: {
       html: degreeDoesNotMeetRequirementsHtml
     }
-  }, {
-    value: "Could not verify qualifications",
-    text: "Could not verify qualifications",
-    checked: checked("['rejection']['" + category + "-reasons']", "Could not verify qualifications"),
+  },
+  {
+    value: "Degree class does not meet course requirements",
+    text: "Degree class does not meet course requirements",
+    checked: checked("['rejection']['" + category + "-reasons']", "Degree does not meet course requirements"),
     conditional: {
-      html: couldNotVertifyQualificationsHtml
+      html: degreeDoesNotMeetRequirementsHtml
     }
-  }, {
-      value: "Other",
-      text: "Other",
-      checked: checked("['rejection']['" + category + "-reasons']", "Other"),
-      conditional: {
-        html: otherHtml
-      }
-    }]
+  }]
 }) }}

--- a/app/views/applications/reject/check.njk
+++ b/app/views/applications/reject/check.njk
@@ -51,6 +51,34 @@
 
       {% endif %}
 
+{{ govukRadios({
+        name: "degree",
+        fieldset: {
+          legend: {
+            text: "Would you recommend this candidate?",
+            isPageHeading: true,
+            classes: "govuk-fieldset__legend--m"
+          }
+        },
+        hint: {
+          text: "These candidates will be invited to join a list of candidates who  providers can contact to directly offer places or interviews."
+        },
+        items: [
+          {
+            value: "england",
+            text: "Yes, they should be invited"
+          },
+          {
+            value: "scotland",
+            text: "No",
+            hint: {
+              text: "Your answer will not be shown to the candidate"
+            }
+          }
+        ]
+      }) }}
+
+
       <form method="post">
         {{ govukButton({
           text: buttonText

--- a/app/views/applications/reject/check.njk
+++ b/app/views/applications/reject/check.njk
@@ -32,33 +32,37 @@
       <p class="govuk-body">The candidate will be sent this email:</p>
       {% include "_includes/candidate-feedback.njk" %}
 
-    {{ govukRadios({
-        name: "degree",
-        fieldset: {
-          legend: {
-            text: "Would you recommend this candidate?",
-            isPageHeading: true,
-            classes: "govuk-fieldset__legend--m"
-          }
-        },
-        hint: {
-          text: "Candidates that meet the ITT criteria will be invited to join a shortlist where providers can contact them directly to offer places or interviews."
-        },
-        items: [
-          {
-            value: "england",
-            text: "Yes, they should be invited"
-          },
-          {
-            value: "scotland",
-            text: "No",
-            hint: {
-              text: "Your answer will not be shown to the candidate"
-            }
-          }
-        ]
-      }) }}
 
+    {% if rejectionReasons.degreeCriteria == 'not-met' or rejectionReasons.englishCriteria == 'not-met' or rejectionReasons.mathsCriteria == 'not-met'  or rejectionReasons.scienceCriteria == 'not-met' %}
+
+    {% else %}
+      {{ govukRadios({
+          name: "degree",
+          fieldset: {
+            legend: {
+              text: "Would you recommend this candidate?",
+              isPageHeading: true,
+              classes: "govuk-fieldset__legend--m"
+            }
+          },
+          hint: {
+            text: "Candidates that meet the ITT criteria will be invited to join a shortlist where providers can contact them directly to offer places or interviews."
+          },
+          items: [
+            {
+              value: "england",
+              text: "Yes, they should be invited"
+            },
+            {
+              value: "scotland",
+              text: "No",
+              hint: {
+                text: "Your answer will not be shown to the candidate"
+              }
+            }
+          ]
+        }) }}
+      {% endif %}
 
       <form method="post">
         {{ govukButton({

--- a/app/views/applications/reject/check.njk
+++ b/app/views/applications/reject/check.njk
@@ -16,7 +16,7 @@
 
 {% block pageNavigation %}
   {{ govukBackLink({
-    href: "/applications/" + application.id + "/reject"
+    href: "/applications/" + application.id + "/reject/reasons"
   }) }}
 {% endblock %}
 
@@ -28,28 +28,44 @@
 
       {% set rejectionReasons = data.rejection %}
       {% set showChangeLinks = true %}
-      {% include "_includes/candidate-feedback.njk" %}
 
-      {% if upcomingInterviews.length == 1 %}
-         {{ govukWarningText({
-          text: "The candidate will be sent emails to tell them why you rejected their application and that the upcoming interview has been cancelled."
-        }) }}
-      {% elseif upcomingInterviews.length > 1 %}
-        {{ govukWarningText({
-          text: "The candidate will be sent emails to tell them why you rejected their application and that the upcoming interviews have been cancelled."
-        }) }}
-      {% else %}
-        {% if application.status == "Rejected" %}
-          {{ govukWarningText({
-          text: "The candidate will be sent an email to tell them why their application was rejected."
-        }) }}
-        {% else %}
-          {{ govukWarningText({
-          text: "The candidate will be sent an email to tell them why you rejected their application."
-        }) }}
-        {% endif %}
+      <p class="govuk-body">The candidate will be sent this email:</p>
 
-      {% endif %}
+      <div class="app-email-preview">
+        <p class="govuk-body">Dear {{ name }},</p>
+
+        <p class="govuk-body">Thank you for your application to study {{ application.course }} at {{ application.provider }}.</p>
+
+        <p class="govuk-body">On this occasion, the provider is not offering you a place on this course.</p>
+
+        <p class="govuk-body">They’ve given the following feedback to explain their decision:</p>
+
+        <div class="govuk-inset-text">
+          {% if rejectionReasons.categories | includes("degree-subject") %}
+            <p class="govuk-body govuk-!-margin-bottom-1">Subject knowledge:</p>
+            <p class="govuk-body">{{ rejectionReasons.degreeSubjectDetails }}</p>
+          {% endif %}
+
+          {% if rejectionReasons.categories | includes("degree-class") %}
+            <p class="govuk-body govuk-!-margin-bottom-1">Degree class:</p>
+            <p class="govuk-body">{{ rejectionReasons.degreeClassDetails }}</p>
+          {% endif %}
+
+          {% if rejectionReasons.categories | includes("personal-statement") %}
+            <p class="govuk-body govuk-!-margin-bottom-1">Personal statement:</p>
+            <p class="govuk-body">{{ rejectionReasons.personalStatementDetails }}</p>
+          {% endif %}
+
+          {% if rejectionReasons.categories | includes("visa-sponsorship") %}
+            <p class="govuk-body govuk-!-margin-bottom-1">Visa sponsorship:</p>
+            <p class="govuk-body">{{ rejectionReasons.visaSponsorshipDetails }}</p>
+          {% endif %}
+
+          <p class="govuk-body">{{ rejectionReasons.advice }}</p>
+        </div>
+
+         <p class="govuk-body">Contact {{ application.provider }} if you would like to talk about their feedback.</p>
+      </div>
 
 {{ govukRadios({
         name: "degree",

--- a/app/views/applications/reject/check.njk
+++ b/app/views/applications/reject/check.njk
@@ -61,7 +61,7 @@
           }
         },
         hint: {
-          text: "These candidates will be invited to join a list of candidates who  providers can contact to directly offer places or interviews."
+          text: "Candidates that meet the ITT criteria will be invited to join a shortlist where providers can contact them directly to offer places or interviews."
         },
         items: [
           {

--- a/app/views/applications/reject/check.njk
+++ b/app/views/applications/reject/check.njk
@@ -30,44 +30,9 @@
       {% set showChangeLinks = true %}
 
       <p class="govuk-body">The candidate will be sent this email:</p>
+      {% include "_includes/candidate-feedback.njk" %}
 
-      <div class="app-email-preview">
-        <p class="govuk-body">Dear {{ name }},</p>
-
-        <p class="govuk-body">Thank you for your application to study {{ application.course }} at {{ application.provider }}.</p>
-
-        <p class="govuk-body">On this occasion, the provider is not offering you a place on this course.</p>
-
-        <p class="govuk-body">They’ve given the following feedback to explain their decision:</p>
-
-        <div class="govuk-inset-text">
-          {% if rejectionReasons.categories | includes("degree-subject") %}
-            <p class="govuk-body govuk-!-margin-bottom-1">Subject knowledge:</p>
-            <p class="govuk-body">{{ rejectionReasons.degreeSubjectDetails }}</p>
-          {% endif %}
-
-          {% if rejectionReasons.categories | includes("degree-class") %}
-            <p class="govuk-body govuk-!-margin-bottom-1">Degree class:</p>
-            <p class="govuk-body">{{ rejectionReasons.degreeClassDetails }}</p>
-          {% endif %}
-
-          {% if rejectionReasons.categories | includes("personal-statement") %}
-            <p class="govuk-body govuk-!-margin-bottom-1">Personal statement:</p>
-            <p class="govuk-body">{{ rejectionReasons.personalStatementDetails }}</p>
-          {% endif %}
-
-          {% if rejectionReasons.categories | includes("visa-sponsorship") %}
-            <p class="govuk-body govuk-!-margin-bottom-1">Visa sponsorship:</p>
-            <p class="govuk-body">{{ rejectionReasons.visaSponsorshipDetails }}</p>
-          {% endif %}
-
-          <p class="govuk-body">{{ rejectionReasons.advice }}</p>
-        </div>
-
-         <p class="govuk-body">Contact {{ application.provider }} if you would like to talk about their feedback.</p>
-      </div>
-
-{{ govukRadios({
+    {{ govukRadios({
         name: "degree",
         fieldset: {
           legend: {

--- a/app/views/applications/reject/degree.njk
+++ b/app/views/applications/reject/degree.njk
@@ -40,6 +40,8 @@
 
       <p class="govuk-body">They must have degree comprising of 300 HE credit points, of which 60 must be at level 6 of the QCF. Applicants with a foundation degree will need to supplement this qualification with at least 60 credits at level 6 (HE level 3) in order to attain an equivalent single qualification.</p>
 
+      <p class="govuk-body">Contact <a href="#">becomingateacher@digital.education.gov.uk</a> if you are not sure they meet the criteria.</p>
+
 
       <p class="govuk-body">{{ name }} added {% if degrees | length > 1 %}these qualifications{% else %}this qualification{% endif %}:</p>
 
@@ -138,9 +140,6 @@
             isPageHeading: true,
             classes: "govuk-fieldset__legend--m"
           }
-        },
-        hint: {
-          text: "If you are not sure, contact us."
         },
         items: [
           {

--- a/app/views/applications/reject/degree.njk
+++ b/app/views/applications/reject/degree.njk
@@ -1,0 +1,165 @@
+{% extends "_layout.njk" %}
+
+{% set primaryNavId = 'applications' %}
+{% set name = application.personalDetails.name %}
+
+{% if application.status == "Rejected" %}
+  {% set caption = content.giveFeedback.caption + ' - ' + name %}
+  {% set heading = "Reasons the application was rejected" %}
+{% else %}
+  {% set caption = content.rejectApplication.caption + ' - ' + name %}
+  {% set heading = "Reasons for rejecting the application" %}
+{% endif %}
+{% set title = heading + ' - ' + caption %}
+
+
+{% set degrees = application.degree %}
+
+{% block pageNavigation %}
+  {% set backUrl = "/applications/" + application.id + "/decision" %}
+  {% if application.status == "Rejected" %}
+    {% set backUrl = "/applications/" + application.id %}
+  {% endif %}
+
+  {{ govukBackLink({
+    href: backUrl
+  }) }}
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {% set h1 %}
+        <span class="govuk-caption-l">{{caption}}</span>
+        {{heading}}
+      {% endset %}
+
+      <form method="post" action="/applications/{{ application.id }}/reject/maths">
+
+      <h1 class="govuk-heading-l">Degree</h1>
+
+      <p class="govuk-body">They must have degree comprising of 300 HE credit points, of which 60 must be at level 6 of the QCF. Applicants with a foundation degree will need to supplement this qualification with at least 60 credits at level 6 (HE level 3) in order to attain an equivalent single qualification.</p>
+
+
+      <p class="govuk-body">{{ name }} added {% if degrees | length > 1 %}these qualifications{% else %}this qualification{% endif %}:</p>
+
+
+{% for item in degrees %}
+
+
+    <dl class="govuk-summary-list">
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Degree type
+        </dt>
+        <dd class="govuk-summary-list__value">
+          {{ item.type }}
+        </dd>
+      </div>
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Subject
+        </dt>
+        <dd class="govuk-summary-list__value">
+          {{ item.subject }}
+        </dd>
+      </div>
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Institution
+        </dt>
+        <dd class="govuk-summary-list__value">
+          {{ item.institution }}
+        </dd>
+      </div>
+
+      {% if item.predicted %}
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Have you completed this degree?
+        </dt>
+        <dd class="govuk-summary-list__value">
+          No
+        </dd>
+      </div>
+      {% endif %}
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          {{ 'Predicted grade' if item.predicted else 'Grade' }}
+        </dt>
+        <dd class="govuk-summary-list__value">
+          {{ item.grade }}
+        </dd>
+      </div>
+
+      {% if item.country != "United Kingdom" %}
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Country or territory
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {{ item.country }}
+          </dd>
+        </div>
+      {% endif %}
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Start year
+        </dt>
+        <dd class="govuk-summary-list__value">
+          {{ item.startYear }}
+        </dd>
+      </div>
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Graduation year
+        </dt>
+        <dd class="govuk-summary-list__value">
+          {{ item.graduationYear }}
+        </dd>
+      </div>
+
+    </dl>
+{% endfor %}
+
+      {% from "govuk/components/radios/macro.njk" import govukRadios %}
+
+      {{ govukRadios({
+        name: "degree",
+        fieldset: {
+          legend: {
+            text: "Do they meet the degree criteria?",
+            isPageHeading: true,
+            classes: "govuk-fieldset__legend--m"
+          }
+        },
+        hint: {
+          text: "If you are not sure, contact us."
+        },
+        items: [
+          {
+            value: "england",
+            text: "Yes"
+          },
+          {
+            value: "scotland",
+            text: "No"
+          }
+        ]
+      }) }}
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+      </form>
+
+      <p class="govuk-body"><a class="govuk-link--no-visited-state" href="/applications/{{ application.id }}">Cancel</a></p>
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/applications/reject/degree.njk
+++ b/app/views/applications/reject/degree.njk
@@ -34,7 +34,7 @@
         {{heading}}
       {% endset %}
 
-      <form method="post" action="/applications/{{ application.id }}/reject/maths">
+      <form method="post" action="/applications/{{ application.id }}/reject/degree-answer">
 
       <h1 class="govuk-heading-l">Degree criteria</h1>
 
@@ -133,7 +133,7 @@
       {% from "govuk/components/radios/macro.njk" import govukRadios %}
 
       {{ govukRadios({
-        name: "degree",
+        name: "rejection[degreeCriteria]",
         fieldset: {
           legend: {
             text: "Do they meet the degree criteria?",
@@ -143,12 +143,14 @@
         },
         items: [
           {
-            value: "england",
-            text: "Yes"
+            value: "met",
+            text: "Yes",
+            checked: (data.rejection.degreeCriteria == 'met')
           },
           {
-            value: "scotland",
-            text: "No"
+            value: "not-met",
+            text: "No",
+            checked: (data.rejection.degreeCriteria == 'not-met')
           }
         ]
       }) }}

--- a/app/views/applications/reject/degree.njk
+++ b/app/views/applications/reject/degree.njk
@@ -36,11 +36,11 @@
 
       <form method="post" action="/applications/{{ application.id }}/reject/maths">
 
-      <h1 class="govuk-heading-l">Degree</h1>
+      <h1 class="govuk-heading-l">Degree criteria</h1>
 
-      <p class="govuk-body">They must have degree comprising of 300 HE credit points, of which 60 must be at level 6 of the QCF. Applicants with a foundation degree will need to supplement this qualification with at least 60 credits at level 6 (HE level 3) in order to attain an equivalent single qualification.</p>
+      <p class="govuk-body">Entrants to initial teacher training must have degree comprising of 300 HE credit points, of which 60 must be at level 6 of the QCF. Candidates with a foundation degree will need to supplement this qualification with at least 60 credits at level 6 (HE level 3) in order to attain an equivalent single qualification.</p>
 
-      <p class="govuk-body">Contact <a href="#">becomingateacher@digital.education.gov.uk</a> if you are not sure they meet the criteria.</p>
+      <p class="govuk-body">Contact <a href="#">becomingateacher@digital.education.gov.uk</a> if you're not sure this candidate meets the criteria.</p>
 
 
       <p class="govuk-body">{{ name }} added {% if degrees | length > 1 %}these qualifications{% else %}this qualification{% endif %}:</p>

--- a/app/views/applications/reject/english.njk
+++ b/app/views/applications/reject/english.njk
@@ -33,7 +33,7 @@
 
       <form method="post" action="/applications/{{ application.id }}/reject/english-answer">
 
-      <h1 class="govuk-heading-l">English GCSE equivalent</h1>
+      <h1 class="govuk-heading-l">English GCSE criteria</h1>
 
       <p class="govuk-body">Candidates must have achieved a standard equivalent to a grade 4 (C) in the GCSE examinations in English.</p>
 
@@ -215,7 +215,7 @@
           },
           {
             value: "not-met",
-            text: "They do not have an equivalent qualification and we’re not able to offer a GCSE equivalency test",
+            text: "No, they do not have an equivalent qualification and we’re not able to offer a GCSE equivalency test",
             checked: (data.rejection.englishCriteria == 'met-standard')
           }
         ]

--- a/app/views/applications/reject/english.njk
+++ b/app/views/applications/reject/english.njk
@@ -33,11 +33,13 @@
 
       <form method="post" action="/applications/{{ application.id }}/reject/science">
 
-      <h1 class="govuk-heading-l">English</h1>
+      <h1 class="govuk-heading-l">English GCSE equivalent</h1>
 
       <p class="govuk-body">Candidates must have achieved a standard equivalent to a grade 4 (C) in the GCSE examinations in English.</p>
 
       <p class="govuk-body">It is the standard, not the certificate, that matters. Candidates who are otherwise suitable but have not successfully achieved a GCSE grade 4 may be given an opportunity to show that they can meet the required standard either by taking an equivalence test or by offering other evidence of attainment, which should demonstrate a similar level and breadth.</p>
+
+       <p class="govuk-body">Contact <a href="#">becomingateacher@digital.education.gov.uk</a> if you're not sure this candidate meets the criteria.</p>
 
 
       <p class="govuk-body">{{ name }} has said this:</p>
@@ -195,7 +197,7 @@
         name: "degree",
         fieldset: {
           legend: {
-            text: "Do they meet the standard equivalent to grade 4 English GCSE?",
+            text: "Do they meet the standard equivalent to a grade 4 (C) English GCSE?",
             isPageHeading: true,
             classes: "govuk-fieldset__legend--m"
           }
@@ -207,11 +209,11 @@
           },
           {
             value: "scotland",
-            text: "Yes, they have demonstrated they meet the standard in some other way"
+            text: "Yes, they’ve demonstrated they meet the standard in another way"
           },
           {
             value: "wales",
-            text: "They don’t have GCSE grade 4 (C) or an an equivalent qualification and we are not able to offer a GCSE equivalency test"
+            text: "They do not have an equivalent qualification and we’re not able to offer a GCSE equivalency test"
           }
         ]
       }) }}

--- a/app/views/applications/reject/english.njk
+++ b/app/views/applications/reject/english.njk
@@ -31,7 +31,7 @@
         {{heading}}
       {% endset %}
 
-      <form method="post" action="/applications/{{ application.id }}/reject/science">
+      <form method="post" action="/applications/{{ application.id }}/reject/english-answer">
 
       <h1 class="govuk-heading-l">English GCSE equivalent</h1>
 
@@ -194,7 +194,7 @@
       {% from "govuk/components/radios/macro.njk" import govukRadios %}
 
       {{ govukRadios({
-        name: "degree",
+        name: "rejection[englishCriteria]",
         fieldset: {
           legend: {
             text: "Do they meet the standard equivalent to a grade 4 (C) English GCSE?",
@@ -204,16 +204,19 @@
         },
         items: [
           {
-            value: "england",
-            text: "Yes, they have an equivalent qualification"
+            value: "met-qualification",
+            text: "Yes, they have an equivalent qualification",
+            checked: (data.rejection.englishCriteria == 'met-qualification')
           },
           {
-            value: "scotland",
-            text: "Yes, they’ve demonstrated they meet the standard in another way"
+            value: "met-standard",
+            text: "Yes, they’ve demonstrated they meet the standard in another way",
+            checked: (data.rejection.englishCriteria == 'met-standard')
           },
           {
-            value: "wales",
-            text: "They do not have an equivalent qualification and we’re not able to offer a GCSE equivalency test"
+            value: "not-met",
+            text: "They do not have an equivalent qualification and we’re not able to offer a GCSE equivalency test",
+            checked: (data.rejection.englishCriteria == 'met-standard')
           }
         ]
       }) }}

--- a/app/views/applications/reject/english.njk
+++ b/app/views/applications/reject/english.njk
@@ -1,0 +1,221 @@
+{% extends "_layout.njk" %}
+
+{% set primaryNavId = 'applications' %}
+{% set name = application.personalDetails.name %}
+
+{% if application.status == "Rejected" %}
+  {% set caption = content.giveFeedback.caption + ' - ' + name %}
+  {% set heading = "Reasons the application was rejected" %}
+{% else %}
+  {% set caption = content.rejectApplication.caption + ' - ' + name %}
+  {% set heading = "Reasons for rejecting the application" %}
+{% endif %}
+{% set title = heading + ' - ' + caption %}
+
+{% block pageNavigation %}
+  {% set backUrl = "/applications/" + application.id + "/decision" %}
+  {% if application.status == "Rejected" %}
+    {% set backUrl = "/applications/" + application.id %}
+  {% endif %}
+
+  {{ govukBackLink({
+    href: backUrl
+  }) }}
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {% set h1 %}
+        <span class="govuk-caption-l">{{caption}}</span>
+        {{heading}}
+      {% endset %}
+
+      <form method="post" action="/applications/{{ application.id }}/reject/science">
+
+      <h1 class="govuk-heading-l">English</h1>
+
+      <p class="govuk-body">{{ name }} has said this:</p>
+
+      {% set item = application.gcse.english %}
+
+      {% set gradesHtml %}
+        <ul class="govuk-list">
+        {% for grade in item.grade %}
+          <li>{{ grade.grade }}{% if grade.exam %} ({{ grade.exam }}){% endif %}</li>
+        {% endfor %}
+        </ul>
+      {% endset %}
+
+      <dl class="govuk-summary-list">
+        {% if item.hasQualification == "Yes" %}
+
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+              Qualification type
+            </dt>
+            <dd class="govuk-summary-list__value">
+              {{ item.type }}
+            </dd>
+          </div>
+
+          {% if item.country != "United Kingdom" %}
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Country or territory
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {{ item.country }}
+              </dd>
+            </div>
+          {% endif %}
+
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+              Grade
+            </dt>
+            <dd class="govuk-summary-list__value">
+              {{ gradesHtml | safe }}
+            </dd>
+          </div>
+
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+              Year awarded
+            </dt>
+            <dd class="govuk-summary-list__value">
+              {{ item.year }}
+            </dd>
+          </div>
+
+          {% if item.retake %}
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Are you currently studying to retake this qualification?
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {{ item.retake.isRetaking }}
+              </dd>
+            </div>
+            {% if item.retake.isRetaking == "No" %}
+              <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                  Evidence of having {{ item.subject if item.subject == 'English' else item.subject | lower }} skills at the required standard
+                </dt>
+                <dd class="govuk-summary-list__value">
+                  {{ item.retake.evidence }}
+                </dd>
+              </div>
+            {% endif %}
+          {% endif %}
+
+          {% if item.naric %}
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                UK ENIC reference number
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {{ item.naric.reference }}
+              </dd>
+            </div>
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Comparable UK qualification
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {{ item.naric.comparable }}
+              </dd>
+            </div>
+          {% else %}
+            {% if application.personalDetails.isInternationalCandidate %}
+              <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                  Do you have a UK ENIC statement of comparability?
+                </dt>
+                <dd class="govuk-summary-list__value">
+                  No
+                </dd>
+              </div>
+            {% endif %}
+          {% endif %}
+
+        {% else %}
+
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+              What type of {{ item.subject if item.subject == 'English' else item.subject | lower }} qualification do you have?
+            </dt>
+            <dd class="govuk-summary-list__value">
+              {{ item.missing.hasQualification }}
+            </dd>
+          </div>
+
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+              Are you currently studying for this qualification?
+            </dt>
+            <dd class="govuk-summary-list__value">
+              {{ item.missing.isStudying }}
+            </dd>
+          </div>
+
+          {% if item.missing.studyingDetails %}
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Details of the qualification you’re studying for
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {{ item.missing.studyingDetails }}
+              </dd>
+            </div>
+          {% endif %}
+
+          {% if item.missing.otherReason %}
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Other evidence of having {{ item.subject if item.subject == 'English' else item.subject | lower }} skills at the required standard
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {{ item.missing.otherReason }}
+              </dd>
+            </div>
+          {% endif %}
+
+        {% endif %}
+      </dl>
+
+      {% from "govuk/components/radios/macro.njk" import govukRadios %}
+
+      {{ govukRadios({
+        name: "degree",
+        fieldset: {
+          legend: {
+            text: "Do they meet the standard equivalent to grade 4 English GCSE?",
+            isPageHeading: true,
+            classes: "govuk-fieldset__legend--m"
+          }
+        },
+        items: [
+          {
+            value: "england",
+            text: "Yes, they have an equivalent qualification"
+          },
+          {
+            value: "scotland",
+            text: "Yes, they have demonstrated they meet the standard in some othe way"
+          },
+          {
+            value: "wales",
+            text: "They don’t have a qualification and we are not able to offer a GCSE equivalency test"
+          }
+        ]
+      }) }}
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+      </form>
+
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/applications/reject/english.njk
+++ b/app/views/applications/reject/english.njk
@@ -35,6 +35,11 @@
 
       <h1 class="govuk-heading-l">English</h1>
 
+      <p class="govuk-body">Candidates must have achieved a standard equivalent to a grade 4 (C) in the GCSE examinations in English.</p>
+
+      <p class="govuk-body">It is the standard, not the certificate, that matters. Candidates who are otherwise suitable but have not successfully achieved a GCSE grade 4 may be given an opportunity to show that they can meet the required standard either by taking an equivalence test or by offering other evidence of attainment, which should demonstrate a similar level and breadth.</p>
+
+
       <p class="govuk-body">{{ name }} has said this:</p>
 
       {% set item = application.gcse.english %}
@@ -202,11 +207,11 @@
           },
           {
             value: "scotland",
-            text: "Yes, they have demonstrated they meet the standard in some othe way"
+            text: "Yes, they have demonstrated they meet the standard in some other way"
           },
           {
             value: "wales",
-            text: "They don’t have a qualification and we are not able to offer a GCSE equivalency test"
+            text: "They don’t have GCSE grade 4 (C) or an an equivalent qualification and we are not able to offer a GCSE equivalency test"
           }
         ]
       }) }}

--- a/app/views/applications/reject/maths.njk
+++ b/app/views/applications/reject/maths.njk
@@ -35,6 +35,10 @@
 
       <h1 class="govuk-heading-l">Maths</h1>
 
+      <p class="govuk-body">Candidates must have achieved a standard equivalent to a grade 4 (C) in the GCSE examinations in mathematics.</p>
+
+      <p class="govuk-body">It is the standard, not the certificate, that matters. Candidates who are otherwise suitable but have not successfully achieved a GCSE grade 4 may be given an opportunity to show that they can meet the required standard either by taking an equivalence test or by offering other evidence of attainment, which should demonstrate a similar level and breadth.</p>
+
       <p class="govuk-body">{{ name }} has said this:</p>
 
       {% set item = application.gcse.maths %}
@@ -202,11 +206,11 @@
           },
           {
             value: "scotland",
-            text: "Yes, they have demonstrated they meet the standard in some othe way"
+            text: "Yes, they have demonstrated they meet the standard in some other way"
           },
           {
             value: "wales",
-            text: "They don’t have a qualification and we are not able to offer a GCSE equivalency test"
+            text: "They don’t have GCSE grade 4 (C) or an an equivalent qualification and we are not able to offer a GCSE equivalency test"
           }
         ]
       }) }}

--- a/app/views/applications/reject/maths.njk
+++ b/app/views/applications/reject/maths.njk
@@ -33,11 +33,13 @@
 
       <form method="post" action="/applications/{{ application.id }}/reject/english">
 
-      <h1 class="govuk-heading-l">Maths</h1>
+      <h1 class="govuk-heading-l">Maths GCSE equivalent</h1>
 
       <p class="govuk-body">Candidates must have achieved a standard equivalent to a grade 4 (C) in the GCSE examinations in mathematics.</p>
 
       <p class="govuk-body">It is the standard, not the certificate, that matters. Candidates who are otherwise suitable but have not successfully achieved a GCSE grade 4 may be given an opportunity to show that they can meet the required standard either by taking an equivalence test or by offering other evidence of attainment, which should demonstrate a similar level and breadth.</p>
+
+       <p class="govuk-body">Contact <a href="#">becomingateacher@digital.education.gov.uk</a> if you're not sure this candidate meets the criteria.</p>
 
       <p class="govuk-body">{{ name }} has said this:</p>
 
@@ -194,7 +196,7 @@
         name: "degree",
         fieldset: {
           legend: {
-            text: "Do they meet the standard equivalent to grade 4 maths GCSE?",
+            text: "Do they meet the standard equivalent to a grade 4 (C) maths GCSE?",
             isPageHeading: true,
             classes: "govuk-fieldset__legend--m"
           }
@@ -206,11 +208,11 @@
           },
           {
             value: "scotland",
-            text: "Yes, they have demonstrated they meet the standard in some other way"
+            text: "Yes, they’ve demonstrated they meet the standard in another way"
           },
           {
             value: "wales",
-            text: "They don’t have GCSE grade 4 (C) or an an equivalent qualification and we are not able to offer a GCSE equivalency test"
+            text: "They do not have an equivalent qualification and we’re not able to offer a GCSE equivalency test"
           }
         ]
       }) }}

--- a/app/views/applications/reject/maths.njk
+++ b/app/views/applications/reject/maths.njk
@@ -1,0 +1,221 @@
+{% extends "_layout.njk" %}
+
+{% set primaryNavId = 'applications' %}
+{% set name = application.personalDetails.name %}
+
+{% if application.status == "Rejected" %}
+  {% set caption = content.giveFeedback.caption + ' - ' + name %}
+  {% set heading = "Reasons the application was rejected" %}
+{% else %}
+  {% set caption = content.rejectApplication.caption + ' - ' + name %}
+  {% set heading = "Reasons for rejecting the application" %}
+{% endif %}
+{% set title = heading + ' - ' + caption %}
+
+{% block pageNavigation %}
+  {% set backUrl = "/applications/" + application.id + "/decision" %}
+  {% if application.status == "Rejected" %}
+    {% set backUrl = "/applications/" + application.id %}
+  {% endif %}
+
+  {{ govukBackLink({
+    href: backUrl
+  }) }}
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {% set h1 %}
+        <span class="govuk-caption-l">{{caption}}</span>
+        {{heading}}
+      {% endset %}
+
+      <form method="post" action="/applications/{{ application.id }}/reject/english">
+
+      <h1 class="govuk-heading-l">Maths</h1>
+
+      <p class="govuk-body">{{ name }} has said this:</p>
+
+      {% set item = application.gcse.maths %}
+
+      {% set gradesHtml %}
+        <ul class="govuk-list">
+        {% for grade in item.grade %}
+          <li>{{ grade.grade }}{% if grade.exam %} ({{ grade.exam }}){% endif %}</li>
+        {% endfor %}
+        </ul>
+      {% endset %}
+
+      <dl class="govuk-summary-list">
+        {% if item.hasQualification == "Yes" %}
+
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+              Qualification type
+            </dt>
+            <dd class="govuk-summary-list__value">
+              {{ item.type }}
+            </dd>
+          </div>
+
+          {% if item.country != "United Kingdom" %}
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Country or territory
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {{ item.country }}
+              </dd>
+            </div>
+          {% endif %}
+
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+              Grade
+            </dt>
+            <dd class="govuk-summary-list__value">
+              {{ gradesHtml | safe }}
+            </dd>
+          </div>
+
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+              Year awarded
+            </dt>
+            <dd class="govuk-summary-list__value">
+              {{ item.year }}
+            </dd>
+          </div>
+
+          {% if item.retake %}
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Are you currently studying to retake this qualification?
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {{ item.retake.isRetaking }}
+              </dd>
+            </div>
+            {% if item.retake.isRetaking == "No" %}
+              <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                  Evidence of having {{ item.subject if item.subject == 'English' else item.subject | lower }} skills at the required standard
+                </dt>
+                <dd class="govuk-summary-list__value">
+                  {{ item.retake.evidence }}
+                </dd>
+              </div>
+            {% endif %}
+          {% endif %}
+
+          {% if item.naric %}
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                UK ENIC reference number
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {{ item.naric.reference }}
+              </dd>
+            </div>
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Comparable UK qualification
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {{ item.naric.comparable }}
+              </dd>
+            </div>
+          {% else %}
+            {% if application.personalDetails.isInternationalCandidate %}
+              <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                  Do you have a UK ENIC statement of comparability?
+                </dt>
+                <dd class="govuk-summary-list__value">
+                  No
+                </dd>
+              </div>
+            {% endif %}
+          {% endif %}
+
+        {% else %}
+
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+              What type of {{ item.subject if item.subject == 'English' else item.subject | lower }} qualification do you have?
+            </dt>
+            <dd class="govuk-summary-list__value">
+              {{ item.missing.hasQualification }}
+            </dd>
+          </div>
+
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+              Are you currently studying for this qualification?
+            </dt>
+            <dd class="govuk-summary-list__value">
+              {{ item.missing.isStudying }}
+            </dd>
+          </div>
+
+          {% if item.missing.studyingDetails %}
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Details of the qualification you’re studying for
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {{ item.missing.studyingDetails }}
+              </dd>
+            </div>
+          {% endif %}
+
+          {% if item.missing.otherReason %}
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Other evidence of having {{ item.subject if item.subject == 'English' else item.subject | lower }} skills at the required standard
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {{ item.missing.otherReason }}
+              </dd>
+            </div>
+          {% endif %}
+
+        {% endif %}
+      </dl>
+
+      {% from "govuk/components/radios/macro.njk" import govukRadios %}
+
+      {{ govukRadios({
+        name: "degree",
+        fieldset: {
+          legend: {
+            text: "Do they meet the standard equivalent to grade 4 maths GCSE?",
+            isPageHeading: true,
+            classes: "govuk-fieldset__legend--m"
+          }
+        },
+        items: [
+          {
+            value: "england",
+            text: "Yes, they have an equivalent qualification"
+          },
+          {
+            value: "scotland",
+            text: "Yes, they have demonstrated they meet the standard in some othe way"
+          },
+          {
+            value: "wales",
+            text: "They don’t have a qualification and we are not able to offer a GCSE equivalency test"
+          }
+        ]
+      }) }}
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+      </form>
+
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/applications/reject/maths.njk
+++ b/app/views/applications/reject/maths.njk
@@ -33,7 +33,7 @@
 
       <form method="post" action="/applications/{{ application.id }}/reject/maths-answer">
 
-      <h1 class="govuk-heading-l">Maths GCSE equivalent</h1>
+      <h1 class="govuk-heading-l">Maths GCSE criteria</h1>
 
       <p class="govuk-body">Candidates must have achieved a standard equivalent to a grade 4 (C) in the GCSE examinations in mathematics.</p>
 
@@ -214,7 +214,7 @@
           },
           {
             value: "not-met",
-            text: "They do not have an equivalent qualification and we’re not able to offer a GCSE equivalency test",
+            text: "No, they do not have an equivalent qualification and we’re not able to offer a GCSE equivalency test",
             checked: (data.rejection.mathsCriteria == 'met-standard')
           }
         ]

--- a/app/views/applications/reject/maths.njk
+++ b/app/views/applications/reject/maths.njk
@@ -31,7 +31,7 @@
         {{heading}}
       {% endset %}
 
-      <form method="post" action="/applications/{{ application.id }}/reject/english">
+      <form method="post" action="/applications/{{ application.id }}/reject/maths-answer">
 
       <h1 class="govuk-heading-l">Maths GCSE equivalent</h1>
 
@@ -193,7 +193,7 @@
       {% from "govuk/components/radios/macro.njk" import govukRadios %}
 
       {{ govukRadios({
-        name: "degree",
+        name: "rejection[mathsCriteria]",
         fieldset: {
           legend: {
             text: "Do they meet the standard equivalent to a grade 4 (C) maths GCSE?",
@@ -203,16 +203,19 @@
         },
         items: [
           {
-            value: "england",
-            text: "Yes, they have an equivalent qualification"
+            value: "met-qualification",
+            text: "Yes, they have an equivalent qualification",
+            checked: (data.rejection.mathsCriteria == 'met-qualification')
           },
           {
-            value: "scotland",
-            text: "Yes, they’ve demonstrated they meet the standard in another way"
+            value: "met-standard",
+            text: "Yes, they’ve demonstrated they meet the standard in another way",
+            checked: (data.rejection.mathsCriteria == 'met-standard')
           },
           {
-            value: "wales",
-            text: "They do not have an equivalent qualification and we’re not able to offer a GCSE equivalency test"
+            value: "not-met",
+            text: "They do not have an equivalent qualification and we’re not able to offer a GCSE equivalency test",
+            checked: (data.rejection.mathsCriteria == 'met-standard')
           }
         ]
       }) }}

--- a/app/views/applications/reject/other-reasons.njk
+++ b/app/views/applications/reject/other-reasons.njk
@@ -1,0 +1,172 @@
+{% extends "_layout.njk" %}
+
+{% set primaryNavId = 'applications' %}
+{% set name = application.personalDetails.name %}
+
+{% if application.status == "Rejected" %}
+  {% set caption = content.giveFeedback.caption + ' - ' + name %}
+  {% set heading = "Reasons the application was rejected" %}
+{% else %}
+  {% set caption = content.rejectApplication.caption + ' - ' + name %}
+  {% set heading = "Tell " + name + " why you are rejecting their application" %}
+{% endif %}
+{% set title = heading + ' - ' + caption %}
+
+{% block pageNavigation %}
+  {% set backUrl = "/applications/" + application.id + "/decision" %}
+  {% if application.status == "Rejected" %}
+    {% set backUrl = "/applications/" + application.id %}
+  {% endif %}
+
+  {{ govukBackLink({
+    href: backUrl
+  }) }}
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      {# <h1 class="govuk-heading-l">Feedback for {{ name }}</h1>
+
+      <p class="govuk-body">
+        You’ve said {{ name }} does not meet the ITT criteria because:
+      </p>
+
+      <ul class="govuk-list govuk-list--bullet">
+        <li>they do not have a degree or equivalent</li>
+      </ul> #}
+
+      <form method="post">
+
+        {% set qualificationReasonsHtml %}
+          {% include "_includes/reasons/qualifications.njk" %}
+        {% endset %}
+
+        {% set personalStatementReasonsHtml %}
+          {% include "_includes/reasons/personal-statement.njk" %}
+        {% endset %}
+
+        {% set teachingKnowledgeReasonsHtml %}
+        {{ govukTextarea({
+          name: "more-detail",
+          id: "more-detail",
+          label: {
+            text: "Give details",
+            classes: "govuk-label--s"
+          }
+        }) }}
+        {% endset %}
+
+        {% set communicationReasonsHtml %}
+                  {{ govukTextarea({
+          name: "more-detail",
+          id: "more-detail",
+          label: {
+            text: "Give details",
+            classes: "govuk-label--s"
+          }
+        }) }}
+
+        {% endset %}
+
+        {% set referencesHtml %}
+          {{appRejectionDetails({ category: 'references', reason: 'details', data: data })}}
+        {% endset %}
+
+        {% set safeguardingHtml %}
+          {{appRejectionDetails({ category: 'safeguarding', reason: 'details', data: data })}}
+        {% endset %}
+
+        {% set sponsorshipHtml %}
+          {{appRejectionDetails({ category: 'sponsorship', reason: 'details', data: data })}}
+        {% endset %}
+
+        {% set otherDetailsHtml %}
+          {{appRejectionDetails({ category: 'other', reason: 'details', data: data })}}
+        {% endset %}
+
+        {{ govukCheckboxes({
+          idPrefix: "rejection-categories",
+          name: "rejection[categories]",
+          fieldset: {
+            legend: {
+              text: "Give " + name + " any other feedback (optional)",
+              isPageHeading: true,
+              classes: "govuk-fieldset__legend--l"
+            }
+          },
+          items: [
+          {
+    value: "Degree subject does not meet course requirements",
+    text: "Degree subject does not meet course requirements",
+    checked: checked("['rejection']['" + category + "-reasons']", "Degree does not meet course requirements"),
+    conditional: {
+      html: degreeDoesNotMeetRequirementsHtml
+    }
+  },
+  {
+    value: "Degree class does not meet course requirements",
+    text: "Degree class does not meet course requirements",
+    checked: checked("['rejection']['" + category + "-reasons']", "Degree does not meet course requirements"),
+    conditional: {
+      html: degreeDoesNotMeetRequirementsHtml
+    }
+  },
+            {
+              value: "Personal statement",
+              text: "Personal statement could be improved",
+              checked: checked("['rejection']['categories']", "Personal statement"),
+              conditional: {
+                html: personalStatementReasonsHtml
+              }
+            },
+            {
+              value: "Communication, attendance and scheduling",
+              text: "Could not get in touch with them",
+              checked: checked("['rejection']['categandies']", "Communication, attendance or scheduling"),
+              conditional: {
+                html: communicationReasonsHtml
+              }
+            },
+            {
+              value: "Safeguarding",
+              text: "We have safeguarding concerns",
+              checked: checked("['rejection']['categories']", "Safeguarding"),
+              conditional: {
+                html: safeguardingHtml
+              }
+            },
+            {
+              value: "Visa sponsorship",
+              text: "We cannot sponsor a visa",
+              checked: checked("['rejection']['categories']", "Visa sponsorship"),
+              conditional: {
+                html: sponsorshipHtml
+              }
+            },
+            {
+              value: "Course full",
+              text: "The course is now full",
+              checked: checked("['rejection']['categories']", "Course full")
+            },
+            {
+              value: "Other",
+              text: "Other",
+              checked: checked("['rejection']['categories']", "Other"),
+              conditional: {
+                html: otherDetailsHtml
+              }
+            }
+          ]
+        }) }}
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+      </form>
+
+      <p class="govuk-body"><a class="govuk-link--no-visited-state" href="/applications/{{ application.id }}">Cancel</a></p>
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/applications/reject/other-reasons.njk
+++ b/app/views/applications/reject/other-reasons.njk
@@ -27,63 +27,106 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      {# <h1 class="govuk-heading-l">Feedback for {{ name }}</h1>
+      <form method="get" action="/applications/{{ applicationId }}/reject/check">
 
-      <p class="govuk-body">
-        You’ve said {{ name }} does not meet the ITT criteria because:
-      </p>
+        {% set subjectKnowledgeHtml %}
+           {{ govukTextarea({
+            name: "rejection[degreeSubjectDetails]",
+            value: data.rejection.degreeSubjectDetails,
+            label: {
+              text: "Give details",
+              classes: "govuk-label--s"
+            }
+          }) }}
+        {% endset %}
 
-      <ul class="govuk-list govuk-list--bullet">
-        <li>they do not have a degree or equivalent</li>
-      </ul> #}
-
-      <form method="post">
-
-        {% set qualificationReasonsHtml %}
-          {% include "_includes/reasons/qualifications.njk" %}
+        {% set degreeClassDoesNotMeetRequirementsHtml %}
+           {{ govukTextarea({
+            name: "rejection[degreeClassDetails]",
+            value: data.rejection.degreeClassDetails,
+            label: {
+              text: "Give details",
+              classes: "govuk-label--s"
+            }
+          }) }}
         {% endset %}
 
         {% set personalStatementReasonsHtml %}
-          {% include "_includes/reasons/personal-statement.njk" %}
+          {{ govukTextarea({
+            name: "rejection[personalStatementDetails]",
+            value: data.rejection.personalStatementDetails,
+            label: {
+              text: "Give details",
+              classes: "govuk-label--s"
+            }
+          }) }}
         {% endset %}
 
-        {% set teachingKnowledgeReasonsHtml %}
-        {{ govukTextarea({
-          name: "more-detail",
-          id: "more-detail",
-          label: {
-            text: "Give details",
-            classes: "govuk-label--s"
-          }
-        }) }}
-        {% endset %}
 
         {% set communicationReasonsHtml %}
-                  {{ govukTextarea({
-          name: "more-detail",
-          id: "more-detail",
-          label: {
-            text: "Give details",
-            classes: "govuk-label--s"
-          }
-        }) }}
-
+          {{ govukTextarea({
+            name: "rejection[communicationDetails]",
+            value: data.rejection.communicationDetails,
+            label: {
+              text: "Give details",
+              classes: "govuk-label--s"
+            }
+          }) }}
         {% endset %}
 
-        {% set referencesHtml %}
-          {{appRejectionDetails({ category: 'references', reason: 'details', data: data })}}
+        {% set couldNotArrangeInterviewHtml %}
+          {{ govukTextarea({
+            name: "rejection[couldNotArrangeInterviewDetails]",
+            value: data.rejection.couldNotArrangeInterviewDetails,
+            label: {
+              text: "Give details",
+              classes: "govuk-label--s"
+            }
+          }) }}
+        {% endset %}
+
+        {% set interviewPerformanceHtml %}
+          {{ govukTextarea({
+            name: "rejection[interviewPerformanceDetails]",
+            value: data.rejection.interviewPerformanceDetails,
+            label: {
+              text: "Give details",
+              classes: "govuk-label--s"
+            }
+          }) }}
         {% endset %}
 
         {% set safeguardingHtml %}
-          {{appRejectionDetails({ category: 'safeguarding', reason: 'details', data: data })}}
+          {{ govukTextarea({
+            name: "rejection[safeguardingDetails]",
+            value: data.rejection.safeguardingDetails,
+            label: {
+              text: "Give details",
+              classes: "govuk-label--s"
+            }
+          }) }}
         {% endset %}
 
-        {% set sponsorshipHtml %}
-          {{appRejectionDetails({ category: 'sponsorship', reason: 'details', data: data })}}
+        {% set visaSponsorshipHtml %}
+          {{ govukTextarea({
+            name: "rejection[visaSponsorshipDetails]",
+            value: data.rejection.visaSponsorshipDetails,
+            label: {
+              text: "Give details",
+              classes: "govuk-label--s"
+            }
+          }) }}
         {% endset %}
 
-        {% set otherDetailsHtml %}
-          {{appRejectionDetails({ category: 'other', reason: 'details', data: data })}}
+        {% set courseFullHtml %}
+          {{ govukTextarea({
+            name: "rejection[courseFullDetails]",
+            value: data.rejection.courseFullDetails,
+            label: {
+              text: "Give details",
+              classes: "govuk-label--s"
+            }
+          }) }}
         {% endset %}
 
         {{ govukCheckboxes({
@@ -96,88 +139,81 @@
               classes: "govuk-fieldset__legend--l"
             }
           },
-          items: [
-         {
-    value: "Degree subject does not meet course requirements",
-    text: "Does not have a degree or A level in physics",
-    checked: checked("['rejection']['" + category + "-reasons']", "Degree does not meet course requirements"),
-    conditional: {
-    html: degreeDoesNotMeetRequirementsHtml
-    }
-  },
-  {
-    value: "Degree class does not meet course requirements",
-    text: "Degree class does not meet course requirements",
-    checked: checked("['rejection']['" + category + "-reasons']", "Degree does not meet course requirements"),
-    conditional: {
-    html: degreeClassDoesNotMeetRequirementsHtml
-    }
-  },
-  {
-    value: "Personal statement",
-    text: "Personal statement did not demonstrate they are suitable to teach",
-    checked: checked("['rejection']['categories']", "Personal statement"),
-    conditional: {
-    html: personalStatementReasonsHtml
-    }
-  },
-  {
-    value: "Communication, attendance and scheduling",
-    text: "Could not get in touch with them",
-    checked: checked("['rejection']['categandies']", "Communication, attendance or scheduling"),
-    conditional: {
-    html: communicationReasonsHtml
-    }
-  },
-  {
-    value: "Visa sponsorship",
-    text: "Could not arrange an interview",
-    conditional: {
-    html: sponsorshipHtml
-    }
-  },
-  {
-    value: "Personal statement",
-    text: "Interview performance was not strong enough",
-    checked: checked("['rejection']['categories']", "Personal statement"),
-    conditional: {
-    html: personalStatementReasonsHtml
-    }
-  },
-  {
-    value: "Safeguarding",
-    text: "We have safeguarding concerns",
-    checked: checked("['rejection']['categories']", "Safeguarding"),
-    conditional: {
-    html: safeguardingHtml
-    }
-  },
-  {
-    value: "Visa sponsorship",
-    text: "We cannot sponsor a visa",
-    checked: checked("['rejection']['categories']", "Visa sponsorship"),
-    conditional: {
-    html: sponsorshipHtml
-    }
-  },
-  {
-    value: "Course full",
-    text: "The course is now full",
-    checked: checked("['rejection']['categories']", "Course full"),
-    conditional: {
-    html: courseFullHtml
-    }
-  },
-  {
-    value: "Other",
-    text: "Other",
-    checked: checked("['rejection']['categories']", "Other"),
-    conditional: {
-    html: otherDetailsHtml
-    }
-  }
-          ]
-        }) }}
+        items: [
+        {
+          value: "degree-subject",
+          text: "Does not have a degree or A level in " + application.subject[0].name,
+          checked: checked("['rejection']['categories']", "degree-subject"),
+          conditional: {
+          html: subjectKnowledgeHtml
+          }
+        },
+        {
+          value: "degree-class",
+          text: "Degree class does not meet course requirements",
+          checked: checked("['rejection']['categories']", "degree-class"),
+          conditional: {
+          html: degreeClassDoesNotMeetRequirementsHtml
+          }
+        },
+        {
+          value: "personal-statement",
+          text: "Personal statement did not demonstrate they are suitable to teach",
+          checked: checked("['rejection']['categories']", "personal-statement"),
+          conditional: {
+          html: personalStatementReasonsHtml
+          }
+        },
+        {
+          value: "communication",
+          text: "Could not get in touch with them",
+          checked: checked("['rejection']['categories']", "communication"),
+          conditional: {
+          html: communicationReasonsHtml
+          }
+        },
+        {
+          value: "interview",
+          text: "Could not arrange an interview",
+          checked: checked("['rejection']['categories']", "interview"),
+          conditional: {
+          html: couldNotArrangeInterviewHtml
+          }
+        },
+        {
+          value: "interview-performance",
+          text: "Interview performance was not strong enough",
+          checked: checked("['rejection']['categories']", "interview-performance"),
+          conditional: {
+          html: interviewPerformanceHtml
+          }
+        },
+        {
+          value: "safeguarding",
+          text: "We have safeguarding concerns",
+          checked: checked("['rejection']['categories']", "safeguarding"),
+          conditional: {
+          html: safeguardingHtml
+          }
+        },
+        {
+          value: "visa-sponsorship",
+          text: "We cannot sponsor a visa",
+          checked: checked("['rejection']['categories']", "visa-sponsorship"),
+          conditional: {
+          html: visaSponsorshipHtml
+          }
+        },
+        {
+          value: "course-full",
+          text: "The course is now full",
+          checked: checked("['rejection']['categories']", "course-full"),
+          conditional: {
+          html: courseFullHtml
+          }
+        }
+      ]
+    }) }}
 
         {{ govukButton({
           text: "Continue"

--- a/app/views/applications/reject/other-reasons.njk
+++ b/app/views/applications/reject/other-reasons.njk
@@ -97,12 +97,12 @@
             }
           },
           items: [
-          {
+         {
     value: "Degree subject does not meet course requirements",
-    text: "Degree subject does not meet course requirements",
+    text: "Does not have a degree or A level in physics",
     checked: checked("['rejection']['" + category + "-reasons']", "Degree does not meet course requirements"),
     conditional: {
-      html: degreeDoesNotMeetRequirementsHtml
+    html: degreeDoesNotMeetRequirementsHtml
     }
   },
   {
@@ -110,54 +110,72 @@
     text: "Degree class does not meet course requirements",
     checked: checked("['rejection']['" + category + "-reasons']", "Degree does not meet course requirements"),
     conditional: {
-      html: degreeDoesNotMeetRequirementsHtml
+    html: degreeClassDoesNotMeetRequirementsHtml
     }
   },
-            {
-              value: "Personal statement",
-              text: "Personal statement could be improved",
-              checked: checked("['rejection']['categories']", "Personal statement"),
-              conditional: {
-                html: personalStatementReasonsHtml
-              }
-            },
-            {
-              value: "Communication, attendance and scheduling",
-              text: "Could not get in touch with them",
-              checked: checked("['rejection']['categandies']", "Communication, attendance or scheduling"),
-              conditional: {
-                html: communicationReasonsHtml
-              }
-            },
-            {
-              value: "Safeguarding",
-              text: "We have safeguarding concerns",
-              checked: checked("['rejection']['categories']", "Safeguarding"),
-              conditional: {
-                html: safeguardingHtml
-              }
-            },
-            {
-              value: "Visa sponsorship",
-              text: "We cannot sponsor a visa",
-              checked: checked("['rejection']['categories']", "Visa sponsorship"),
-              conditional: {
-                html: sponsorshipHtml
-              }
-            },
-            {
-              value: "Course full",
-              text: "The course is now full",
-              checked: checked("['rejection']['categories']", "Course full")
-            },
-            {
-              value: "Other",
-              text: "Other",
-              checked: checked("['rejection']['categories']", "Other"),
-              conditional: {
-                html: otherDetailsHtml
-              }
-            }
+  {
+    value: "Personal statement",
+    text: "Personal statement did not demonstrate they are suitable to teach",
+    checked: checked("['rejection']['categories']", "Personal statement"),
+    conditional: {
+    html: personalStatementReasonsHtml
+    }
+  },
+  {
+    value: "Communication, attendance and scheduling",
+    text: "Could not get in touch with them",
+    checked: checked("['rejection']['categandies']", "Communication, attendance or scheduling"),
+    conditional: {
+    html: communicationReasonsHtml
+    }
+  },
+  {
+    value: "Visa sponsorship",
+    text: "Could not arrange an interview",
+    conditional: {
+    html: sponsorshipHtml
+    }
+  },
+  {
+    value: "Personal statement",
+    text: "Interview performance was not strong enough",
+    checked: checked("['rejection']['categories']", "Personal statement"),
+    conditional: {
+    html: personalStatementReasonsHtml
+    }
+  },
+  {
+    value: "Safeguarding",
+    text: "We have safeguarding concerns",
+    checked: checked("['rejection']['categories']", "Safeguarding"),
+    conditional: {
+    html: safeguardingHtml
+    }
+  },
+  {
+    value: "Visa sponsorship",
+    text: "We cannot sponsor a visa",
+    checked: checked("['rejection']['categories']", "Visa sponsorship"),
+    conditional: {
+    html: sponsorshipHtml
+    }
+  },
+  {
+    value: "Course full",
+    text: "The course is now full",
+    checked: checked("['rejection']['categories']", "Course full"),
+    conditional: {
+    html: courseFullHtml
+    }
+  },
+  {
+    value: "Other",
+    text: "Other",
+    checked: checked("['rejection']['categories']", "Other"),
+    conditional: {
+    html: otherDetailsHtml
+    }
+  }
           ]
         }) }}
 

--- a/app/views/applications/reject/other.njk
+++ b/app/views/applications/reject/other.njk
@@ -8,7 +8,7 @@
   {% set heading = "Reasons the application was rejected" %}
 {% else %}
   {% set caption = content.rejectApplication.caption + ' - ' + name %}
-  {% set heading = "Reasons for rejecting the application" %}
+  {% set heading = "Tell " + name + " why you are rejecting their application" %}
 {% endif %}
 {% set title = heading + ' - ' + caption %}
 
@@ -27,7 +27,6 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       {% set h1 %}
-        <span class="govuk-caption-l">{{caption}}</span>
         {{heading}}
       {% endset %}
 

--- a/app/views/applications/reject/reasons.njk
+++ b/app/views/applications/reject/reasons.njk
@@ -30,7 +30,7 @@
       <h1 class="govuk-heading-l">Feedback for {{ name }}</h1>
 
 
-      <form method="post">
+      <form method="get" action="/applications/{{ applicationId }}/reject/check">
 
         {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
         {{ govukWarningText({
@@ -43,7 +43,14 @@
         {% endset %}
 
         {% set personalStatementReasonsHtml %}
-          {% include "_includes/reasons/personal-statement.njk" %}
+          {{ govukTextarea({
+            name: "rejection[personalStatementDetails]",
+            value: data.rejection.personalStatementDetails,
+            label: {
+              text: "Give details",
+              classes: "govuk-label--s"
+            }
+          }) }}
         {% endset %}
 
         {% set teachingKnowledgeReasonsHtml %}
@@ -69,16 +76,6 @@
 
         {% endset %}
 
-        {% set adviceHtml %}
-        {{ govukTextarea({
-            name: "more-detail",
-            id: "more-detail",
-            label: {
-              text: "Give details",
-              classes: "govuk-label--s"
-            }
-          }) }}
-        {% endset %}
 
         {% set referencesHtml %}
           {{appRejectionDetails({ category: 'references', reason: 'details', data: data })}}
@@ -89,7 +86,14 @@
         {% endset %}
 
         {% set sponsorshipHtml %}
-          {{appRejectionDetails({ category: 'sponsorship', reason: 'details', data: data })}}
+          {{ govukTextarea({
+            name: "rejection[visaSponsorshipDetails]",
+            value: data.rejection.visaSponsorshipDetails,
+            label: {
+              text: "Give details",
+              classes: "govuk-label--s"
+            }
+          }) }}
         {% endset %}
 
         {% set otherDetailsHtml %}
@@ -109,8 +113,8 @@
 
         {% set degreeDoesNotMeetRequirementsHtml %}
            {{ govukTextarea({
-            name: "more-detail",
-            id: "more-detail",
+            name: "rejection[degreeSubjectDetails]",
+            value: data.rejection.degreeSubjectDetails,
             label: {
               text: "Give details",
               classes: "govuk-label--s"
@@ -120,8 +124,8 @@
 
         {% set degreeClassDoesNotMeetRequirementsHtml %}
            {{ govukTextarea({
-            name: "more-detail",
-            id: "more-detail",
+            name: "rejection[degreeClassDetails]",
+            value: data.rejection.degreeClassDetails,
             label: {
               text: "Give details",
               classes: "govuk-label--s"
@@ -142,80 +146,81 @@
   items: [
 
   {
-    value: "Degree subject does not meet course requirements",
-    text: "Does not have a degree or A level in physics",
-    checked: checked("['rejection']['" + category + "-reasons']", "Degree does not meet course requirements"),
+    value: "degree-subject",
+    text: "Does not have a degree or A level in " + application.subject[0].name,
+    checked: checked("['rejection']['categories']", "degree-subject"),
     conditional: {
     html: degreeDoesNotMeetRequirementsHtml
     }
   },
   {
-    value: "Degree class does not meet course requirements",
+    value: "degree-class",
     text: "Degree class does not meet course requirements",
-    checked: checked("['rejection']['" + category + "-reasons']", "Degree does not meet course requirements"),
+    checked: checked("['rejection']['categories']", "degree-class"),
     conditional: {
     html: degreeClassDoesNotMeetRequirementsHtml
     }
   },
   {
-    value: "Personal statement",
+    value: "personal-statement",
     text: "Personal statement did not demonstrate they are suitable to teach",
-    checked: checked("['rejection']['categories']", "Personal statement"),
+    checked: checked("['rejection']['categories']", "personal-statement"),
     conditional: {
     html: personalStatementReasonsHtml
     }
   },
   {
-    value: "Communication, attendance and scheduling",
+    value: "communication",
     text: "Could not get in touch with them",
-    checked: checked("['rejection']['categandies']", "Communication, attendance or scheduling"),
+    checked: checked("['rejection']['categories']", "communication"),
     conditional: {
     html: communicationReasonsHtml
     }
   },
   {
-    value: "Visa sponsorship",
+    value: "interview",
     text: "Could not arrange an interview",
+    checked: checked("['rejection']['categories']", "interview"),
     conditional: {
     html: sponsorshipHtml
     }
   },
   {
-    value: "Personal statement",
+    value: "interview-performance",
     text: "Interview performance was not strong enough",
-    checked: checked("['rejection']['categories']", "Personal statement"),
+    checked: checked("['rejection']['categories']", "interview-performance"),
     conditional: {
     html: personalStatementReasonsHtml
     }
   },
   {
-    value: "Safeguarding",
+    value: "safeguarding",
     text: "We have safeguarding concerns",
-    checked: checked("['rejection']['categories']", "Safeguarding"),
+    checked: checked("['rejection']['categories']", "safeguarding"),
     conditional: {
     html: safeguardingHtml
     }
   },
   {
-    value: "Visa sponsorship",
+    value: "visa-sponsorship",
     text: "We cannot sponsor a visa",
-    checked: checked("['rejection']['categories']", "Visa sponsorship"),
+    checked: checked("['rejection']['categories']", "visa-sponsorship"),
     conditional: {
     html: sponsorshipHtml
     }
   },
   {
-    value: "Course full",
+    value: "course-full",
     text: "The course is now full",
-    checked: checked("['rejection']['categories']", "Course full"),
+    checked: checked("['rejection']['categories']", "course-full"),
     conditional: {
     html: courseFullHtml
     }
   },
   {
-    value: "Other",
+    value: "other",
     text: "Other",
-    checked: checked("['rejection']['categories']", "Other"),
+    checked: checked("['rejection']['categories']", "other"),
     conditional: {
     html: otherDetailsHtml
     }
@@ -224,19 +229,17 @@
    }) }}
 
 
-{{ govukTextarea({
-  name: "more-detail",
-  id: "more-detail",
-  label: {
-    text: "Give " + name + " advice on what to do next",
-    classes: "govuk-label--m"
-  },
-  hint: {
-    text: "For example, ‘You should apply again to a different course’"
-  }
-}) }}
-
-
+    {{ govukTextarea({
+      name: "rejection[advice]",
+      value: data.rejection.advice,
+      label: {
+        text: "Give " + name + " advice on what to do next",
+        classes: "govuk-label--m"
+      },
+      hint: {
+        text: "For example, ‘You should apply again to a different course’"
+      }
+    }) }}
 
 
         {{ govukButton({

--- a/app/views/applications/reject/reasons.njk
+++ b/app/views/applications/reject/reasons.njk
@@ -38,80 +38,7 @@
           iconFallbackText: "Warning"
         }) }}
 
-        {% set qualificationReasonsHtml %}
-          {% include "_includes/reasons/qualifications.njk" %}
-        {% endset %}
-
-        {% set personalStatementReasonsHtml %}
-          {{ govukTextarea({
-            name: "rejection[personalStatementDetails]",
-            value: data.rejection.personalStatementDetails,
-            label: {
-              text: "Give details",
-              classes: "govuk-label--s"
-            }
-          }) }}
-        {% endset %}
-
-        {% set teachingKnowledgeReasonsHtml %}
-        {{ govukTextarea({
-          name: "more-detail",
-          id: "more-detail",
-          label: {
-            text: "Give details",
-            classes: "govuk-label--s"
-          }
-        }) }}
-        {% endset %}
-
-        {% set communicationReasonsHtml %}
-                  {{ govukTextarea({
-          name: "more-detail",
-          id: "more-detail",
-          label: {
-            text: "Give details",
-            classes: "govuk-label--s"
-          }
-        }) }}
-
-        {% endset %}
-
-
-        {% set referencesHtml %}
-          {{appRejectionDetails({ category: 'references', reason: 'details', data: data })}}
-        {% endset %}
-
-        {% set safeguardingHtml %}
-          {{appRejectionDetails({ category: 'safeguarding', reason: 'details', data: data })}}
-        {% endset %}
-
-        {% set sponsorshipHtml %}
-          {{ govukTextarea({
-            name: "rejection[visaSponsorshipDetails]",
-            value: data.rejection.visaSponsorshipDetails,
-            label: {
-              text: "Give details",
-              classes: "govuk-label--s"
-            }
-          }) }}
-        {% endset %}
-
-        {% set otherDetailsHtml %}
-          {{appRejectionDetails({ category: 'other', reason: 'details', data: data })}}
-        {% endset %}
-
-        {% set courseFullHtml %}
-        {{ govukTextarea({
-            name: "more-detail",
-            id: "more-detail",
-            label: {
-              text: "Give details",
-              classes: "govuk-label--s"
-            }
-          }) }}
-        {% endset %}
-
-        {% set degreeDoesNotMeetRequirementsHtml %}
+        {% set subjectKnowledgeHtml %}
            {{ govukTextarea({
             name: "rejection[degreeSubjectDetails]",
             value: data.rejection.degreeSubjectDetails,
@@ -133,6 +60,84 @@
           }) }}
         {% endset %}
 
+        {% set personalStatementReasonsHtml %}
+          {{ govukTextarea({
+            name: "rejection[personalStatementDetails]",
+            value: data.rejection.personalStatementDetails,
+            label: {
+              text: "Give details",
+              classes: "govuk-label--s"
+            }
+          }) }}
+        {% endset %}
+
+
+        {% set communicationReasonsHtml %}
+          {{ govukTextarea({
+            name: "rejection[communicationDetails]",
+            value: data.rejection.communicationDetails,
+            label: {
+              text: "Give details",
+              classes: "govuk-label--s"
+            }
+          }) }}
+        {% endset %}
+
+        {% set couldNotArrangeInterviewHtml %}
+          {{ govukTextarea({
+            name: "rejection[couldNotArrangeInterviewDetails]",
+            value: data.rejection.couldNotArrangeInterviewDetails,
+            label: {
+              text: "Give details",
+              classes: "govuk-label--s"
+            }
+          }) }}
+        {% endset %}
+
+        {% set interviewPerformanceHtml %}
+          {{ govukTextarea({
+            name: "rejection[interviewPerformanceDetails]",
+            value: data.rejection.interviewPerformanceDetails,
+            label: {
+              text: "Give details",
+              classes: "govuk-label--s"
+            }
+          }) }}
+        {% endset %}
+
+        {% set safeguardingHtml %}
+          {{ govukTextarea({
+            name: "rejection[safeguardingDetails]",
+            value: data.rejection.safeguardingDetails,
+            label: {
+              text: "Give details",
+              classes: "govuk-label--s"
+            }
+          }) }}
+        {% endset %}
+
+        {% set visaSponsorshipHtml %}
+          {{ govukTextarea({
+            name: "rejection[visaSponsorshipDetails]",
+            value: data.rejection.visaSponsorshipDetails,
+            label: {
+              text: "Give details",
+              classes: "govuk-label--s"
+            }
+          }) }}
+        {% endset %}
+
+        {% set courseFullHtml %}
+          {{ govukTextarea({
+            name: "rejection[courseFullDetails]",
+            value: data.rejection.courseFullDetails,
+            label: {
+              text: "Give details",
+              classes: "govuk-label--s"
+            }
+          }) }}
+        {% endset %}
+
         {{ govukCheckboxes({
           idPrefix: "rejection-categories",
           name: "rejection[categories]",
@@ -143,90 +148,81 @@
               classes: "govuk-fieldset__legend--m"
             }
           },
-  items: [
-
-  {
-    value: "degree-subject",
-    text: "Does not have a degree or A level in " + application.subject[0].name,
-    checked: checked("['rejection']['categories']", "degree-subject"),
-    conditional: {
-    html: degreeDoesNotMeetRequirementsHtml
-    }
-  },
-  {
-    value: "degree-class",
-    text: "Degree class does not meet course requirements",
-    checked: checked("['rejection']['categories']", "degree-class"),
-    conditional: {
-    html: degreeClassDoesNotMeetRequirementsHtml
-    }
-  },
-  {
-    value: "personal-statement",
-    text: "Personal statement did not demonstrate they are suitable to teach",
-    checked: checked("['rejection']['categories']", "personal-statement"),
-    conditional: {
-    html: personalStatementReasonsHtml
-    }
-  },
-  {
-    value: "communication",
-    text: "Could not get in touch with them",
-    checked: checked("['rejection']['categories']", "communication"),
-    conditional: {
-    html: communicationReasonsHtml
-    }
-  },
-  {
-    value: "interview",
-    text: "Could not arrange an interview",
-    checked: checked("['rejection']['categories']", "interview"),
-    conditional: {
-    html: sponsorshipHtml
-    }
-  },
-  {
-    value: "interview-performance",
-    text: "Interview performance was not strong enough",
-    checked: checked("['rejection']['categories']", "interview-performance"),
-    conditional: {
-    html: personalStatementReasonsHtml
-    }
-  },
-  {
-    value: "safeguarding",
-    text: "We have safeguarding concerns",
-    checked: checked("['rejection']['categories']", "safeguarding"),
-    conditional: {
-    html: safeguardingHtml
-    }
-  },
-  {
-    value: "visa-sponsorship",
-    text: "We cannot sponsor a visa",
-    checked: checked("['rejection']['categories']", "visa-sponsorship"),
-    conditional: {
-    html: sponsorshipHtml
-    }
-  },
-  {
-    value: "course-full",
-    text: "The course is now full",
-    checked: checked("['rejection']['categories']", "course-full"),
-    conditional: {
-    html: courseFullHtml
-    }
-  },
-  {
-    value: "other",
-    text: "Other",
-    checked: checked("['rejection']['categories']", "other"),
-    conditional: {
-    html: otherDetailsHtml
-    }
-  }
-        ]
-   }) }}
+        items: [
+        {
+          value: "degree-subject",
+          text: "Does not have a degree or A level in " + application.subject[0].name,
+          checked: checked("['rejection']['categories']", "degree-subject"),
+          conditional: {
+          html: subjectKnowledgeHtml
+          }
+        },
+        {
+          value: "degree-class",
+          text: "Degree class does not meet course requirements",
+          checked: checked("['rejection']['categories']", "degree-class"),
+          conditional: {
+          html: degreeClassDoesNotMeetRequirementsHtml
+          }
+        },
+        {
+          value: "personal-statement",
+          text: "Personal statement did not demonstrate they are suitable to teach",
+          checked: checked("['rejection']['categories']", "personal-statement"),
+          conditional: {
+          html: personalStatementReasonsHtml
+          }
+        },
+        {
+          value: "communication",
+          text: "Could not get in touch with them",
+          checked: checked("['rejection']['categories']", "communication"),
+          conditional: {
+          html: communicationReasonsHtml
+          }
+        },
+        {
+          value: "interview",
+          text: "Could not arrange an interview",
+          checked: checked("['rejection']['categories']", "interview"),
+          conditional: {
+          html: couldNotArrangeInterviewHtml
+          }
+        },
+        {
+          value: "interview-performance",
+          text: "Interview performance was not strong enough",
+          checked: checked("['rejection']['categories']", "interview-performance"),
+          conditional: {
+          html: interviewPerformanceHtml
+          }
+        },
+        {
+          value: "safeguarding",
+          text: "We have safeguarding concerns",
+          checked: checked("['rejection']['categories']", "safeguarding"),
+          conditional: {
+          html: safeguardingHtml
+          }
+        },
+        {
+          value: "visa-sponsorship",
+          text: "We cannot sponsor a visa",
+          checked: checked("['rejection']['categories']", "visa-sponsorship"),
+          conditional: {
+          html: visaSponsorshipHtml
+          }
+        },
+        {
+          value: "course-full",
+          text: "The course is now full",
+          checked: checked("['rejection']['categories']", "course-full"),
+          conditional: {
+          html: courseFullHtml
+          }
+        }
+      ]
+    }) }}
 
 
     {{ govukTextarea({

--- a/app/views/applications/reject/reasons.njk
+++ b/app/views/applications/reject/reasons.njk
@@ -29,8 +29,6 @@
 
       <h1 class="govuk-heading-l">Feedback for {{ name }}</h1>
 
-      {{ data.rejection | dump }}
-
       <form method="get" action="/applications/{{ applicationId }}/reject/check">
 
         {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}

--- a/app/views/applications/reject/reasons.njk
+++ b/app/views/applications/reject/reasons.njk
@@ -29,6 +29,7 @@
 
       <h1 class="govuk-heading-l">Feedback for {{ name }}</h1>
 
+      {{ data.rejection | dump }}
 
       <form method="get" action="/applications/{{ applicationId }}/reject/check">
 

--- a/app/views/applications/reject/reasons.njk
+++ b/app/views/applications/reject/reasons.njk
@@ -26,9 +26,16 @@
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      {% set h1 %}
-        {{heading}}
-      {% endset %}
+
+      {# <h1 class="govuk-heading-l">Feedback for {{ name }}</h1>
+
+      <p class="govuk-body">
+        You’ve said {{ name }} does not meet the ITT criteria because:
+      </p>
+
+      <ul class="govuk-list govuk-list--bullet">
+        <li>they do not have a degree or equivalent</li>
+      </ul> #}
 
       <form method="post">
 
@@ -41,11 +48,37 @@
         {% endset %}
 
         {% set teachingKnowledgeReasonsHtml %}
-          {% include "_includes/reasons/teaching-knowledge.njk" %}
+        {{ govukTextarea({
+          name: "more-detail",
+          id: "more-detail",
+          label: {
+            text: "Give details",
+            classes: "govuk-label--s"
+          }
+        }) }}
         {% endset %}
 
         {% set communicationReasonsHtml %}
-          {% include "_includes/reasons/communication.njk" %}
+                  {{ govukTextarea({
+          name: "more-detail",
+          id: "more-detail",
+          label: {
+            text: "Give details",
+            classes: "govuk-label--s"
+          }
+        }) }}
+
+        {% endset %}
+
+        {% set adviceHtml %}
+        {{ govukTextarea({
+            name: "more-detail",
+            id: "more-detail",
+            label: {
+              text: "Give details",
+              classes: "govuk-label--s"
+            }
+          }) }}
         {% endset %}
 
         {% set referencesHtml %}
@@ -64,60 +97,100 @@
           {{appRejectionDetails({ category: 'other', reason: 'details', data: data })}}
         {% endset %}
 
+        {% set courseFullHtml %}
+        {{ govukTextarea({
+            name: "more-detail",
+            id: "more-detail",
+            label: {
+              text: "Give details",
+              classes: "govuk-label--s"
+            }
+          }) }}
+        {% endset %}
+
+        {% set degreeDoesNotMeetRequirementsHtml %}
+           {{ govukTextarea({
+            name: "more-detail",
+            id: "more-detail",
+            label: {
+              text: "Give details",
+              classes: "govuk-label--s"
+            }
+          }) }}
+        {% endset %}
+
+        {% set degreeClassDoesNotMeetRequirementsHtml %}
+           {{ govukTextarea({
+            name: "more-detail",
+            id: "more-detail",
+            label: {
+              text: "Give details",
+              classes: "govuk-label--s"
+            }
+          }) }}
+        {% endset %}
+
         {{ govukCheckboxes({
           idPrefix: "rejection-categories",
           name: "rejection[categories]",
           fieldset: {
             legend: {
-              html: h1,
+              text: "Tell " + name + " why you are rejecting them",
               isPageHeading: true,
               classes: "govuk-fieldset__legend--l"
             }
           },
           items: [
-            {
-              value: "Qualifications",
-              text: "Qualifications",
-              checked: checked("['rejection']['categories']", "Qualifications"),
-              conditional: {
-                html: qualificationReasonsHtml
-              }
-            },
+          {
+    value: "Degree subject does not meet course requirements",
+    text: "Does not have a degree or A level in physics",
+    checked: checked("['rejection']['" + category + "-reasons']", "Degree does not meet course requirements"),
+    conditional: {
+      html: degreeDoesNotMeetRequirementsHtml
+    }
+  },
+  {
+    value: "Degree class does not meet course requirements",
+    text: "Degree class does not meet course requirements",
+    checked: checked("['rejection']['" + category + "-reasons']", "Degree does not meet course requirements"),
+    conditional: {
+      html: degreeClassDoesNotMeetRequirementsHtml
+    }
+  },
             {
               value: "Personal statement",
-              text: "Personal statement",
+              text: "Personal statement is not strong enough",
               checked: checked("['rejection']['categories']", "Personal statement"),
               conditional: {
                 html: personalStatementReasonsHtml
               }
             },
             {
-              value: "Teaching knowledge and ability",
-              text: "Teaching knowledge and ability",
-              checked: checked("['rejection']['categories']", "Teaching knowledge and ability"),
+              value: "Personal statement",
+              text: "Interview performance was not strong enough",
+              checked: checked("['rejection']['categories']", "Personal statement"),
               conditional: {
-                html: teachingKnowledgeReasonsHtml
+                html: personalStatementReasonsHtml
+              }
+            },
+            {
+              value: "Visa sponsorship",
+              text: "Not enough knowledge of the teaching profession",
+              conditional: {
+                html: sponsorshipHtml
               }
             },
             {
               value: "Communication, attendance and scheduling",
-              text: "Communication, attendance and scheduling",
+              text: "Could not get in touch with them",
               checked: checked("['rejection']['categandies']", "Communication, attendance or scheduling"),
               conditional: {
                 html: communicationReasonsHtml
               }
             },
             {
-              value: "References",
-              text: "References",
-              checked: checked("['rejection']['categories']", "References"),
-              conditional: {
-                html: referencesHtml
-              }
-            },
-            {
               value: "Safeguarding",
-              text: "Safeguarding",
+              text: "We have safeguarding concerns",
               checked: checked("['rejection']['categories']", "Safeguarding"),
               conditional: {
                 html: safeguardingHtml
@@ -125,16 +198,26 @@
             },
             {
               value: "Visa sponsorship",
-              text: "Visa sponsorship",
+              text: "We cannot sponsor a visa",
               checked: checked("['rejection']['categories']", "Visa sponsorship"),
               conditional: {
                 html: sponsorshipHtml
               }
             },
             {
+              value: "Visa sponsorship",
+              text: "Could not arrange an interview",
+              conditional: {
+                html: sponsorshipHtml
+              }
+            },
+            {
               value: "Course full",
-              text: "Course full",
-              checked: checked("['rejection']['categories']", "Course full")
+              text: "The course is now full",
+              checked: checked("['rejection']['categories']", "Course full"),
+              conditional: {
+                html: courseFullHtml
+              }
             },
             {
               value: "Other",
@@ -146,6 +229,22 @@
             }
           ]
         }) }}
+
+
+{{ govukTextarea({
+  name: "more-detail",
+  id: "more-detail",
+  label: {
+    text: "Give " + name + " advice on what to do next",
+    classes: "govuk-label--m"
+  },
+  hint: {
+    text: "For example, ‘You should apply again to a different course’"
+  }
+}) }}
+
+
+
 
         {{ govukButton({
           text: "Continue"

--- a/app/views/applications/reject/reasons.njk
+++ b/app/views/applications/reject/reasons.njk
@@ -34,7 +34,7 @@
 
         {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
         {{ govukWarningText({
-          text: "You must not use lack of school experience as a reason for rejecting an otherwise suitable applicant.",
+          text: "You must not reject candidates for lack of experience working in a school.",
           iconFallbackText: "Warning"
         }) }}
 
@@ -134,18 +134,19 @@
           name: "rejection[categories]",
           fieldset: {
             legend: {
-              text: "Tell " + name + " why you are rejecting them",
+              text: "Tell " + name + " why you are rejecting their application",
               isPageHeading: false,
               classes: "govuk-fieldset__legend--m"
             }
           },
-          items: [
-          {
+  items: [
+
+  {
     value: "Degree subject does not meet course requirements",
     text: "Does not have a degree or A level in physics",
     checked: checked("['rejection']['" + category + "-reasons']", "Degree does not meet course requirements"),
     conditional: {
-      html: degreeDoesNotMeetRequirementsHtml
+    html: degreeDoesNotMeetRequirementsHtml
     }
   },
   {
@@ -153,74 +154,74 @@
     text: "Degree class does not meet course requirements",
     checked: checked("['rejection']['" + category + "-reasons']", "Degree does not meet course requirements"),
     conditional: {
-      html: degreeClassDoesNotMeetRequirementsHtml
+    html: degreeClassDoesNotMeetRequirementsHtml
     }
   },
-            {
-              value: "Personal statement",
-              text: "Personal statement is not strong enough",
-              checked: checked("['rejection']['categories']", "Personal statement"),
-              conditional: {
-                html: personalStatementReasonsHtml
-              }
-            },
-            {
-              value: "Personal statement",
-              text: "Interview performance was not strong enough",
-              checked: checked("['rejection']['categories']", "Personal statement"),
-              conditional: {
-                html: personalStatementReasonsHtml
-              }
-            },
-            {
-              value: "Communication, attendance and scheduling",
-              text: "Could not get in touch with them",
-              checked: checked("['rejection']['categandies']", "Communication, attendance or scheduling"),
-              conditional: {
-                html: communicationReasonsHtml
-              }
-            },
-            {
-              value: "Safeguarding",
-              text: "We have safeguarding concerns",
-              checked: checked("['rejection']['categories']", "Safeguarding"),
-              conditional: {
-                html: safeguardingHtml
-              }
-            },
-            {
-              value: "Visa sponsorship",
-              text: "We cannot sponsor a visa",
-              checked: checked("['rejection']['categories']", "Visa sponsorship"),
-              conditional: {
-                html: sponsorshipHtml
-              }
-            },
-            {
-              value: "Visa sponsorship",
-              text: "Could not arrange an interview",
-              conditional: {
-                html: sponsorshipHtml
-              }
-            },
-            {
-              value: "Course full",
-              text: "The course is now full",
-              checked: checked("['rejection']['categories']", "Course full"),
-              conditional: {
-                html: courseFullHtml
-              }
-            },
-            {
-              value: "Other",
-              text: "Other",
-              checked: checked("['rejection']['categories']", "Other"),
-              conditional: {
-                html: otherDetailsHtml
-              }
-            }
-          ]
-        }) }}
+  {
+    value: "Personal statement",
+    text: "Personal statement did not demonstrate they are suitable to teach",
+    checked: checked("['rejection']['categories']", "Personal statement"),
+    conditional: {
+    html: personalStatementReasonsHtml
+    }
+  },
+  {
+    value: "Communication, attendance and scheduling",
+    text: "Could not get in touch with them",
+    checked: checked("['rejection']['categandies']", "Communication, attendance or scheduling"),
+    conditional: {
+    html: communicationReasonsHtml
+    }
+  },
+  {
+    value: "Visa sponsorship",
+    text: "Could not arrange an interview",
+    conditional: {
+    html: sponsorshipHtml
+    }
+  },
+  {
+    value: "Personal statement",
+    text: "Interview performance was not strong enough",
+    checked: checked("['rejection']['categories']", "Personal statement"),
+    conditional: {
+    html: personalStatementReasonsHtml
+    }
+  },
+  {
+    value: "Safeguarding",
+    text: "We have safeguarding concerns",
+    checked: checked("['rejection']['categories']", "Safeguarding"),
+    conditional: {
+    html: safeguardingHtml
+    }
+  },
+  {
+    value: "Visa sponsorship",
+    text: "We cannot sponsor a visa",
+    checked: checked("['rejection']['categories']", "Visa sponsorship"),
+    conditional: {
+    html: sponsorshipHtml
+    }
+  },
+  {
+    value: "Course full",
+    text: "The course is now full",
+    checked: checked("['rejection']['categories']", "Course full"),
+    conditional: {
+    html: courseFullHtml
+    }
+  },
+  {
+    value: "Other",
+    text: "Other",
+    checked: checked("['rejection']['categories']", "Other"),
+    conditional: {
+    html: otherDetailsHtml
+    }
+  }
+        ]
+   }) }}
 
 
 {{ govukTextarea({

--- a/app/views/applications/reject/reasons.njk
+++ b/app/views/applications/reject/reasons.njk
@@ -174,13 +174,6 @@
               }
             },
             {
-              value: "Visa sponsorship",
-              text: "Not enough knowledge of the teaching profession",
-              conditional: {
-                html: sponsorshipHtml
-              }
-            },
-            {
               value: "Communication, attendance and scheduling",
               text: "Could not get in touch with them",
               checked: checked("['rejection']['categandies']", "Communication, attendance or scheduling"),

--- a/app/views/applications/reject/reasons.njk
+++ b/app/views/applications/reject/reasons.njk
@@ -27,17 +27,16 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      {# <h1 class="govuk-heading-l">Feedback for {{ name }}</h1>
+      <h1 class="govuk-heading-l">Feedback for {{ name }}</h1>
 
-      <p class="govuk-body">
-        You’ve said {{ name }} does not meet the ITT criteria because:
-      </p>
-
-      <ul class="govuk-list govuk-list--bullet">
-        <li>they do not have a degree or equivalent</li>
-      </ul> #}
 
       <form method="post">
+
+        {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
+        {{ govukWarningText({
+          text: "You must not use lack of school experience as a reason for rejecting an otherwise suitable applicant.",
+          iconFallbackText: "Warning"
+        }) }}
 
         {% set qualificationReasonsHtml %}
           {% include "_includes/reasons/qualifications.njk" %}
@@ -136,8 +135,8 @@
           fieldset: {
             legend: {
               text: "Tell " + name + " why you are rejecting them",
-              isPageHeading: true,
-              classes: "govuk-fieldset__legend--l"
+              isPageHeading: false,
+              classes: "govuk-fieldset__legend--m"
             }
           },
           items: [

--- a/app/views/applications/reject/recommend.njk
+++ b/app/views/applications/reject/recommend.njk
@@ -1,0 +1,67 @@
+{% extends "_layout.njk" %}
+
+{% set primaryNavId = 'applications' %}
+{% set name = application.personalDetails.name %}
+
+{% if application.status == "Rejected" %}
+  {% set caption = content.giveFeedback.caption + ' - ' + name %}
+  {% set heading = "Reasons the application was rejected" %}
+{% else %}
+  {% set caption = content.rejectApplication.caption + ' - ' + name %}
+  {% set heading = "Reasons for rejecting the application" %}
+{% endif %}
+{% set title = heading + ' - ' + caption %}
+
+{% block pageNavigation %}
+  {% set backUrl = "/applications/" + application.id + "/decision" %}
+  {% if application.status == "Rejected" %}
+    {% set backUrl = "/applications/" + application.id %}
+  {% endif %}
+
+  {{ govukBackLink({
+    href: backUrl
+  }) }}
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {% set h1 %}
+        <span class="govuk-caption-l">{{caption}}</span>
+        {{heading}}
+      {% endset %}
+
+      <form method="post" action="/applications/{{ application.id }}/reject/science">
+
+{{ govukRadios({
+        name: "degree",
+        fieldset: {
+          legend: {
+            text: "Would you recommend this candidate?",
+            isPageHeading: true,
+            classes: "govuk-fieldset__legend--l"
+          }
+        },
+        hint: {
+          text: "Your answer will not be shown to the candidate"
+        },
+        items: [
+          {
+            value: "england",
+            text: "Yes, they should go into a pool of recommended candidates"
+          },
+          {
+            value: "scotland",
+            text: "No"
+          }
+        ]
+      }) }}
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+      </form>
+
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/applications/reject/recommend.njk
+++ b/app/views/applications/reject/recommend.njk
@@ -48,7 +48,7 @@
         items: [
           {
             value: "england",
-            text: "Yes, they should go into a pool of recommended candidates"
+            text: "Yes, they should go into a shortlist of recommended candidates"
           },
           {
             value: "scotland",

--- a/app/views/applications/reject/science.njk
+++ b/app/views/applications/reject/science.njk
@@ -49,7 +49,7 @@
       {% set gradesHtml %}
         <ul class="govuk-list">
         {% for grade in item.grade %}
-          <li>{{ grade.grade }}{% if grade.exam %} ({{ grade.exam }}){% endif %}</li>
+          <li>{{ grade.grade }}{% if grade.subject %} ({{ grade.subject }}){% endif %}</li>
         {% endfor %}
         </ul>
       {% endset %}

--- a/app/views/applications/reject/science.njk
+++ b/app/views/applications/reject/science.njk
@@ -35,6 +35,11 @@
 
       <h1 class="govuk-heading-l">Science</h1>
 
+      <p class="govuk-body">Candidates on a primary course must have achieved a standard equivalent to a grade 4 (C) in the GCSE examinations in a science.</p>
+
+      <p class="govuk-body">It is the standard, not the certificate, that matters. Candidates who are otherwise suitable but have not successfully achieved a GCSE grade 4 may be given an opportunity to show that they can meet the required standard either by taking an equivalence test or by offering other evidence of attainment, which should demonstrate a similar level and breadth.</p>
+
+
       <p class="govuk-body">{{ name }} has said this:</p>
 
 
@@ -191,7 +196,7 @@
         name: "degree",
         fieldset: {
           legend: {
-            text: "Do they meet the standard equivalent to grade 4 science GCSE?",
+            text: "Do they meet the standard equivalent to grade 4 (C) in a science GCSE?",
             isPageHeading: true,
             classes: "govuk-fieldset__legend--m"
           }
@@ -203,11 +208,11 @@
           },
           {
             value: "scotland",
-            text: "Yes, they have demonstrated they meet the standard in some othe way"
+            text: "Yes, they have demonstrated they meet the standard in some other way"
           },
           {
             value: "wales",
-            text: "They don’t have a qualification and we are not able to offer a GCSE equivalency test"
+            text: "They don’t have GCSE grade 4 (C) or an an equivalent qualification and we are not able to offer a GCSE equivalency test"
           }
         ]
       }) }}

--- a/app/views/applications/reject/science.njk
+++ b/app/views/applications/reject/science.njk
@@ -33,7 +33,7 @@
 
       <form method="post" action="/applications/{{ application.id }}/reject/science-answer">
 
-      <h1 class="govuk-heading-l">Science GCSE equivalent</h1>
+      <h1 class="govuk-heading-l">Science GCSE criteria</h1>
 
       <p class="govuk-body">Candidates applying to a primary course must have achieved a standard equivalent to a grade 4 (C) in the GCSE examinations in a science subject.</p>
 
@@ -185,7 +185,7 @@
           },
           {
             value: "not-met",
-            text: "They do not have an equivalent qualification and we’re not able to offer a GCSE equivalency test",
+            text: "No, they do not have an equivalent qualification and we’re not able to offer a GCSE equivalency test",
             checked: (data.rejection.scienceCriteria == 'met-standard')
           }
         ]

--- a/app/views/applications/reject/science.njk
+++ b/app/views/applications/reject/science.njk
@@ -1,0 +1,222 @@
+{% extends "_layout.njk" %}
+
+{% set primaryNavId = 'applications' %}
+{% set name = application.personalDetails.name %}
+
+{% if application.status == "Rejected" %}
+  {% set caption = content.giveFeedback.caption + ' - ' + name %}
+  {% set heading = "Reasons the application was rejected" %}
+{% else %}
+  {% set caption = content.rejectApplication.caption + ' - ' + name %}
+  {% set heading = "Reasons for rejecting the application" %}
+{% endif %}
+{% set title = heading + ' - ' + caption %}
+
+{% block pageNavigation %}
+  {% set backUrl = "/applications/" + application.id + "/decision" %}
+  {% if application.status == "Rejected" %}
+    {% set backUrl = "/applications/" + application.id %}
+  {% endif %}
+
+  {{ govukBackLink({
+    href: backUrl
+  }) }}
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {% set h1 %}
+        <span class="govuk-caption-l">{{caption}}</span>
+        {{heading}}
+      {% endset %}
+
+      <form method="post" action="/applications/{{ application.id }}/reject/other">
+
+      <h1 class="govuk-heading-l">Science</h1>
+
+      <p class="govuk-body">{{ name }} has said this:</p>
+
+
+      {% set item = application.gcse.science %}
+
+      {% set gradesHtml %}
+        <ul class="govuk-list">
+        {% for grade in item.grade %}
+          <li>{{ grade.grade }}{% if grade.exam %} ({{ grade.exam }}){% endif %}</li>
+        {% endfor %}
+        </ul>
+      {% endset %}
+
+      <dl class="govuk-summary-list">
+        {% if item.hasQualification == "Yes" %}
+
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+              Qualification type
+            </dt>
+            <dd class="govuk-summary-list__value">
+              {{ item.type }}
+            </dd>
+          </div>
+
+          {% if item.country != "United Kingdom" %}
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Country or territory
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {{ item.country }}
+              </dd>
+            </div>
+          {% endif %}
+
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+              Grade
+            </dt>
+            <dd class="govuk-summary-list__value">
+              {{ gradesHtml | safe }}
+            </dd>
+          </div>
+
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+              Year awarded
+            </dt>
+            <dd class="govuk-summary-list__value">
+              {{ item.year }}
+            </dd>
+          </div>
+
+          {% if item.retake %}
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Are you currently studying to retake this qualification?
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {{ item.retake.isRetaking }}
+              </dd>
+            </div>
+            {% if item.retake.isRetaking == "No" %}
+              <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                  Evidence of having {{ item.subject if item.subject == 'English' else item.subject | lower }} skills at the required standard
+                </dt>
+                <dd class="govuk-summary-list__value">
+                  {{ item.retake.evidence }}
+                </dd>
+              </div>
+            {% endif %}
+          {% endif %}
+
+          {% if item.naric %}
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                UK ENIC reference number
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {{ item.naric.reference }}
+              </dd>
+            </div>
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Comparable UK qualification
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {{ item.naric.comparable }}
+              </dd>
+            </div>
+          {% else %}
+            {% if application.personalDetails.isInternationalCandidate %}
+              <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                  Do you have a UK ENIC statement of comparability?
+                </dt>
+                <dd class="govuk-summary-list__value">
+                  No
+                </dd>
+              </div>
+            {% endif %}
+          {% endif %}
+
+        {% else %}
+
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+              What type of {{ item.subject if item.subject == 'English' else item.subject | lower }} qualification do you have?
+            </dt>
+            <dd class="govuk-summary-list__value">
+              {{ item.missing.hasQualification }}
+            </dd>
+          </div>
+
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+              Are you currently studying for this qualification?
+            </dt>
+            <dd class="govuk-summary-list__value">
+              {{ item.missing.isStudying }}
+            </dd>
+          </div>
+
+          {% if item.missing.studyingDetails %}
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Details of the qualification you’re studying for
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {{ item.missing.studyingDetails }}
+              </dd>
+            </div>
+          {% endif %}
+
+          {% if item.missing.otherReason %}
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Other evidence of having {{ item.subject if item.subject == 'English' else item.subject | lower }} skills at the required standard
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {{ item.missing.otherReason }}
+              </dd>
+            </div>
+          {% endif %}
+
+        {% endif %}
+      </dl>
+
+      {% from "govuk/components/radios/macro.njk" import govukRadios %}
+
+      {{ govukRadios({
+        name: "degree",
+        fieldset: {
+          legend: {
+            text: "Do they meet the standard equivalent to grade 4 science GCSE?",
+            isPageHeading: true,
+            classes: "govuk-fieldset__legend--m"
+          }
+        },
+        items: [
+          {
+            value: "england",
+            text: "Yes, they have an equivalent qualification"
+          },
+          {
+            value: "scotland",
+            text: "Yes, they have demonstrated they meet the standard in some othe way"
+          },
+          {
+            value: "wales",
+            text: "They don’t have a qualification and we are not able to offer a GCSE equivalency test"
+          }
+        ]
+      }) }}
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+      </form>
+
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/applications/reject/science.njk
+++ b/app/views/applications/reject/science.njk
@@ -31,7 +31,7 @@
         {{heading}}
       {% endset %}
 
-      <form method="post" action="/applications/{{ application.id }}/reject/other">
+      <form method="post" action="/applications/{{ application.id }}/reject/science-answer">
 
       <h1 class="govuk-heading-l">Science GCSE equivalent</h1>
 
@@ -116,36 +116,6 @@
             {% endif %}
           {% endif %}
 
-          {% if item.naric %}
-            <div class="govuk-summary-list__row">
-              <dt class="govuk-summary-list__key">
-                UK ENIC reference number
-              </dt>
-              <dd class="govuk-summary-list__value">
-                {{ item.naric.reference }}
-              </dd>
-            </div>
-            <div class="govuk-summary-list__row">
-              <dt class="govuk-summary-list__key">
-                Comparable UK qualification
-              </dt>
-              <dd class="govuk-summary-list__value">
-                {{ item.naric.comparable }}
-              </dd>
-            </div>
-          {% else %}
-            {% if application.personalDetails.isInternationalCandidate %}
-              <div class="govuk-summary-list__row">
-                <dt class="govuk-summary-list__key">
-                  Do you have a UK ENIC statement of comparability?
-                </dt>
-                <dd class="govuk-summary-list__value">
-                  No
-                </dd>
-              </div>
-            {% endif %}
-          {% endif %}
-
         {% else %}
 
           <div class="govuk-summary-list__row">
@@ -194,7 +164,7 @@
       {% from "govuk/components/radios/macro.njk" import govukRadios %}
 
       {{ govukRadios({
-        name: "degree",
+        name: "rejection[scienceCriteria]",
         fieldset: {
           legend: {
             text: "Do they meet the standard equivalent to grade 4 (C) in a science GCSE?",
@@ -204,16 +174,19 @@
         },
         items: [
           {
-            value: "england",
-            text: "Yes, they have an equivalent qualification"
+            value: "met-qualification",
+            text: "Yes, they have an equivalent qualification",
+            checked: (data.rejection.scienceCriteria == 'met-qualification')
           },
           {
-            value: "scotland",
-            text: "Yes, they’ve demonstrated they meet the standard in another way"
+            value: "met-standard",
+            text: "Yes, they’ve demonstrated they meet the standard in another way",
+            checked: (data.rejection.scienceCriteria == 'met-standard')
           },
           {
-            value: "wales",
-            text: "They do not have an equivalent qualification and we’re not able to offer a GCSE equivalency test"
+            value: "not-met",
+            text: "They do not have an equivalent qualification and we’re not able to offer a GCSE equivalency test",
+            checked: (data.rejection.scienceCriteria == 'met-standard')
           }
         ]
       }) }}

--- a/app/views/applications/reject/science.njk
+++ b/app/views/applications/reject/science.njk
@@ -33,12 +33,13 @@
 
       <form method="post" action="/applications/{{ application.id }}/reject/other">
 
-      <h1 class="govuk-heading-l">Science</h1>
+      <h1 class="govuk-heading-l">Science GCSE equivalent</h1>
 
-      <p class="govuk-body">Candidates on a primary course must have achieved a standard equivalent to a grade 4 (C) in the GCSE examinations in a science.</p>
+      <p class="govuk-body">Candidates applying to a primary course must have achieved a standard equivalent to a grade 4 (C) in the GCSE examinations in a science subject.</p>
 
       <p class="govuk-body">It is the standard, not the certificate, that matters. Candidates who are otherwise suitable but have not successfully achieved a GCSE grade 4 may be given an opportunity to show that they can meet the required standard either by taking an equivalence test or by offering other evidence of attainment, which should demonstrate a similar level and breadth.</p>
 
+      <p class="govuk-body">Contact <a href="#">becomingateacher@digital.education.gov.uk</a> if you're not sure this candidate meets the criteria.</p>
 
       <p class="govuk-body">{{ name }} has said this:</p>
 
@@ -208,11 +209,11 @@
           },
           {
             value: "scotland",
-            text: "Yes, they have demonstrated they meet the standard in some other way"
+            text: "Yes, they’ve demonstrated they meet the standard in another way"
           },
           {
             value: "wales",
-            text: "They don’t have GCSE grade 4 (C) or an an equivalent qualification and we are not able to offer a GCSE equivalency test"
+            text: "They do not have an equivalent qualification and we’re not able to offer a GCSE equivalency test"
           }
         ]
       }) }}

--- a/scripts/generate-applications.js
+++ b/scripts/generate-applications.js
@@ -455,6 +455,125 @@ const generateFakeApplications = () => {
   }))
 
 
+  applications.push(generateFakeApplication({
+    id: '18571512',
+    status: 'Received',
+    course: 'Primary (2S8T)',
+    subject: [
+      {
+        "code": "P1",
+        "name": "Primary"
+      }
+    ],
+    personalDetails: {
+      givenName: 'Freida',
+      familyName: 'Jackson',
+      sex: 'Female',
+      dateOfBirth: '1964-05-11',
+      nationalities: [
+        'British'
+      ],
+      isInternationalCandidate: false
+    },
+    gcse: {
+      maths: {
+        hasQualification: 'Yes',
+        type: 'O level',
+        subject: 'Maths',
+        country: 'United Kingdom',
+        grade: [
+          {
+            grade: 'C'
+          }
+        ],
+        year: 1980
+      },
+      english: {
+        hasQualification: 'Yes',
+        type: 'O level',
+        subject: 'English',
+        country: 'United Kingdom',
+        grade: [
+          {
+            grade: 'B'
+          }
+        ],
+        year: 1980
+      },
+      science: {
+        hasQualification: 'Yes',
+        type: 'O level',
+        subject: 'English',
+        country: 'United Kingdom',
+        grade: [
+          {
+            subject: 'Biology',
+            grade: 'C'
+          }
+        ],
+        year: 1980
+      }
+    },
+    degree: [
+      {
+        type: 'BA',
+        subject: 'German language',
+        institution: 'University of East Anglia',
+        country: 'United Kingdom',
+        grade: 'First-class honours',
+        predicted: false,
+        startYear: '1982',
+        graduationYear: '1986'
+      }
+    ],
+    otherQualifications: [
+      {
+        "type": "Higher Diploma",
+        "subject": "Higher Diploma",
+        "country": "Ghana",
+        "grade": "Pass",
+        "year": "2015"
+      }
+    ],
+    workHistory: {
+      answer: 'yes',
+      items: [
+        {
+          category: 'job',
+          role: 'Librarian',
+          org: 'Lancashire libraries service',
+          type: 'Full time',
+          relevantToTeaching: 'No',
+          startDate: '2015-07-14',
+          endDate: '2018-12-06',
+          isStartDateApproximate: false,
+          isEndDateApproximate: false
+        },
+        {
+          category: 'job',
+          role: 'Researcher',
+          org: 'University of Lancashire',
+          type: 'Full time',
+          relevantToTeaching: 'No',
+          startDate: '2019-01-01',
+          endDate: false,
+          isStartDateApproximate: false,
+          isEndDateApproximate: false
+        }
+      ]
+    },
+    schoolExperience: [],
+    personalStatement: {
+      vocation: "During my school days it was my maths teacher who inspired and taught me to love maths. I discovered that through good teaching methods and stirring up a student’s love and passion for learning anything is possible. I learned from this teacher that mathematics is fun and not as horrible as I thought, the hatred for mathematics was replaced by love and interest to study and practice. This inspired and made me develop an interest in teaching to help students who might be having similar issues.\n\n When I studied maths at university, I discovered that with the right teaching methods, love, patience, understanding, and helping the students develop love and interest in learning, there is virtually no student that can’t learn mathematics. Sound knowledge of the concepts by the teacher builds his/her confidence and also builds the student's trust in the teacher which in turn motivates them to learn.\n\n From working at a university (although I was a researcher) I learned that a lot is expected from teachers as students look up to them as role models and mentors and as such, it is expected that the teacher should be a person of integrity. Because of this I try and model the right attitudes and virtues to every student I have come in contact with at my job.\n\n From being both a librarian and researcher, I have also discovered that learning is not limited to the four walls of the classroom and learning can take place anywhere and anytime. Students tend to retain information or ideas learned during fun or personal discovery for a longer period, so extracurricular activities also help to produce a balanced student and I believe it is an important aspect of learning.\n\n The education system and curriculum should have the well-being and development of the child at their centre. The interest and wholesome development of the child should be the goal of educational policies and the curriculum. Having children who are developed in all areas will eventually result in an organised and a developed society.\n\n I strongly believe that obtaining the Qualified Teachers Status certificate will boost and increase my chances of working and impacting the lives of students.",
+      subjectKnowledge: "I studied mathematics at the university. This helped to sharpen my critical thinking skills and also aided my reasoning. I naturally appreciate numbers and possess a strong affinity for patterns and logic.\n\n I am familiar with the curriculum and I have prepared my own children for their own maths exams. I have also informally helped students at the university with their lessons and mathematical concepts. These experiences have enabled me to acquire the necessary skills to excel as a teacher. Having good communication skills and being an adept listener have given me room for mutual understanding and improved student-teacher relationships.\n\n I enjoy working with students in my current role as a university researcher. I believe that this stage of their life is crucial in making career decisions, and I love to see that they do not allow their former hatred for mathematics to stop them from pursuing their careers."
+    },
+    safeguarding: {
+      response: false
+    },
+    assignedUsers: [],
+    cycle: CycleHelper.CURRENT_CYCLE.code
+  }))
+
 
   return applications
 }

--- a/scripts/generate-applications.js
+++ b/scripts/generate-applications.js
@@ -313,17 +313,6 @@ const generateFakeApplications = () => {
       items: [
         {
           category: 'job',
-          role: 'School placement experience',
-          org: 'Bishop Vesey Grammar School',
-          type: 'Full time',
-          relevantToTeaching: 'Yes',
-          startDate: '2022-09-14',
-          endDate: '2022-10-14',
-          isStartDateApproximate: false,
-          isEndDateApproximate: false
-        },
-        {
-          category: 'job',
           role: 'Waiter',
           org: 'Turtle Bay',
           type: 'Full time',
@@ -337,8 +326,8 @@ const generateFakeApplications = () => {
     },
     schoolExperience: [],
     personalStatement: {
-      vocation: "I feel I’m well placed to teach French having grown up in a french speaking family and being fluent in the language. Sharing my knowledge of this wonderful language and leading the way has always been one of my dreams for a long time. Teaching can be both very rewarding and challenging, which I have experienced through going to Bishop Vesey Grammar School on a 1 month school experience program to observe how teachers operate. Education is not the process of filling a bucket. It’s the experience of helping someone achieve whatever they want. Being part of that process and helping to shape young people’s future is what I’m passionate about.",
-      subjectKnowledge: "Thinking about my own experience in education, I appreciate the incredible impact my teachers had on my life. I know that teachers provide skills and knowledge used by young people throughout life. My greatest aim as a teacher is to be a role model. I want to cultivate open minds and help pupils believe in their own capacity to make positive contributions to society."
+      vocation: "I feel I’m well placed to teach French having grown up in a french speaking family and being fluent in the language.",
+      subjectKnowledge: "Thinking about my own experience in education, I appreciate the incredible impact my teachers had on my life."
     },
     safeguarding: {
       response: false

--- a/scripts/generate-applications.js
+++ b/scripts/generate-applications.js
@@ -362,7 +362,7 @@ const generateFakeApplications = () => {
       givenName: 'Peter',
       familyName: 'Essien',
       sex: 'Male',
-      dateOfBirth: '1994-01-03',
+      dateOfBirth: '1997-09-19',
       nationalities: [
         'British'
       ],
@@ -420,19 +420,8 @@ const generateFakeApplications = () => {
       items: [
         {
           category: 'job',
-          role: 'Librarian',
-          org: 'Lancashire libraries service',
-          type: 'Full time',
-          relevantToTeaching: 'No',
-          startDate: '2015-07-14',
-          endDate: '2018-12-06',
-          isStartDateApproximate: false,
-          isEndDateApproximate: false
-        },
-        {
-          category: 'job',
-          role: 'Researcher',
-          org: 'University of Lancashire',
+          role: 'School Health and Education Coordinator',
+          org: 'Ghana Education Service',
           type: 'Full time',
           relevantToTeaching: 'No',
           startDate: '2019-01-01',
@@ -444,8 +433,8 @@ const generateFakeApplications = () => {
     },
     schoolExperience: [],
     personalStatement: {
-      vocation: "During my school days it was my maths teacher who inspired and taught me to love maths. I discovered that through good teaching methods and stirring up a student’s love and passion for learning anything is possible. I learned from this teacher that mathematics is fun and not as horrible as I thought, the hatred for mathematics was replaced by love and interest to study and practice. This inspired and made me develop an interest in teaching to help students who might be having similar issues.\n\n When I studied maths at university, I discovered that with the right teaching methods, love, patience, understanding, and helping the students develop love and interest in learning, there is virtually no student that can’t learn mathematics. Sound knowledge of the concepts by the teacher builds his/her confidence and also builds the student's trust in the teacher which in turn motivates them to learn.\n\n From working at a university (although I was a researcher) I learned that a lot is expected from teachers as students look up to them as role models and mentors and as such, it is expected that the teacher should be a person of integrity. Because of this I try and model the right attitudes and virtues to every student I have come in contact with at my job.\n\n From being both a librarian and researcher, I have also discovered that learning is not limited to the four walls of the classroom and learning can take place anywhere and anytime. Students tend to retain information or ideas learned during fun or personal discovery for a longer period, so extracurricular activities also help to produce a balanced student and I believe it is an important aspect of learning.\n\n The education system and curriculum should have the well-being and development of the child at their centre. The interest and wholesome development of the child should be the goal of educational policies and the curriculum. Having children who are developed in all areas will eventually result in an organised and a developed society.\n\n I strongly believe that obtaining the Qualified Teachers Status certificate will boost and increase my chances of working and impacting the lives of students.",
-      subjectKnowledge: "I studied mathematics at the university. This helped to sharpen my critical thinking skills and also aided my reasoning. I naturally appreciate numbers and possess a strong affinity for patterns and logic.\n\n I am familiar with the curriculum and I have prepared my own children for their own maths exams. I have also informally helped students at the university with their lessons and mathematical concepts. These experiences have enabled me to acquire the necessary skills to excel as a teacher. Having good communication skills and being an adept listener have given me room for mutual understanding and improved student-teacher relationships.\n\n I enjoy working with students in my current role as a university researcher. I believe that this stage of their life is crucial in making career decisions, and I love to see that they do not allow their former hatred for mathematics to stop them from pursuing their careers."
+      vocation: "In my current role as a School Health and Education Coordinator, has opened my eyes to the fascinating subject of teaching. Seeing such young poverty-stricken children with so much life and eagerness to learn posed many questions: could sparking enthusiasm in children and engaging them to learn through their studies be for me? Am I destined to be a teacher? Where do I learn more about education and inspiring others through teaching? My wish to find out more about child development, education and school curriculum started my interest in teaching. My interest in schools and learning developed further in Sunday school, where I was introduced to areas of Special Education Needs and Disability learning support: child development and 1:1 mentoring, and the differing aspects of teaching in church as opposed to teaching in primary and secondary schools. I became interested in SEND, SENCOs and learning support challenges, leading me to embark upon a SEN training course. The course taught me about the SEN needs background and how the introduction of SEN children into mainstream schools impacted schools in their planning for communication, interaction, social, emotional and mental health difficulties. Beyond teaching, due to my infectious enthusiasm and brilliance in my role as a School Health and Education Coordinator I have learnt a lot about how a teacher should conduct themselves inside and outside the classroom.",
+      subjectKnowledge: "I am personable, energetic and always up for a challenge. I have done a teaching internship at a secondary school where I supported SEN students with reading, writing, maths and French activities and lessons. While working in secondary education, I gained knowledge on child development, teaching strategies and behaviour management. I have also been familiarising myself with the English national curriculum and during my internship at Achimota Senior High School I was given the opportunity to assist teachers in planning lessons, managing behaviours in the classroom and supporting student learning whilst adhering to the national curriculum and child safeguarding guidelines. Through my work, I have a unique ability to see where students need support, I also communicate well with teachers and other teaching staff, to support a team atmosphere. I inspire a love for learning and find that children gravitate towards me in all areas of my life, this allows me to accomplish my classroom aims of supporting their understanding of subjects and encouragement in their healthy peer relationships."
     },
     safeguarding: {
       response: false
@@ -503,7 +492,7 @@ const generateFakeApplications = () => {
       science: {
         hasQualification: 'Yes',
         type: 'O level',
-        subject: 'English',
+        subject: 'Biology',
         country: 'United Kingdom',
         grade: [
           {
@@ -526,36 +515,27 @@ const generateFakeApplications = () => {
         graduationYear: '1986'
       }
     ],
-    otherQualifications: [
-      {
-        "type": "Higher Diploma",
-        "subject": "Higher Diploma",
-        "country": "Ghana",
-        "grade": "Pass",
-        "year": "2015"
-      }
-    ],
     workHistory: {
       answer: 'yes',
       items: [
         {
           category: 'job',
-          role: 'Librarian',
-          org: 'Lancashire libraries service',
+          role: 'Observing a classroom (unpaid)',
+          org: 'St Marys Community Primary School',
           type: 'Full time',
-          relevantToTeaching: 'No',
-          startDate: '2015-07-14',
-          endDate: '2018-12-06',
+          relevantToTeaching: 'Yes',
+          startDate: '2022-09-1',
+          endDate: '2022-11-30',
           isStartDateApproximate: false,
           isEndDateApproximate: false
         },
         {
           category: 'job',
-          role: 'Researcher',
-          org: 'University of Lancashire',
+          role: 'Administrative assistant',
+          org: 'Mitchell and Mcgill Law Firm',
           type: 'Full time',
           relevantToTeaching: 'No',
-          startDate: '2019-01-01',
+          startDate: '2002-03-04',
           endDate: false,
           isStartDateApproximate: false,
           isEndDateApproximate: false
@@ -564,8 +544,8 @@ const generateFakeApplications = () => {
     },
     schoolExperience: [],
     personalStatement: {
-      vocation: "During my school days it was my maths teacher who inspired and taught me to love maths. I discovered that through good teaching methods and stirring up a student’s love and passion for learning anything is possible. I learned from this teacher that mathematics is fun and not as horrible as I thought, the hatred for mathematics was replaced by love and interest to study and practice. This inspired and made me develop an interest in teaching to help students who might be having similar issues.\n\n When I studied maths at university, I discovered that with the right teaching methods, love, patience, understanding, and helping the students develop love and interest in learning, there is virtually no student that can’t learn mathematics. Sound knowledge of the concepts by the teacher builds his/her confidence and also builds the student's trust in the teacher which in turn motivates them to learn.\n\n From working at a university (although I was a researcher) I learned that a lot is expected from teachers as students look up to them as role models and mentors and as such, it is expected that the teacher should be a person of integrity. Because of this I try and model the right attitudes and virtues to every student I have come in contact with at my job.\n\n From being both a librarian and researcher, I have also discovered that learning is not limited to the four walls of the classroom and learning can take place anywhere and anytime. Students tend to retain information or ideas learned during fun or personal discovery for a longer period, so extracurricular activities also help to produce a balanced student and I believe it is an important aspect of learning.\n\n The education system and curriculum should have the well-being and development of the child at their centre. The interest and wholesome development of the child should be the goal of educational policies and the curriculum. Having children who are developed in all areas will eventually result in an organised and a developed society.\n\n I strongly believe that obtaining the Qualified Teachers Status certificate will boost and increase my chances of working and impacting the lives of students.",
-      subjectKnowledge: "I studied mathematics at the university. This helped to sharpen my critical thinking skills and also aided my reasoning. I naturally appreciate numbers and possess a strong affinity for patterns and logic.\n\n I am familiar with the curriculum and I have prepared my own children for their own maths exams. I have also informally helped students at the university with their lessons and mathematical concepts. These experiences have enabled me to acquire the necessary skills to excel as a teacher. Having good communication skills and being an adept listener have given me room for mutual understanding and improved student-teacher relationships.\n\n I enjoy working with students in my current role as a university researcher. I believe that this stage of their life is crucial in making career decisions, and I love to see that they do not allow their former hatred for mathematics to stop them from pursuing their careers."
+      vocation: "My education journey is firmly rooted in the inspiring primary school teachers I had growing up. I remember feeling fully supported, gently guided and made to feel I could achieve my goals. I now hope to become this type of teacher, to guide young children in a positive direction. I have volunteered at the school listening to readers in Key Stage 1 and Lower Key Stage 2. I particularly enjoyed engaging with the children and helping to reinforce their phonics knowledge, as well as watching the children develop their love of stories and reading for pleasure. I have also helped my own children throughout their schooling in helping them understand subjects they struggled with like Maths and foreign languages. Through observing teachers at St Mary’s Community Primary School, I have seen first-hand the demands of the profession; classroom and behaviour management within a mixed ability class, periods of assessment, and managing the expectations of parents and carers. However, I have also seen the unwavering commitment of all teachers towards their pupils, and the hundreds of ‘little wins’ that show how rewarding the role of teacher can be. I am particularly looking forward to being challenged and ultimately making a small difference. Though my intention will be to strive for perfection in my role as a teacher, I have realistic expectations. External factors such as a child’s behaviour, homelife and special educational needs may hinder my ability to succeed in this aim and it may at times feel like a struggle. However, I will aim to provide a stimulating learning environment for the children in my care, in conjunction with being supportive and encouraging while offering a safe space for children to make mistakes and learn from them.",
+      subjectKnowledge: "Primary teaching offers a wide range of learning opportunities for children, and I hope to introduce the children to many different subjects and experiences. I have always loved languages and I carried this love through to completing a degree in German at the University of East Anglia. I firmly believe that introducing a second language to young children is vital. Not only will the children have their first experience of a different language, but it will also start a conversation about different cultures and the multicultural world that we live in. I hope to be able to use my enthusiasm for foreign languages in my role as a primary school teacher to start these conversations, and perhaps to inspire other children to seek out opportunities to learn and use a foreign language. I also have a particular love of literature and feel it is important to promote reading and storytelling from a young age. I hope to give children the confidence to learn to read, to broaden their vocabulary and ultimately to enjoy retrieving information from a written text. While studying for my English Literature A-level, I enjoyed reading poetry and comparing poems. I found the analysis of the structure of the poems and the use of rhythm and words chosen to be of particular interest. I look forward to introducing the children to poetry in the form of simple poems and nursery rhymes."
     },
     safeguarding: {
       response: false

--- a/scripts/generate-applications.js
+++ b/scripts/generate-applications.js
@@ -237,16 +237,16 @@ const generateFakeApplications = () => {
   applications.push(generateFakeApplication({
     id: '46436',
     status: 'Received',
-    course: 'Mathematics (MA14)',
+    course: 'Modern languages (French) (MD9Q)',
     subject: [
       {
-        "code": "M1",
-        "name": "Mathematics"
+        "code": "F1",
+        "name": "French"
       }
     ],
     personalDetails: {
-      givenName: 'Jane',
-      familyName: 'Smith',
+      givenName: 'Malika',
+      familyName: 'Boutella',
       sex: 'Female',
       dateOfBirth: '1994-01-03',
       nationalities: [
@@ -262,10 +262,10 @@ const generateFakeApplications = () => {
         country: 'United Kingdom',
         grade: [
           {
-            grade: 'A'
+            grade: 'C'
           }
         ],
-        year: 2009
+        year: 2017
       },
       english: {
         hasQualification: 'Yes',
@@ -275,35 +275,22 @@ const generateFakeApplications = () => {
         grade: [
           {
             exam: 'English',
-            grade: 'A'
+            grade: 'C'
           }
         ],
-        year: 2009
-      },
-      science: {
-        hasQualification: 'Yes',
-        type: 'GCSE',
-        subject: 'Double Science',
-        country: 'United Kingdom',
-        grade: [
-          {
-            exam: 'English',
-            grade: 'BB'
-          }
-        ],
-        year: 2009
+        year: 2017
       }
     },
     degree: [
       {
-        type: 'BSc',
-        subject: 'Mathematics',
-        institution: 'University of Central Lancashire',
+        type: 'BA',
+        subject: 'English',
+        institution: 'University of Sheffield',
         country: 'United Kingdom',
-        grade: '2:1',
+        grade: '3rd',
         predicted: false,
-        startYear: '2011',
-        graduationYear: '2015'
+        startYear: '2019',
+        graduationYear: '2022'
       }
     ],
     otherQualifications: [
@@ -355,316 +342,6 @@ const generateFakeApplications = () => {
   }))
 
 
-  applications.push(generateFakeApplication({
-    course: 'Mathematics (MA14)',
-    courseCode: 'HIS1',
-    studyMode: 'Full time',
-    provider: user.organisation.name,
-    id: '63633',
-    status: 'Received',
-    assignedUsers: [],
-    cycle: CycleHelper.CURRENT_CYCLE.code,
-    subject: [
-      {
-        "code": "M1",
-        "name": "Mathematics"
-      }
-    ],
-    personalDetails: {
-      givenName: 'Tommy',
-      familyName: 'Doyle',
-      sex: 'Male',
-      dateOfBirth: '1996-01-03',
-      nationalities: [
-        'British'
-      ],
-      isInternationalCandidate: false
-    },
-    degree: [
-      {
-        type: 'BSc',
-        subject: 'Mathematics',
-        institution: 'University of Leeds',
-        country: 'United Kingdom',
-        grade: '2:1',
-        predicted: false,
-        startYear: '2018',
-        graduationYear: '2021'
-      }
-    ],
-    gcse: {
-      maths: {
-        hasQualification: 'Yes',
-        type: 'GCSE',
-        subject: 'Maths',
-        country: 'United Kingdom',
-        grade: [
-          {
-            grade: 'A'
-          }
-        ],
-        year: 2016
-      },
-      english: {
-        hasQualification: 'Yes',
-        type: 'GCSE',
-        subject: 'English',
-        country: 'United Kingdom',
-        grade: [
-          {
-            exam: 'English',
-            grade: 'A'
-          }
-        ],
-        year: 2016
-      }
-    },
-    otherQualifications: [
-      {
-        "type": "A level",
-        "subject": "Mathematics",
-        "country": "United Kingdom",
-        "grade": "A",
-        "year": "2018"
-      },
-      {
-        "type": "A level",
-        "subject": "Statistics",
-        "country": "United Kingdom",
-        "grade": "B",
-        "year": "2018"
-      },
-      {
-        "type": "A level",
-        "subject": "Economics",
-        "country": "United Kingdom",
-        "grade": "C",
-        "year": "2018"
-      }
-    ],
-    references: {},
-    schoolExperience: [
-    ],
-    notes: {
-      items: [
-      ]
-    },
-    workHistory: {
-      answer: 'yes',
-      items: [
-        {
-          category: 'job',
-          role: 'Bar staff',
-          org: 'Red Lion pub',
-          type: 'Full time',
-          relevantToTeaching: 'No',
-          startDate: '2021-07-14',
-          endDate: false,
-          isStartDateApproximate: false,
-          isEndDateApproximate: false
-        }
-      ]
-    },
-    schoolExperience: [
-    ],
-    safeguarding: {
-      response: false
-    },
-    interviewNeeds: {
-      response: false
-    },
-    disability: {
-      response: false
-    },
-    personalStatement: {
-      vocation: "My primary motivation for wanting to become a teacher is that I love working with children and supporting them in developing as individuals and reaching their full potential. I believe teaching would be an enjoyable and rewarding career for me and one to which I am well-suited.\n\n I received advice from a Teaching Advisor that becoming a teacher would be the best way to pursue a career in education and one that was open to me as a holder of a Mathematics degree. After reflection on this advice I came to the conclusion that this was something I was interested in.\n\n My first experience of working with children was as a support worker at a community centre in my area. During my time at the centre I had the privilege to work with a wide range of students and learned a huge amount about working with young people.\n\n My work as a support worker (both with adults and children) has required me to support people in accessing their communities and taking part in outings and activities of a wide variety. I also have led after school and lunchtime clubs related to my own interests, including maths and music. I believe this experience would be invaluable in contributing to a school inside and outside the classroom.\n\n In addition, my experience as a performer has helped me build the confidence to stand in front of a classroom. I have also received extensive training in safeguarding and behaviour support having worked with adults and children with SEND for many years. I believe it is paramount to the development of healthy and happy young people that the professionals working with them are good role-models, and that with vigilance, dedication and compassion a teacher can make a huge difference to their lives. It would be an enormous honour to be given the opportunity to become a teacher.",
-      subjectKnowledge: "Mathematics has always been one of my strongest subjects and I chose to study this subject at A-Level and for my degree because of the satisfaction I gained from working through complex problems. I am already confident with the curriculum so I feel I am well placed to teach it.\n\n I studied a BSc in Maths at Leeds University and I found the subjects I studied fascinating and this knowledge of high-level Mathematics would be beneficial when working with students who have the ability and inclination to take their study of the subject further.\n\n I also have experience of organising and delivering a study clubs to groups of SEND students at a community centre in my area. This was enormously rewarding, particularly in the way I saw the students develop and begin to enjoy the practice over many months.\n\n I have had a lifelong interest in music. I have played and sung in various different groups over the years in front of many audiences, and this has helped me build confidence in public speaking and presentation. I am always keen to inspire and encourage a love for music in young people and would welcome any opportunities a career in teaching presented me with to do this."
-    }
-  }))
-
-
-
-  applications.push(generateFakeApplication({
-    course: 'Mathematics (MA14)',
-    courseCode: 'HIS1',
-    studyMode: 'Full time',
-    provider: user.organisation.name,
-    id: '618451',
-    status: 'Received',
-    assignedUsers: [],
-    cycle: CycleHelper.CURRENT_CYCLE.code,
-    subject: [
-      {
-        "code": "M1",
-        "name": "Mathematics"
-      }
-    ],
-    personalDetails: {
-      givenName: 'Aisha',
-      familyName: 'Fadel',
-      sex: 'Female',
-      dateOfBirth: '1996-01-03',
-      nationalities: [
-        'British'
-      ],
-      isInternationalCandidate: false
-    },
-    degree: [
-      {
-        type: 'BSc',
-        subject: 'Economics',
-        institution: 'University of Central Lancashire',
-        country: 'United Kingdom',
-        grade: '2:1',
-        predicted: false,
-        startYear: '2018',
-        graduationYear: '2021'
-      }
-    ],
-    gcse: {
-      maths: {
-        hasQualification: 'Yes',
-        type: 'GCSE',
-        subject: 'Maths',
-        country: 'United Kingdom',
-        grade: [
-          {
-            grade: 'B'
-          }
-        ],
-        year: 2016
-      },
-      english: {
-        hasQualification: 'Yes',
-        type: 'GCSE',
-        subject: 'English',
-        country: 'United Kingdom',
-        grade: [
-          {
-            exam: 'English',
-            grade: 'A'
-          }
-        ],
-        year: 2016
-      }
-    },
-    otherQualifications: [
-      {
-        "type": "A level",
-        "subject": "Economics",
-        "country": "United Kingdom",
-        "grade": "A",
-        "year": "2018"
-      },
-      {
-        "type": "A level",
-        "subject": "Mathematics",
-        "country": "United Kingdom",
-        "grade": "B",
-        "year": "2018"
-      },
-      {
-        "type": "A level",
-        "subject": "Chemistry",
-        "country": "United Kingdom",
-        "grade": "C",
-        "year": "2018"
-      }
-    ],
-    references: {},
-    schoolExperience: [
-    ],
-    notes: {
-      items: [
-      ]
-    },
-    workHistory: {
-      answer: 'yes',
-      items: [
-        {
-          category: 'job',
-          role: 'Business Analyst',
-          org: 'Department for Work and Pensions',
-          type: 'Full time',
-          relevantToTeaching: 'No',
-          startDate: '2021-07-14',
-          endDate: false,
-          isStartDateApproximate: false,
-          isEndDateApproximate: false
-        }
-      ]
-    },
-    schoolExperience: [
-    ],
-    safeguarding: {
-      response: false
-    },
-    interviewNeeds: {
-      response: false
-    },
-    disability: {
-      response: false
-    },
-    personalStatement: {
-      vocation: "I want to become a teacher because I’m passionate about learning, I love working with youth groups and I want to have a positive impact on the future of humanity. I believe education has the power to transform and empower the world. Our children are our most valuable asset and education is the key by which their true value can be realised.\n\n My teachers played a pivotal role in educating, inspiring, and shaping my life, and now I aspire to do the same for my students. For me, contributing to children's education, growth and development is exciting, meaningful, and satisfying. This is also a way for me to give back to society, what I have been privileged to receive, which brings me joy.\n\n Every teacher has a different personality but teachers who were my role models had some common traits, which I deem to be essential for being a good teacher. They were always trustworthy, understood their students, relationship builders, and excellent presenters and listeners. In my short career, I have worked on weaving these traits into my job.",
-      subjectKnowledge: "My educational background includes A levels in Maths, Chemistry and Economics, and a degree in Economics. I believe these credentials will enable me to teach the curriculum to students as I know the subject matter very well because I am familiar with the curriculum having only finished my A levels 3 years ago.\n\n I am also currently volunteering as an exam invigilator at local schools in my area. I am responsible for ensuring that exam rules are being followed and that students are being supervised in an appropriate manner. I have performed my invigilator duties with utmost responsibility and am good at managing special and/or unforeseen circumstances such as a student feeling sick or a fire alarm going off. This experience has helped me see how things are run at a school and has helped me form good relationships with other teachers."
-    }
-  }))
-
-
-  applications.push(generateFakeApplication({
-    id: '57261',
-    status: 'Received',
-    course: 'French with Spanish (FS23)',
-    assignedUsers: [],
-    cycle: CycleHelper.CURRENT_CYCLE.code,
-    provider: user.organisation.name,
-    subject: [
-      {
-        "code": "F1",
-        "name": "French"
-      },
-      {
-        "code": "S1",
-        "name": "Spanish"
-      }
-    ],
-    personalDetails: {
-      givenName: 'Michelle',
-      familyName: 'Aragon',
-      sex: 'Female',
-      dateOfBirth: '1994-01-03',
-      nationalities: [
-        'British'
-      ],
-      isInternationalCandidate: false
-    }
-  }))
-
-applications.push(generateFakeApplication({
-    id: '3464',
-    status: 'Received',
-    course: 'PE with EBacc (PE13)',
-    assignedUsers: [],
-    cycle: CycleHelper.CURRENT_CYCLE.code,
-    provider: user.organisation.name,
-    subject: [
-      {
-        "code": "F1",
-        "name": "PE with EBacc"
-      }
-    ],
-    personalDetails: {
-      givenName: 'John',
-      familyName: 'Routledge',
-      sex: 'Males',
-      dateOfBirth: '1994-01-03',
-      nationalities: [
-        'British'
-      ],
-      isInternationalCandidate: false
-    }
-  }))
 
 
   return applications

--- a/scripts/generate-applications.js
+++ b/scripts/generate-applications.js
@@ -342,6 +342,112 @@ const generateFakeApplications = () => {
   }))
 
 
+  applications.push(generateFakeApplication({
+    id: '9475924',
+    status: 'Received',
+    course: 'History (H152)',
+    subject: [
+      {
+        "code": "H1",
+        "name": "History"
+      }
+    ],
+    personalDetails: {
+      givenName: 'Peter',
+      familyName: 'Essien',
+      sex: 'Male',
+      dateOfBirth: '1994-01-03',
+      nationalities: [
+        'British'
+      ],
+      isInternationalCandidate: false
+    },
+    gcse: {
+      maths: {
+        hasQualification: 'Yes',
+        type: 'Maths senior secondary school certificate',
+        subject: 'Maths',
+        country: 'Ghana',
+        grade: [
+          {
+            grade: 'B'
+          }
+        ],
+        year: 2015
+      },
+      english: {
+        hasQualification: 'Yes',
+        type: 'English senior secondary school certificate',
+        subject: 'English',
+        country: 'Ghana',
+        grade: [
+          {
+            grade: 'B'
+          }
+        ],
+        year: 2015
+      }
+    },
+    degree: [
+      {
+        type: 'BEd',
+        subject: 'Social Studies',
+        institution: 'University of Education',
+        country: 'Ghana',
+        grade: 'Pass',
+        predicted: false,
+        startYear: '2016',
+        graduationYear: '2019'
+      }
+    ],
+    otherQualifications: [
+      {
+        "type": "Higher Diploma",
+        "subject": "Higher Diploma",
+        "country": "Ghana",
+        "grade": "Pass",
+        "year": "2015"
+      }
+    ],
+    workHistory: {
+      answer: 'yes',
+      items: [
+        {
+          category: 'job',
+          role: 'Librarian',
+          org: 'Lancashire libraries service',
+          type: 'Full time',
+          relevantToTeaching: 'No',
+          startDate: '2015-07-14',
+          endDate: '2018-12-06',
+          isStartDateApproximate: false,
+          isEndDateApproximate: false
+        },
+        {
+          category: 'job',
+          role: 'Researcher',
+          org: 'University of Lancashire',
+          type: 'Full time',
+          relevantToTeaching: 'No',
+          startDate: '2019-01-01',
+          endDate: false,
+          isStartDateApproximate: false,
+          isEndDateApproximate: false
+        }
+      ]
+    },
+    schoolExperience: [],
+    personalStatement: {
+      vocation: "During my school days it was my maths teacher who inspired and taught me to love maths. I discovered that through good teaching methods and stirring up a student’s love and passion for learning anything is possible. I learned from this teacher that mathematics is fun and not as horrible as I thought, the hatred for mathematics was replaced by love and interest to study and practice. This inspired and made me develop an interest in teaching to help students who might be having similar issues.\n\n When I studied maths at university, I discovered that with the right teaching methods, love, patience, understanding, and helping the students develop love and interest in learning, there is virtually no student that can’t learn mathematics. Sound knowledge of the concepts by the teacher builds his/her confidence and also builds the student's trust in the teacher which in turn motivates them to learn.\n\n From working at a university (although I was a researcher) I learned that a lot is expected from teachers as students look up to them as role models and mentors and as such, it is expected that the teacher should be a person of integrity. Because of this I try and model the right attitudes and virtues to every student I have come in contact with at my job.\n\n From being both a librarian and researcher, I have also discovered that learning is not limited to the four walls of the classroom and learning can take place anywhere and anytime. Students tend to retain information or ideas learned during fun or personal discovery for a longer period, so extracurricular activities also help to produce a balanced student and I believe it is an important aspect of learning.\n\n The education system and curriculum should have the well-being and development of the child at their centre. The interest and wholesome development of the child should be the goal of educational policies and the curriculum. Having children who are developed in all areas will eventually result in an organised and a developed society.\n\n I strongly believe that obtaining the Qualified Teachers Status certificate will boost and increase my chances of working and impacting the lives of students.",
+      subjectKnowledge: "I studied mathematics at the university. This helped to sharpen my critical thinking skills and also aided my reasoning. I naturally appreciate numbers and possess a strong affinity for patterns and logic.\n\n I am familiar with the curriculum and I have prepared my own children for their own maths exams. I have also informally helped students at the university with their lessons and mathematical concepts. These experiences have enabled me to acquire the necessary skills to excel as a teacher. Having good communication skills and being an adept listener have given me room for mutual understanding and improved student-teacher relationships.\n\n I enjoy working with students in my current role as a university researcher. I believe that this stage of their life is crucial in making career decisions, and I love to see that they do not allow their former hatred for mathematics to stop them from pursuing their careers."
+    },
+    safeguarding: {
+      response: false
+    },
+    assignedUsers: [],
+    cycle: CycleHelper.CURRENT_CYCLE.code
+  }))
+
 
 
   return applications

--- a/scripts/generate-applications.js
+++ b/scripts/generate-applications.js
@@ -153,7 +153,7 @@ const generateFakeApplication = (params = {}) => {
 
   let otherQualifications
 
-  if(!params.otherQualifications) {
+  if(!params.otherQualifications == null) {
     otherQualifications = generateOtherQualifications()
   } else {
     otherQualifications = params.otherQualifications
@@ -492,7 +492,7 @@ const generateFakeApplications = () => {
       science: {
         hasQualification: 'Yes',
         type: 'O level',
-        subject: 'Biology',
+        subject: 'Science',
         country: 'United Kingdom',
         grade: [
           {
@@ -515,6 +515,7 @@ const generateFakeApplications = () => {
         graduationYear: '1986'
       }
     ],
+    otherQualifications: false,
     workHistory: {
       answer: 'yes',
       items: [


### PR DESCRIPTION
This is a sketch of how we might pull out the ITT criteria from the existing "reject" flow by asking about each criteria on a separate page. We’d skip these questions where it was obvious the candidate met the criteria (eg a UK bachelors degree, or a C at GCSE) and would only show the relevant pages where it was less clear cut.

The aim here would be to give providers better guidance on the ITT criteria, and a prompt to get in touch if they are unsure whether a candidate meets the criteria.

This is an alternative to #637 which lists them all on the same page.