### PR TITLE
Bugfix: markdown filter

### DIFF
--- a/app/views/_components/conditions-panel/template.njk
+++ b/app/views/_components/conditions-panel/template.njk
@@ -4,7 +4,7 @@
   {% for condition in params.conditions %}
     <div class="govuk-summary-list__row">
       <dt class="govuk-summary-list__key app-no-spacing-after-last-paragraph">
-        {{condition.description | markdownToHtml | safe }}
+        {{condition.description | govukMarkdown | safe }}
       </dt>
       <dd class="govuk-summary-list__value app-conditions-list__tag">
         {% if params.changeStatus %}

--- a/app/views/changes-to-this-service/index.njk
+++ b/app/views/changes-to-this-service/index.njk
@@ -53,7 +53,7 @@ Upcoming changes include:
       <p class="govuk-hint">Last updated: 26 January 2022</p>
       <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
       <div class="app-markdown">
-        {{ roadMapMarkdown | markdownToHtml | safe }}
+        {{ roadMapMarkdown | govukMarkdown | safe }}
       </div>
     </div>
   </div>

--- a/app/views/feedback/index.njk
+++ b/app/views/feedback/index.njk
@@ -15,7 +15,7 @@
       </h1>
 
       <div class="app-markdown">
-        {{ content | markdownToHtml | safe }}
+        {{ content | govukMarkdown | safe }}
       </div>
 
     </div>

--- a/app/views/guidance/show.njk
+++ b/app/views/guidance/show.njk
@@ -25,7 +25,7 @@
       </h1>
 
       <div class="app-markdown">
-        {{ content | markdownToHtml | safe }}
+        {{ content | govukMarkdown | safe }}
       </div>
 
     </div>

--- a/app/views/privacy/show.njk
+++ b/app/views/privacy/show.njk
@@ -29,7 +29,7 @@
       </h1>
 
       <div class="app-markdown">
-        {{ content | markdownToHtml | safe }}
+        {{ content | govukMarkdown | safe }}
       </div>
 
     </div>


### PR DESCRIPTION
Replace `markdownToHtml` with `govukMarkdown` from [string filters](https://x-govuk.github.io/govuk-prototype-filters/string/).

(Thanks @paulrobertlloyd!)