### PR TITLE
Upgrade heroku stack from 18 to 22

### DIFF
--- a/app.json
+++ b/app.json
@@ -19,5 +19,5 @@
     }
   },
   "name": "Apply (Prototype)",
-  "stack": "heroku-18"
+  "stack": "heroku-22"
 }


### PR DESCRIPTION
heroku-18 has been end-of-life since April 30th 2023.