### PR TITLE
Updated hint text on language SKE length

### DIFF
--- a/app/views/applications/offer/new/ske-length.njk
+++ b/app/views/applications/offer/new/ske-length.njk
@@ -22,7 +22,7 @@
 
         <h1 class="govuk-heading-l">Subject knowledge enhancement (SKE) course requirements</h1>
 
-        <p class="govuk-body">The 2 courses must not add up to more than 36 weeks.</p>
+        <p class="govuk-body">One language course must be 8 weeks. The other course can be between 8 and 28 weeks.</p>
 
         {% for language in data.skeLanguage %}
           {% if language != '_unchecked' %}


### PR DESCRIPTION
When testing the SKE provider flow with the policy team, we learnt that when there are 2 language courses, one (the 'main' language) should always be 8 weeks, the other can be between 8 and 28 weeks.

Our designs don't cater for differentiating between the 'main' language SKE and the other language SKE. To resolve this we have edited the hint text for the length question and will include validation to make sure 1 language SKE is always 8 weeks.

New hint text below. By saying 1 course must be 8 weeks and the other 8 to 28 weeks, we do not need to spell out that both should not be more than 36 weeks (but we will still have validation on if they select lengths for each course that leads to more than 36 weeks)

[Trello ticket](https://trello.com/c/wjpFzTqn/1193-%E2%9B%B7%EF%B8%8Fske-improve-our-validation-for-modern-language-ske-offers-with-2-language-courses)

<img width="631" alt="Screenshot 2023-02-21 at 11 55 58" src="https://user-images.githubusercontent.com/68232608/220339185-aa7fac2a-a692-453a-a621-5a6fd1cd0d8f.png">

