### PR TITLE
Bugfix: add missing 'includes' filter

### DIFF
--- a/app/filters.js
+++ b/app/filters.js
@@ -101,3 +101,9 @@ function arrayToList (array, join = ', ', final = ' and ') {
   return last
 }
 addFilter('arrayToList', arrayToList)
+
+function includes (array, string) {
+  return array.includes(string)
+}
+addFilter('includes', includes)
+


### PR DESCRIPTION
This was accidentally dropped when updating the kit, and is used on the rejection feedback page.