### PR TITLE
Bugfix: expose content to pages

### DIFF
--- a/app/routes/interviews.js
+++ b/app/routes/interviews.js
@@ -155,7 +155,8 @@ module.exports = router => {
     const application = req.session.data.applications.find(app => app.id === applicationId)
 
     res.render('applications/interviews/new/index', {
-      application
+      application,
+      content
     })
   })
 
@@ -168,7 +169,8 @@ module.exports = router => {
     const application = req.session.data.applications.find(app => app.id === applicationId)
 
     res.render('applications/interviews/new/check', {
-      application
+      application,
+      content
     })
   })
 
@@ -231,7 +233,8 @@ module.exports = router => {
 
     res.render('applications/interviews/edit/index', {
       application,
-      interview
+      interview,
+      content
     })
   })
 
@@ -246,6 +249,7 @@ module.exports = router => {
 
     res.render('applications/interviews/edit/check', {
       application,
+      content,
       interview: application.interviews.items.find(interview => interview.id === interviewId)
     })
   })
@@ -289,6 +293,7 @@ module.exports = router => {
 
     res.render('applications/interviews/delete/index', {
       application,
+      content,
       interview: application.interviews.items.find(interview => interview.id === interviewId)
     })
   })
@@ -304,6 +309,7 @@ module.exports = router => {
 
     res.render('applications/interviews/delete/check', {
       application,
+      content,
       interview: application.interviews.items.find(interview => interview.id === interviewId)
     })
   })

--- a/app/routes/make-offer.js
+++ b/app/routes/make-offer.js
@@ -46,7 +46,8 @@ module.exports = router => {
 
     res.render('applications/offer/new/ske', {
       application,
-      applicationId
+      applicationId,
+      content
     })
   })
 
@@ -80,7 +81,8 @@ module.exports = router => {
 
     res.render('applications/offer/new/ske-reason', {
       application,
-      applicationId
+      applicationId,
+      content
     })
   })
 
@@ -98,7 +100,8 @@ module.exports = router => {
 
     res.render('applications/offer/new/ske-length', {
       application,
-      applicationId
+      applicationId,
+      content
     })
   })
 
@@ -115,7 +118,8 @@ module.exports = router => {
 
     res.render('applications/offer/new/conditions', {
       application,
-      applicationId
+      applicationId,
+      content
     })
   })
 
@@ -192,6 +196,7 @@ module.exports = router => {
       studyMode,
       location,
       conditions,
+      content,
       actions: {
         back: `/applications/${req.params.applicationId}/offer/new`,
         cancel: `/applications/${req.params.applicationId}/offer/new/cancel`,


### PR DESCRIPTION
Some of the content, eg for buttons and headings, seems to be stored in a separate [`content.js`](https://github.com/DFE-Digital/manage-teacher-training-applications-prototype/blob/main/app/data/content.js) file.

For some reason the upgrade to v13 of the kit meant this variable was no longer being made available to the page templates.

The simplest fix was to list it within the `res.render()` calls of each of the pages in the routes file.

Longer term it might make sense to move away from this file and just copy all of the content back into the individual templates?