### PR TITLE
Bugfix: use native push function

### DIFF
--- a/app/views/applications/offer/new/check.njk
+++ b/app/views/applications/offer/new/check.njk
@@ -45,12 +45,12 @@
           {% set reason = data['skeReason-' + language] %}
           {% set length = data.skeCourseLengthRequired[language] %}
 
-          {% set skeConditions = skeConditions | push({
+          {% set skeConditions = skeConditions.push(skeConditions, {
               subject: language,
               reason: reason,
               deadline: data.skeDeadline,
               lengthRequired: length
-            ])
+            })
           %}
 
         {% endfor %}


### PR DESCRIPTION
There's no `push` filter declared, but we don't need it as we can use the native `.push()` function (albeit a bit clunky).