### PR TITLE
Updated interview needs content

### DIFF
--- a/app/views/_includes/applications/interview-needs.njk
+++ b/app/views/_includes/applications/interview-needs.njk
@@ -1,10 +1,10 @@
-<h2 class="govuk-heading-m govuk-!-margin-top-7 govuk-!-margin-bottom-2 govuk-!-font-size-27">Interview needs</h2>
+<h2 class="govuk-heading-m govuk-!-margin-top-7 govuk-!-margin-bottom-2 govuk-!-font-size-27">Interview availability</h2>
 
 {{ govukSummaryList({
   rows: [
     {
       key: {
-        text: "Do you have any interview needs?"
+        text: "Do you have any times you cannot be available for interviews?"
       },
       value: {
         text: "Yes" if application.interviewNeeds.response else "No"
@@ -12,7 +12,7 @@
     },
     {
       key: {
-        text: "What are your interview needs?"
+        text: "Give details of your interview availability"
       },
       value: {
         html: application.interviewNeeds.details


### PR DESCRIPTION
As part of continuous applications, we updated the 'Interview needs' question on Apply. This means we need to match that new content on Manage:

<img width="692" alt="Screenshot 2023-06-28 at 09 04 31" src="https://github.com/DFE-Digital/manage-teacher-training-applications-prototype/assets/68232608/44faaae9-0da1-434e-9ccd-2f4b7fc2ea7a">
