### PR TITLE
Replace faker with @faker-js/faker

### DIFF
--- a/app/data/generators/assigned-users.js
+++ b/app/data/generators/assigned-users.js
@@ -16,7 +16,7 @@ module.exports = (accreditedBody, provider, status) => {
       return user.organisation.id == accreditedBody.id
     })
 
-    const accreditedBodyUserCount = faker.datatype.number({ min: 1, max: 3 })
+    const accreditedBodyUserCount = faker.number.int({ min: 1, max: 3 })
 
     for (let i = 0; i < accreditedBodyUserCount; i++) {
       let accreditedBodyUser = {}
@@ -42,7 +42,7 @@ module.exports = (accreditedBody, provider, status) => {
       return user.organisation.id == provider.id
     })
 
-    const providerUserCount = faker.datatype.number({ min: 1, max: 3 })
+    const providerUserCount = faker.number.int({ min: 1, max: 3 })
 
     for (let i = 0; i < providerUserCount; i++) {
       let providerUser = {}

--- a/app/data/generators/assigned-users.js
+++ b/app/data/generators/assigned-users.js
@@ -1,4 +1,4 @@
-const faker = require('@faker-js/faker').faker
+const { fakerUK: faker } = require('@faker-js/faker')
 
 const _ = require('lodash')
 

--- a/app/data/generators/assigned-users.js
+++ b/app/data/generators/assigned-users.js
@@ -1,4 +1,4 @@
-const faker = require('faker')
+const faker = require('@faker-js/faker').faker
 faker.locale = 'en_GB'
 
 const _ = require('lodash')

--- a/app/data/generators/assigned-users.js
+++ b/app/data/generators/assigned-users.js
@@ -1,5 +1,4 @@
 const faker = require('@faker-js/faker').faker
-faker.locale = 'en_GB'
 
 const _ = require('lodash')
 

--- a/app/data/generators/assigned-users.js
+++ b/app/data/generators/assigned-users.js
@@ -21,7 +21,7 @@ module.exports = (accreditedBody, provider, status) => {
     for (let i = 0; i < accreditedBodyUserCount; i++) {
       let accreditedBodyUser = {}
 
-      accreditedBodyUser = faker.helpers.randomize(accreditedBodyUsers)
+      accreditedBodyUser = faker.helpers.arrayElement(accreditedBodyUsers)
 
       // clone the users so we can clean the data and only use what we need
       accreditedBodyUser = _.cloneDeep(accreditedBodyUser)
@@ -47,7 +47,7 @@ module.exports = (accreditedBody, provider, status) => {
     for (let i = 0; i < providerUserCount; i++) {
       let providerUser = {}
 
-      providerUser = faker.helpers.randomize(providerUsers)
+      providerUser = faker.helpers.arrayElement(providerUsers)
 
       // clone the users so we can clean the data and only use what we need
       providerUser = _.cloneDeep(providerUser)

--- a/app/data/generators/contact-details.js
+++ b/app/data/generators/contact-details.js
@@ -1,5 +1,4 @@
 const faker = require('@faker-js/faker').faker
-faker.locale = 'en_GB'
 
 module.exports = (personalDetails) => {
   if (personalDetails.isInternationalCandidate) {

--- a/app/data/generators/contact-details.js
+++ b/app/data/generators/contact-details.js
@@ -1,4 +1,4 @@
-const faker = require('faker')
+const faker = require('@faker-js/faker').faker
 faker.locale = 'en_GB'
 
 module.exports = (personalDetails) => {

--- a/app/data/generators/contact-details.js
+++ b/app/data/generators/contact-details.js
@@ -1,21 +1,22 @@
-const faker = require('@faker-js/faker').faker
-
 module.exports = (personalDetails) => {
+  let faker = require('@faker-js/faker').fakerUK
   if (personalDetails.isInternationalCandidate) {
-    faker.locale = 'fr'
-  } else {
-    faker.locale = 'en_GB'
+    faker = require('@faker-js/faker').fakerFR
   }
 
   return {
-    tel: faker.phone.phoneNumber(),
-    email: faker.internet.email(personalDetails.givenName, personalDetails.familyName).toLowerCase(),
+    tel: faker.phone.number(),
+    email: faker.internet.email({
+      firstName: personalDetails.givenName,
+      lastName: personalDetails.familyName
+    }
+    ).toLowerCase(),
     address: {
-      line1: faker.address.streetAddress(),
+      line1: faker.location.streetAddress(),
       line2: '',
-      level2: faker.address.city(),
-      level1: personalDetails.isInternationalCandidate ? faker.address.state() : faker.address.county(),
-      postcode: faker.address.zipCode(),
+      level2: faker.location.city(),
+      level1: personalDetails.isInternationalCandidate ? faker.location.state() : faker.location.county(),
+      postcode: faker.location.zipCode(),
       ...(personalDetails.isInternationalCandidate && { country: 'France' })
     },
     addressType: personalDetails.isInternationalCandidate ? 'international' : 'uk'

--- a/app/data/generators/course.js
+++ b/app/data/generators/course.js
@@ -1,5 +1,4 @@
 const faker = require('@faker-js/faker').faker
-faker.locale = 'en_GB'
 const weighted = require('weighted')
 
 const arrayToList = (array, join = ', ', final = ' and ') => {

--- a/app/data/generators/course.js
+++ b/app/data/generators/course.js
@@ -1,4 +1,4 @@
-const faker = require('@faker-js/faker').faker
+const { fakerUK: faker } = require('@faker-js/faker')
 const weighted = require('weighted')
 
 const arrayToList = (array, join = ', ', final = ' and ') => {

--- a/app/data/generators/course.js
+++ b/app/data/generators/course.js
@@ -1,4 +1,4 @@
-const faker = require('faker')
+const faker = require('@faker-js/faker').faker
 faker.locale = 'en_GB'
 const weighted = require('weighted')
 

--- a/app/data/generators/course.js
+++ b/app/data/generators/course.js
@@ -232,7 +232,7 @@ module.exports = (params = {}) => {
     }
 
     if (['French','German','Italian','Spanish'].includes(subject.name)) {
-      const languageCount = faker.datatype.number({ 'min': 1, 'max': 2 })
+      const languageCount = faker.number.int({ 'min': 1, 'max': 2 })
 
       const languageChoices = [
         { code: '15', name: 'French' },
@@ -253,7 +253,7 @@ module.exports = (params = {}) => {
     }
 
     if (['Japanese','Mandarin','Russian'].includes(subject.name)) {
-      const languageCount = faker.datatype.number({ 'min': 1, 'max': 2 })
+      const languageCount = faker.number.int({ 'min': 1, 'max': 2 })
 
       const languageChoices = [
         { code: '19', name: 'Japanese' },
@@ -273,7 +273,7 @@ module.exports = (params = {}) => {
     }
 
     if (['Biology','Chemistry','Physics'].includes(subject.name)) {
-      const scienceCount = faker.datatype.number({ 'min': 1, 'max': 2 })
+      const scienceCount = faker.number.int({ 'min': 1, 'max': 2 })
 
       const scienceChoices = [
         { code: 'C1', name: 'Biology' },
@@ -476,7 +476,7 @@ module.exports = (params = {}) => {
   // ---------------------------------------------------------------------------
   // Locations
   // ---------------------------------------------------------------------------
-  const locationCount = faker.datatype.number({ 'min': 1, 'max': 2 })
+  const locationCount = faker.number.int({ 'min': 1, 'max': 2 })
 
   const locationChoices = require('../locations')
 
@@ -567,7 +567,7 @@ module.exports = (params = {}) => {
   // ---------------------------------------------------------------------------
   const course = {}
 
-  course.code = faker.random.alphaNumeric(4).toUpperCase()
+  course.code = faker.string.alphanumeric({length: 4, casing: 'upper'})
   course.name = courseName
 
   course.subjects = subjects

--- a/app/data/generators/cycle.js
+++ b/app/data/generators/cycle.js
@@ -1,4 +1,4 @@
-const faker = require('faker')
+const faker = require('@faker-js/faker').faker
 faker.locale = 'en_GB'
 
 const CycleHelper = require('../helpers/cycles')

--- a/app/data/generators/cycle.js
+++ b/app/data/generators/cycle.js
@@ -1,5 +1,4 @@
 const faker = require('@faker-js/faker').faker
-faker.locale = 'en_GB'
 
 const CycleHelper = require('../helpers/cycles')
 

--- a/app/data/generators/cycle.js
+++ b/app/data/generators/cycle.js
@@ -1,4 +1,4 @@
-const faker = require('@faker-js/faker').faker
+const { fakerUK: faker } = require('@faker-js/faker')
 
 const CycleHelper = require('../helpers/cycles')
 

--- a/app/data/generators/cycle.js
+++ b/app/data/generators/cycle.js
@@ -3,7 +3,7 @@ const faker = require('@faker-js/faker').faker
 const CycleHelper = require('../helpers/cycles')
 
 module.exports = (params = {}) => {
-  let cycleCode = faker.helpers.randomize([
+  let cycleCode = faker.helpers.arrayElement([
     CycleHelper.PREVIOUS_CYCLE.code,
     CycleHelper.CURRENT_CYCLE.code
   ])

--- a/app/data/generators/degree.js
+++ b/app/data/generators/degree.js
@@ -1,5 +1,4 @@
 const faker = require('@faker-js/faker').faker
-faker.locale = 'en_GB'
 
 const { DateTime } = require('luxon')
 const weighted = require('weighted')

--- a/app/data/generators/degree.js
+++ b/app/data/generators/degree.js
@@ -8,7 +8,7 @@ module.exports = (params) => {
 
   // Start year - 18 or 19 years after date of birth
   let year = DateTime.fromISO(params.dateOfBirth).toObject().year
-  year += faker.helpers.randomize([18,19])
+  year += faker.helpers.arrayElement([18,19])
 
   const currentYear = DateTime.now().year
 
@@ -23,7 +23,7 @@ module.exports = (params) => {
   for (let i = 0; i < count; i++) {
     let degree = {}
 
-    degree.subject = faker.helpers.randomize(DegreeHelper.getSubjects())
+    degree.subject = faker.helpers.arrayElement(DegreeHelper.getSubjects())
 
     // Start year for second degree must be after first
     if (i > 0) {
@@ -51,11 +51,11 @@ module.exports = (params) => {
 
     } else {
 
-      const qualification = faker.helpers.randomize(DegreeHelper.getQualifications())
+      const qualification = faker.helpers.arrayElement(DegreeHelper.getQualifications())
 
       degree.level = qualification.level
 
-      degree.grade = faker.helpers.randomize([
+      degree.grade = faker.helpers.arrayElement([
         'First-class honours',
         'Upper second-class honours (2:1)',
         'Lower second-class honours (2:2)',
@@ -69,7 +69,7 @@ module.exports = (params) => {
 
       degree.type = qualification.text + (degree.grade.includes('honours') ? ' (Hons)' : '')
 
-      degree.institution = faker.helpers.randomize(DegreeHelper.getInstitutions())
+      degree.institution = faker.helpers.arrayElement(DegreeHelper.getInstitutions())
       degree.country = 'United Kingdom'
     }
 

--- a/app/data/generators/degree.js
+++ b/app/data/generators/degree.js
@@ -1,4 +1,4 @@
-const faker = require('faker')
+const faker = require('@faker-js/faker').faker
 faker.locale = 'en_GB'
 
 const { DateTime } = require('luxon')

--- a/app/data/generators/degree.js
+++ b/app/data/generators/degree.js
@@ -27,13 +27,13 @@ module.exports = (params) => {
 
     // Start year for second degree must be after first
     if (i > 0) {
-      degree.startYear = degrees[i-1].startYear + faker.datatype.number({ 'min': 1, 'max': 10 })
+      degree.startYear = degrees[i-1].startYear + faker.number.int({ 'min': 1, 'max': 10 })
     } else {
       degree.startYear = year
     }
 
     // Set the graduation year to be between 3 and 4 years after start year
-    degree.graduationYear = degree.startYear + faker.datatype.number({ 'min': 3, 'max': 4 })
+    degree.graduationYear = degree.startYear + faker.number.int({ 'min': 3, 'max': 4 })
 
     // If graduation year is after the current year, set predicted to true
     degree.predicted = (degree.graduationYear > currentYear) ? true : false

--- a/app/data/generators/degree.js
+++ b/app/data/generators/degree.js
@@ -1,4 +1,4 @@
-const faker = require('@faker-js/faker').faker
+const { fakerUK: faker } = require('@faker-js/faker')
 
 const { DateTime } = require('luxon')
 const weighted = require('weighted')

--- a/app/data/generators/disability.js
+++ b/app/data/generators/disability.js
@@ -1,5 +1,4 @@
 const faker = require('@faker-js/faker').faker
-faker.locale = 'en_GB'
 
 module.exports = () => {
   let response = faker.helpers.randomize([true])

--- a/app/data/generators/disability.js
+++ b/app/data/generators/disability.js
@@ -1,7 +1,7 @@
 const faker = require('@faker-js/faker').faker
 
 module.exports = () => {
-  let response = faker.helpers.randomize([true])
+  let response = faker.helpers.arrayElement([true])
 
   let details;
 

--- a/app/data/generators/disability.js
+++ b/app/data/generators/disability.js
@@ -1,4 +1,4 @@
-const faker = require('faker')
+const faker = require('@faker-js/faker').faker
 faker.locale = 'en_GB'
 
 module.exports = () => {

--- a/app/data/generators/disability.js
+++ b/app/data/generators/disability.js
@@ -1,4 +1,4 @@
-const faker = require('@faker-js/faker').faker
+const { fakerUK: faker } = require('@faker-js/faker')
 
 module.exports = () => {
   let response = faker.helpers.arrayElement([true])

--- a/app/data/generators/english-language-qualification.js
+++ b/app/data/generators/english-language-qualification.js
@@ -1,5 +1,4 @@
 const faker = require('@faker-js/faker').faker
-faker.locale = 'en_GB'
 
 const { DateTime } = require('luxon')
 const weighted = require('weighted')

--- a/app/data/generators/english-language-qualification.js
+++ b/app/data/generators/english-language-qualification.js
@@ -1,4 +1,4 @@
-const faker = require('faker')
+const faker = require('@faker-js/faker').faker
 faker.locale = 'en_GB'
 
 const { DateTime } = require('luxon')

--- a/app/data/generators/english-language-qualification.js
+++ b/app/data/generators/english-language-qualification.js
@@ -1,4 +1,4 @@
-const faker = require('@faker-js/faker').faker
+const { fakerUK: faker } = require('@faker-js/faker')
 
 const { DateTime } = require('luxon')
 const weighted = require('weighted')

--- a/app/data/generators/english-language-qualification.js
+++ b/app/data/generators/english-language-qualification.js
@@ -9,19 +9,19 @@ module.exports = (params) => {
 
   // To create qaulification year add n years after date of birth
   let year = DateTime.fromISO(params.dateOfBirth).toObject().year
-  year += faker.helpers.randomize([18,19,20,21,22])
+  year += faker.helpers.arrayElement([18,19,20,21,22])
 
   if (year > currentYear) {
     year = currentYear
   }
 
-  const type = faker.helpers.randomize([
+  const type = faker.helpers.arrayElement([
     'IELTS',
     'TOEFL',
     'Other'
   ])
 
-  const reason = faker.helpers.randomize([
+  const reason = faker.helpers.arrayElement([
     'I have booked to take an IELTS test next month',
     'I am taking a TOEFL test next month',
     'I will take a Pearson English test',
@@ -46,7 +46,7 @@ module.exports = (params) => {
   } else {
     grade = 'B'
     gradeLabel = 'Score or grade'
-    reference = faker.helpers.randomize([
+    reference = faker.helpers.arrayElement([
       'Pearson Test of English (Academic)',
       'Cambridge IGCSE English as a Second Language'
     ])

--- a/app/data/generators/events.js
+++ b/app/data/generators/events.js
@@ -43,7 +43,7 @@ module.exports = (params) => {
 //
 //       events.items.push({
 //         title: eventTitle,
-//         user: faker.name.findName(),
+//         user: faker.person.fullName(),
 //         date: date,
 //         assignedUsers: assignedUsers
 //       })
@@ -57,7 +57,7 @@ module.exports = (params) => {
 
     events.items.push({
       title: 'Interview set up',
-      user: faker.name.findName(),
+      user: faker.person.fullName(),
       date: date,
       meta: {
         interview: params.interviews.items[0],
@@ -71,7 +71,7 @@ module.exports = (params) => {
 
     events.items.push({
       title: 'Interview set up',
-      user: faker.name.findName(),
+      user: faker.person.fullName(),
       date: date,
       meta: {
         interview: params.interviews.items[1],
@@ -87,7 +87,7 @@ module.exports = (params) => {
 
       events.items.push({
         title: 'Interview updated',
-        user: faker.name.findName(),
+        user: faker.person.fullName(),
         date: date,
         meta: {
           interview: interview,
@@ -102,7 +102,7 @@ module.exports = (params) => {
 
       events.items.push({
         title: 'Interview cancelled',
-        user: faker.name.findName(),
+        user: faker.person.fullName(),
         date: date,
         meta: {
           interview: interview,
@@ -134,7 +134,7 @@ module.exports = (params) => {
 
       events.items.push({
       title: 'Application rejected',
-      user: faker.name.findName(),
+      user: faker.person.fullName(),
       date: date
     })
 
@@ -157,7 +157,7 @@ module.exports = (params) => {
 
     events.items.push({
       title: 'Offer made',
-      user: faker.name.findName(),
+      user: faker.person.fullName(),
       date: date,
       meta: {
         offer: {
@@ -269,7 +269,7 @@ module.exports = (params) => {
       date = DateHelper.getFutureDate(date)
       events.items.push({
         title: 'Offer accepted',
-        user: faker.name.findName(),
+        user: faker.person.fullName(),
         date: date,
         meta: {
           offer: {
@@ -287,7 +287,7 @@ module.exports = (params) => {
       date = DateHelper.getFutureDate(date)
       events.items.push({
         title: 'Conditions marked as met',
-        user: faker.name.findName(),
+        user: faker.person.fullName(),
         date: date,
         meta: {
           offer: {
@@ -306,7 +306,7 @@ module.exports = (params) => {
       date = DateHelper.getFutureDate(date)
       events.items.push({
         title: 'Offer accepted',
-        user: faker.name.findName(),
+        user: faker.person.fullName(),
         date: date,
         meta: {
           offer: {
@@ -330,7 +330,7 @@ module.exports = (params) => {
 
     events.items.push({
       title: 'Conditions marked as not met',
-      user: faker.name.findName(),
+      user: faker.person.fullName(),
       date: date,
       meta: {
         offer: {
@@ -352,7 +352,7 @@ module.exports = (params) => {
 
     events.items.push({
       title: 'Offer deferred',
-      user: faker.name.findName(),
+      user: faker.person.fullName(),
       date: date,
       meta: {
         offer: {

--- a/app/data/generators/events.js
+++ b/app/data/generators/events.js
@@ -1,6 +1,6 @@
 const DateHelper = require('../helpers/dates');
 const ApplicationHelper = require('../helpers/application');
-const faker = require('faker')
+const faker = require('@faker-js/faker').faker
 faker.locale = 'en_GB'
 const _ = require('lodash')
 const { DateTime } = require('luxon')

--- a/app/data/generators/events.js
+++ b/app/data/generators/events.js
@@ -1,7 +1,6 @@
 const DateHelper = require('../helpers/dates');
 const ApplicationHelper = require('../helpers/application');
 const faker = require('@faker-js/faker').faker
-faker.locale = 'en_GB'
 const _ = require('lodash')
 const { DateTime } = require('luxon')
 const weighted = require('weighted')

--- a/app/data/generators/events.js
+++ b/app/data/generators/events.js
@@ -79,7 +79,7 @@ module.exports = (params) => {
       }
     })
 
-    if (faker.helpers.randomize([true])) {
+    if (faker.helpers.arrayElement([true])) {
       date = DateHelper.getFutureDate(date)
 
       var interview = _.clone(params.interviews.items[1])
@@ -97,7 +97,7 @@ module.exports = (params) => {
 
     }
 
-    if (faker.helpers.randomize([true])) {
+    if (faker.helpers.arrayElement([true])) {
       date = DateHelper.getFutureDate(date)
 
       events.items.push({
@@ -224,7 +224,7 @@ module.exports = (params) => {
   } else if (params.status === 'Declined') {
     date = DateHelper.getFutureDate(date)
 
-    if(faker.helpers.randomize([true, false])) {
+    if(faker.helpers.arrayElement([true, false])) {
       events.items.push({
         title: 'Offer automatically declined',
         date: date,

--- a/app/data/generators/events.js
+++ b/app/data/generators/events.js
@@ -1,6 +1,6 @@
 const DateHelper = require('../helpers/dates');
 const ApplicationHelper = require('../helpers/application');
-const faker = require('@faker-js/faker').faker
+const { fakerUK: faker } = require('@faker-js/faker')
 const _ = require('lodash')
 const { DateTime } = require('luxon')
 const weighted = require('weighted')

--- a/app/data/generators/gcse.js
+++ b/app/data/generators/gcse.js
@@ -38,25 +38,25 @@ module.exports = (params) => {
   const englishGradeOptions = {
     singleAwardEnglish: [{
       exam: 'English Language',
-      grade: faker.helpers.randomize(singleGrades)
+      grade: faker.helpers.arrayElement(singleGrades)
     }],
     doubleAwardEnglish: [{
       exam: 'English',
-      grade: faker.helpers.randomize(doubleGrades)
+      grade: faker.helpers.arrayElement(doubleGrades)
     }],
     separateEnglish1: [{
       exam: 'English Language',
-      grade: faker.helpers.randomize(singleGrades)
+      grade: faker.helpers.arrayElement(singleGrades)
     }, {
       exam: 'English Literature',
-      grade: faker.helpers.randomize(singleGrades)
+      grade: faker.helpers.arrayElement(singleGrades)
     }],
     separateEnglish2: [{
       exam: 'English Language',
-      grade: faker.helpers.randomize(singleGrades)
+      grade: faker.helpers.arrayElement(singleGrades)
     }, {
       exam: 'English Studies',
-      grade: faker.helpers.randomize(singleGrades)
+      grade: faker.helpers.arrayElement(singleGrades)
     }]
   }
 
@@ -73,7 +73,7 @@ module.exports = (params) => {
   // Maths
   // ---------------------------------------------------------------------------
   const mathsGrade = [{
-    grade: faker.helpers.randomize(singleGrades)
+    grade: faker.helpers.arrayElement(singleGrades)
   }]
 
   // ---------------------------------------------------------------------------
@@ -85,21 +85,21 @@ module.exports = (params) => {
     const scienceGradeOptions = {
       singleAwardScience: [{
         exam: 'Single award',
-        grade: faker.helpers.randomize(singleGrades)
+        grade: faker.helpers.arrayElement(singleGrades)
       }],
       doubleAwardScience: [{
         exam: 'Double award',
-        grade: faker.helpers.randomize(doubleGrades)
+        grade: faker.helpers.arrayElement(doubleGrades)
       }],
       tripleAwardScience: [{
         exam: 'Biology',
-        grade: faker.helpers.randomize(singleGrades)
+        grade: faker.helpers.arrayElement(singleGrades)
       }, {
         exam: 'Chemistry',
-        grade: faker.helpers.randomize(singleGrades)
+        grade: faker.helpers.arrayElement(singleGrades)
       }, {
         exam: 'Physics',
-        grade: faker.helpers.randomize(singleGrades)
+        grade: faker.helpers.arrayElement(singleGrades)
       }]
     }
 
@@ -289,16 +289,16 @@ module.exports = (params) => {
   }
 
   if (hasEnglishQualification !== 'Yes' && isStudyingEnglish !== 'Yes') {
-    missingEnglishReason = faker.helpers.randomize(missingEnglishReasonOptions)
+    missingEnglishReason = faker.helpers.arrayElement(missingEnglishReasonOptions)
   }
 
   if (hasMathsQualification !== 'Yes' && isStudyingMaths !== 'Yes') {
-    missingMathsReason = faker.helpers.randomize(missingMathsReasonOptions)
+    missingMathsReason = faker.helpers.arrayElement(missingMathsReasonOptions)
   }
 
   if (params.subjectLevel === 'Primary') {
     if (hasScienceQualification !== 'Yes' && isStudyingScience !== 'Yes') {
-      missingScienceReason = faker.helpers.randomize(missingScienceReasonOptions)
+      missingScienceReason = faker.helpers.arrayElement(missingScienceReasonOptions)
     }
   }
 
@@ -380,7 +380,7 @@ module.exports = (params) => {
     ]
 
     if (isRetakingEnglish === 'No') {
-      evidenceRetakingEnglish = faker.helpers.randomize(evidenceRetakingEnglishOptions)
+      evidenceRetakingEnglish = faker.helpers.arrayElement(evidenceRetakingEnglishOptions)
     }
   }
 
@@ -410,7 +410,7 @@ module.exports = (params) => {
     ]
 
     if (isRetakingMaths === 'No') {
-      evidenceRetakingMaths = faker.helpers.randomize(evidenceRetakingMathsOptions)
+      evidenceRetakingMaths = faker.helpers.arrayElement(evidenceRetakingMathsOptions)
     }
   }
 
@@ -442,7 +442,7 @@ module.exports = (params) => {
       ]
 
       if (isRetakingScience === 'No') {
-        evidenceRetakingScience = faker.helpers.randomize(evidenceRetakingScienceOptions)
+        evidenceRetakingScience = faker.helpers.arrayElement(evidenceRetakingScienceOptions)
       }
     }
   }

--- a/app/data/generators/gcse.js
+++ b/app/data/generators/gcse.js
@@ -1,5 +1,4 @@
 const faker = require('@faker-js/faker').faker
-faker.locale = 'en_GB'
 
 const { DateTime } = require('luxon')
 const weighted = require('weighted')

--- a/app/data/generators/gcse.js
+++ b/app/data/generators/gcse.js
@@ -1,4 +1,4 @@
-const faker = require('faker')
+const faker = require('@faker-js/faker').faker
 faker.locale = 'en_GB'
 
 const { DateTime } = require('luxon')

--- a/app/data/generators/gcse.js
+++ b/app/data/generators/gcse.js
@@ -467,7 +467,7 @@ module.exports = (params) => {
           comparable: 'GCSE (grades A*-C / 9-4)'
         },
         grade: [{
-          grade: faker.datatype.number({ min: 10, max: 20 })
+          grade: faker.number.int({ min: 10, max: 20 })
         }],
         year
       }
@@ -490,7 +490,7 @@ module.exports = (params) => {
           comparable: 'GCSE grades A*-C/9-4'
         },
         grade: [{
-          grade: faker.datatype.number({ min: 10, max: 20 })
+          grade: faker.number.int({ min: 10, max: 20 })
         }],
         year
       }
@@ -514,7 +514,7 @@ module.exports = (params) => {
             comparable: 'GCSE (grades A*-C / 9-4)'
           },
           grade: [{
-            grade: faker.datatype.number({ min: 10, max: 20 })
+            grade: faker.number.int({ min: 10, max: 20 })
           }],
           year
         }

--- a/app/data/generators/gcse.js
+++ b/app/data/generators/gcse.js
@@ -1,4 +1,4 @@
-const faker = require('@faker-js/faker').faker
+const { fakerUK: faker } = require('@faker-js/faker')
 
 const { DateTime } = require('luxon')
 const weighted = require('weighted')

--- a/app/data/generators/interview-needs.js
+++ b/app/data/generators/interview-needs.js
@@ -1,4 +1,4 @@
-const faker = require('faker')
+const faker = require('@faker-js/faker').faker
 faker.locale = 'en_GB'
 
 module.exports = () => {

--- a/app/data/generators/interview-needs.js
+++ b/app/data/generators/interview-needs.js
@@ -1,4 +1,4 @@
-const faker = require('@faker-js/faker').faker
+const { fakerUK: faker } = require('@faker-js/faker')
 
 module.exports = () => {
   let response = faker.helpers.arrayElement([true, false])

--- a/app/data/generators/interview-needs.js
+++ b/app/data/generators/interview-needs.js
@@ -1,12 +1,12 @@
 const faker = require('@faker-js/faker').faker
 
 module.exports = () => {
-  let response = faker.helpers.randomize([true, false])
+  let response = faker.helpers.arrayElement([true, false])
 
   let details;
 
   if(response) {
-    details = faker.helpers.randomize([
+    details = faker.helpers.arrayElement([
       'I have employment commitments',
       'I’ll be travelling a long way to get to the interview',
       'I use a wheelchair'

--- a/app/data/generators/interview-needs.js
+++ b/app/data/generators/interview-needs.js
@@ -1,5 +1,4 @@
 const faker = require('@faker-js/faker').faker
-faker.locale = 'en_GB'
 
 module.exports = () => {
   let response = faker.helpers.randomize([true, false])

--- a/app/data/generators/interviews.js
+++ b/app/data/generators/interviews.js
@@ -1,5 +1,4 @@
 const faker = require('@faker-js/faker').faker
-faker.locale = 'en_GB'
 const { DateTime } = require('luxon')
 const SystemHelper = require('../helpers/system')
 

--- a/app/data/generators/interviews.js
+++ b/app/data/generators/interviews.js
@@ -4,31 +4,31 @@ const SystemHelper = require('../helpers/system')
 
 function getInterview(params) {
   const now = SystemHelper.now().set({
-    hour: faker.helpers.randomize([9, 10, 11]),
-    minute: faker.helpers.randomize([0, 15, 30, 45])
+    hour: faker.helpers.arrayElement([9, 10, 11]),
+    minute: faker.helpers.arrayElement([0, 15, 30, 45])
   })
   const past = now.minus({ days: faker.number.int({ 'min': 1, 'max': 20 }) }).set({
-    hour: faker.helpers.randomize([9, 10, 11]),
-    minute: faker.helpers.randomize([0, 15, 30, 45])
+    hour: faker.helpers.arrayElement([9, 10, 11]),
+    minute: faker.helpers.arrayElement([0, 15, 30, 45])
   });
   const future = now.plus({ days: faker.number.int({ 'min': 0, 'max': 10 }) }).set({
-    hour: faker.helpers.randomize([9, 10, 11]),
-    minute: faker.helpers.randomize([0, 15, 30, 45])
+    hour: faker.helpers.arrayElement([9, 10, 11]),
+    minute: faker.helpers.arrayElement([0, 15, 30, 45])
   });
 
   var interview = {};
   interview.id = faker.string.uuid()
-  interview.details = faker.helpers.randomize([faker.lorem.sentence(20), ''])
+  interview.details = faker.helpers.arrayElement([faker.lorem.sentence(20), ''])
 
   faker.locale = 'en_GB'
 
   interview.location = faker.address.streetAddress() + ', ' + faker.address.city() + ', ' + faker.address.zipCode()
 
-  interview.organisation = faker.helpers.randomize(["The Royal Borough Teaching School Alliance", "Kingston University"])
+  interview.organisation = faker.helpers.arrayElement(["The Royal Borough Teaching School Alliance", "Kingston University"])
 
   if (params.status === 'Interviewing') {
-    interview.date = faker.helpers.randomize([past, future, now, now.plus({days: 1})])
-    if(faker.helpers.randomize(["has interviews", ""]) == "has interviews") {
+    interview.date = faker.helpers.arrayElement([past, future, now, now.plus({days: 1})])
+    if(faker.helpers.arrayElement(["has interviews", ""]) == "has interviews") {
       return interview
     }
   } else {

--- a/app/data/generators/interviews.js
+++ b/app/data/generators/interviews.js
@@ -7,17 +7,17 @@ function getInterview(params) {
     hour: faker.helpers.randomize([9, 10, 11]),
     minute: faker.helpers.randomize([0, 15, 30, 45])
   })
-  const past = now.minus({ days: faker.datatype.number({ 'min': 1, 'max': 20 }) }).set({
+  const past = now.minus({ days: faker.number.int({ 'min': 1, 'max': 20 }) }).set({
     hour: faker.helpers.randomize([9, 10, 11]),
     minute: faker.helpers.randomize([0, 15, 30, 45])
   });
-  const future = now.plus({ days: faker.datatype.number({ 'min': 0, 'max': 10 }) }).set({
+  const future = now.plus({ days: faker.number.int({ 'min': 0, 'max': 10 }) }).set({
     hour: faker.helpers.randomize([9, 10, 11]),
     minute: faker.helpers.randomize([0, 15, 30, 45])
   });
 
   var interview = {};
-  interview.id = faker.datatype.uuid()
+  interview.id = faker.string.uuid()
   interview.details = faker.helpers.randomize([faker.lorem.sentence(20), ''])
 
   faker.locale = 'en_GB'

--- a/app/data/generators/interviews.js
+++ b/app/data/generators/interviews.js
@@ -1,4 +1,4 @@
-const faker = require('faker')
+const faker = require('@faker-js/faker').faker
 faker.locale = 'en_GB'
 const { DateTime } = require('luxon')
 const SystemHelper = require('../helpers/system')

--- a/app/data/generators/interviews.js
+++ b/app/data/generators/interviews.js
@@ -20,7 +20,7 @@ function getInterview(params) {
   interview.id = faker.string.uuid()
   interview.details = faker.helpers.arrayElement([faker.lorem.sentence(20), ''])
 
-  interview.location = faker.address.streetAddress() + ', ' + faker.address.city() + ', ' + faker.address.zipCode()
+  interview.location = faker.location.streetAddress() + ', ' + faker.location.city() + ', ' + faker.location.zipCode()
 
   interview.organisation = faker.helpers.arrayElement(["The Royal Borough Teaching School Alliance", "Kingston University"])
 

--- a/app/data/generators/interviews.js
+++ b/app/data/generators/interviews.js
@@ -1,4 +1,4 @@
-const faker = require('@faker-js/faker').faker
+const { fakerUK: faker } = require('@faker-js/faker')
 const { DateTime } = require('luxon')
 const SystemHelper = require('../helpers/system')
 
@@ -19,8 +19,6 @@ function getInterview(params) {
   var interview = {};
   interview.id = faker.string.uuid()
   interview.details = faker.helpers.arrayElement([faker.lorem.sentence(20), ''])
-
-  faker.locale = 'en_GB'
 
   interview.location = faker.address.streetAddress() + ', ' + faker.address.city() + ', ' + faker.address.zipCode()
 

--- a/app/data/generators/notes.js
+++ b/app/data/generators/notes.js
@@ -35,7 +35,7 @@ module.exports = () => {
 
   if(faker.helpers.randomize([true, false])) {
     notes.items = [{
-      id: faker.datatype.uuid(),
+      id: faker.string.uuid(),
       message: message,
       sender: faker.helpers.randomize([
         faker.name.findName(),

--- a/app/data/generators/notes.js
+++ b/app/data/generators/notes.js
@@ -1,4 +1,4 @@
-const faker = require('@faker-js/faker').faker
+const { fakerUK: faker } = require('@faker-js/faker')
 const user = require('../user')
 
 module.exports = () => {

--- a/app/data/generators/notes.js
+++ b/app/data/generators/notes.js
@@ -1,4 +1,4 @@
-const faker = require('faker')
+const faker = require('@faker-js/faker').faker
 const user = require('../user')
 faker.locale = 'en_GB'
 

--- a/app/data/generators/notes.js
+++ b/app/data/generators/notes.js
@@ -38,7 +38,7 @@ module.exports = () => {
       id: faker.string.uuid(),
       message: message,
       sender: faker.helpers.arrayElement([
-        faker.name.findName(),
+        faker.person.fullName(),
         user.firstName + ' ' + user.lastName
       ]),
       date: faker.date.past()

--- a/app/data/generators/notes.js
+++ b/app/data/generators/notes.js
@@ -1,6 +1,5 @@
 const faker = require('@faker-js/faker').faker
 const user = require('../user')
-faker.locale = 'en_GB'
 
 module.exports = () => {
 

--- a/app/data/generators/notes.js
+++ b/app/data/generators/notes.js
@@ -7,7 +7,7 @@ module.exports = () => {
     items: []
   }
 
-  var message = faker.helpers.randomize([
+  var message = faker.helpers.arrayElement([
     'The candidate has appropriate qualifications. Personal statement looks good too – I think we should get them in for interview.',
     'I’d like a second opinion on the personal statement as I’m not sure they’re suitable for the course they’ve applied for.',
     'Several grammar and spelling issues in the personal statement.',
@@ -33,11 +33,11 @@ module.exports = () => {
     'We rejected this candidate last year but they’ve gained some relevant experience since then. Worth a second look, I think.'
   ])
 
-  if(faker.helpers.randomize([true, false])) {
+  if(faker.helpers.arrayElement([true, false])) {
     notes.items = [{
       id: faker.string.uuid(),
       message: message,
-      sender: faker.helpers.randomize([
+      sender: faker.helpers.arrayElement([
         faker.name.findName(),
         user.firstName + ' ' + user.lastName
       ]),

--- a/app/data/generators/offer.js
+++ b/app/data/generators/offer.js
@@ -1,4 +1,4 @@
-const faker = require('@faker-js/faker').faker
+const { fakerUK: faker } = require('@faker-js/faker')
 const { DateTime } = require('luxon')
 let generateWithdrawal = require('./withdrawal')
 

--- a/app/data/generators/offer.js
+++ b/app/data/generators/offer.js
@@ -5,7 +5,7 @@ let generateWithdrawal = require('./withdrawal')
 module.exports = (params) => {
   let status = params.status
   let submittedDate = params.submittedDate
-  let madeDate = DateTime.fromISO(submittedDate).plus({ days: faker.datatype.number({ min: 3, max: 19 }) }).toISO()
+  let madeDate = DateTime.fromISO(submittedDate).plus({ days: faker.number.int({ min: 3, max: 19 }) }).toISO()
 
   let conditionStatus = 'Pending'
   if (status === 'Recruited') {
@@ -21,13 +21,13 @@ module.exports = (params) => {
   let withdrawalDate = null;
   let withdrawalReasons = null;
   if(status === 'Offer withdrawn') {
-    withdrawalDate = DateTime.fromISO(madeDate).plus({ days: faker.datatype.number({ min: 1, max: 5 })}).toISO()
+    withdrawalDate = DateTime.fromISO(madeDate).plus({ days: faker.number.int({ min: 1, max: 5 })}).toISO()
     withdrawalReasons = generateWithdrawal()
   }
 
   let acceptedDate = null
   if(status === 'Conditions pending' || status === 'Recruited' || status === 'Conditions not met' || status === 'Deferred') {
-    acceptedDate = DateTime.fromISO(madeDate).plus({ days: faker.datatype.number({ min: 1, max: 3 })}).toISO()
+    acceptedDate = DateTime.fromISO(madeDate).plus({ days: faker.number.int({ min: 1, max: 3 })}).toISO()
   }
 
   let standardConditions
@@ -35,16 +35,16 @@ module.exports = (params) => {
 
   if(params.status == 'Deferred' || params.status == 'Conditions pending' || faker.helpers.randomize([true, false])) {
     standardConditions = [{
-      id: faker.datatype.uuid(),
+      id: faker.string.uuid(),
       description: 'Fitness to train to teach check',
       status: 'Met'
     }, {
-      id: faker.datatype.uuid(),
+      id: faker.string.uuid(),
       description: 'Disclosure and Barring Service (DBS) check',
       status: 'Met'
     },
     {
-      id: faker.datatype.uuid(),
+      id: faker.string.uuid(),
       description: '2 references',
       status: 'Pending'
     }

--- a/app/data/generators/offer.js
+++ b/app/data/generators/offer.js
@@ -33,7 +33,7 @@ module.exports = (params) => {
   let standardConditions
   let conditions
 
-  if(params.status == 'Deferred' || params.status == 'Conditions pending' || faker.helpers.randomize([true, false])) {
+  if(params.status == 'Deferred' || params.status == 'Conditions pending' || faker.helpers.arrayElement([true, false])) {
     standardConditions = [{
       id: faker.string.uuid(),
       description: 'Fitness to train to teach check',

--- a/app/data/generators/offer.js
+++ b/app/data/generators/offer.js
@@ -1,5 +1,4 @@
 const faker = require('@faker-js/faker').faker
-faker.locale = 'en_GB'
 const { DateTime } = require('luxon')
 let generateWithdrawal = require('./withdrawal')
 

--- a/app/data/generators/offer.js
+++ b/app/data/generators/offer.js
@@ -1,4 +1,4 @@
-const faker = require('faker')
+const faker = require('@faker-js/faker').faker
 faker.locale = 'en_GB'
 const { DateTime } = require('luxon')
 let generateWithdrawal = require('./withdrawal')

--- a/app/data/generators/organisation.js
+++ b/app/data/generators/organisation.js
@@ -1,4 +1,4 @@
-const faker = require('@faker-js/faker').faker
+const { fakerUK: faker } = require('@faker-js/faker')
 
 module.exports = (params = {}) => {
   return {

--- a/app/data/generators/organisation.js
+++ b/app/data/generators/organisation.js
@@ -1,5 +1,4 @@
 const faker = require('@faker-js/faker').faker
-faker.locale = 'en_GB'
 
 module.exports = (params = {}) => {
   return {

--- a/app/data/generators/organisation.js
+++ b/app/data/generators/organisation.js
@@ -1,4 +1,4 @@
-const faker = require('faker')
+const faker = require('@faker-js/faker').faker
 faker.locale = 'en_GB'
 
 module.exports = (params = {}) => {

--- a/app/data/generators/organisation.js
+++ b/app/data/generators/organisation.js
@@ -2,7 +2,7 @@ const faker = require('@faker-js/faker').faker
 
 module.exports = (params = {}) => {
   return {
-    id: faker.datatype.uuid(),
+    id: faker.string.uuid(),
     name: params.name,
     permissions: params.permissions,
     isAccreditedBody: params.isAccreditedBody,

--- a/app/data/generators/other-qualifications.js
+++ b/app/data/generators/other-qualifications.js
@@ -1,5 +1,4 @@
 const faker = require('@faker-js/faker').faker
-faker.locale = 'en_GB'
 
 module.exports = () => {
 

--- a/app/data/generators/other-qualifications.js
+++ b/app/data/generators/other-qualifications.js
@@ -1,4 +1,4 @@
-const faker = require('faker')
+const faker = require('@faker-js/faker').faker
 faker.locale = 'en_GB'
 
 module.exports = () => {

--- a/app/data/generators/other-qualifications.js
+++ b/app/data/generators/other-qualifications.js
@@ -1,4 +1,4 @@
-const faker = require('@faker-js/faker').faker
+const { fakerUK: faker } = require('@faker-js/faker')
 
 module.exports = () => {
 

--- a/app/data/generators/other-qualifications.js
+++ b/app/data/generators/other-qualifications.js
@@ -4,7 +4,7 @@ module.exports = () => {
 
   let qualifications = []
 
-  if(faker.helpers.randomize([true, false])) {
+  if(faker.helpers.arrayElement([true, false])) {
     qualifications.push({
       type: 'ABRSM',
       subject: 'Piano (practical)',
@@ -22,7 +22,7 @@ module.exports = () => {
     year: '2012'
   })
 
-  if(faker.helpers.randomize([true, false])) {
+  if(faker.helpers.arrayElement([true, false])) {
     qualifications.push({
       type: 'GCSE',
       subject: 'Graphics',
@@ -32,7 +32,7 @@ module.exports = () => {
     })
   }
 
-  if(faker.helpers.randomize([true, false])) {
+  if(faker.helpers.arrayElement([true, false])) {
     qualifications.push({
       type: 'GCSE',
       subject: 'Religious Studies',
@@ -42,7 +42,7 @@ module.exports = () => {
     })
   }
 
-  if(faker.helpers.randomize([true, false])) {
+  if(faker.helpers.arrayElement([true, false])) {
     qualifications.push({
       type: 'AS level',
       subject: 'Maths',
@@ -52,7 +52,7 @@ module.exports = () => {
     })
   }
 
-  if(faker.helpers.randomize([true, false])) {
+  if(faker.helpers.arrayElement([true, false])) {
     qualifications.push({
       type: 'A level',
       subject: 'French',
@@ -62,7 +62,7 @@ module.exports = () => {
     })
   }
 
-  if(faker.helpers.randomize([true, false])) {
+  if(faker.helpers.arrayElement([true, false])) {
     qualifications.push({
       type: 'A level',
       subject: 'Religious Studies',
@@ -72,7 +72,7 @@ module.exports = () => {
     })
   }
 
-  if(faker.helpers.randomize([true, false])) {
+  if(faker.helpers.arrayElement([true, false])) {
     qualifications.push({
       type: 'A level',
       subject: 'English',
@@ -91,7 +91,7 @@ module.exports = () => {
     year: '2014'
   })
 
-  if(faker.helpers.randomize([true, false])) {
+  if(faker.helpers.arrayElement([true, false])) {
     qualifications.push({
       type: 'ABRSM',
       subject: 'Music Theory',
@@ -109,5 +109,5 @@ module.exports = () => {
     year: '2013'
   })
 
-  return faker.helpers.randomize([qualifications, qualifications, qualifications, qualifications, qualifications, qualifications, null])
+  return faker.helpers.arrayElement([qualifications, qualifications, qualifications, qualifications, qualifications, qualifications, null])
 }

--- a/app/data/generators/personal-details.js
+++ b/app/data/generators/personal-details.js
@@ -320,7 +320,7 @@ module.exports = () => {
 
     disabled = disabledOptions[selectedDisabled]
 
-    let disabilityCount = faker.datatype.number(3) // up to 3 disabilities
+    let disabilityCount = faker.number.int(3) // up to 3 disabilities
 
     let disabilityChoices = [
       'Blind',

--- a/app/data/generators/personal-details.js
+++ b/app/data/generators/personal-details.js
@@ -1,4 +1,4 @@
-const faker = require('@faker-js/faker').faker
+const { fakerUK: faker } = require('@faker-js/faker')
 const { DateTime } = require('luxon')
 const weighted = require('weighted')
 

--- a/app/data/generators/personal-details.js
+++ b/app/data/generators/personal-details.js
@@ -1,5 +1,4 @@
 const faker = require('@faker-js/faker').faker
-faker.locale = 'en_GB'
 const { DateTime } = require('luxon')
 const weighted = require('weighted')
 

--- a/app/data/generators/personal-details.js
+++ b/app/data/generators/personal-details.js
@@ -1,4 +1,4 @@
-const faker = require('faker')
+const faker = require('@faker-js/faker').faker
 faker.locale = 'en_GB'
 const { DateTime } = require('luxon')
 const weighted = require('weighted')

--- a/app/data/generators/personal-details.js
+++ b/app/data/generators/personal-details.js
@@ -99,7 +99,7 @@ module.exports = () => {
           'I’m applying for a spousal visa'
         ]
 
-        let rightToWorkStudyHowDetails = faker.helpers.randomize(rightToWorkStudyHowChoices)
+        let rightToWorkStudyHowDetails = faker.helpers.arrayElement(rightToWorkStudyHowChoices)
       }
     }
   }
@@ -142,7 +142,7 @@ module.exports = () => {
   if (isInternationalCandidate) {
 
     if (rightToWorkStudy === 'Yes') {
-      dateEnteredUK = faker.date.between('2000-01-01','2016-08-31')
+      dateEnteredUK = faker.date.between({ from: '2000-01-01', to: '2016-08-31'})
       // faker creates a time, which isn't necessary, so we remove it
       dateEnteredUK = DateTime.fromJSDate(dateEnteredUK).toFormat('yyyy-LL-dd')
     }
@@ -152,17 +152,17 @@ module.exports = () => {
   // Date of birth
   // ---------------------------------------------------------------------------
   const dateOfBirthOptions = {
-    y21_under: faker.date.between('2000-01-01', '2001-12-31'),
-    y22_to_24: faker.date.between('1997-01-01', '1999-12-31'),
-    y25_to_29: faker.date.between('1992-01-01', '1996-12-31'),
-    y30_to_34: faker.date.between('1987-01-01', '1991-12-31'),
-    y35_to_39: faker.date.between('1982-01-01', '1986-12-31'),
-    y40_to_44: faker.date.between('1977-01-01', '1981-12-31'),
-    y45_to_49: faker.date.between('1972-01-01', '1976-12-31'),
-    y50_to_54: faker.date.between('1967-01-01', '1971-12-31'),
-    y55_to_59: faker.date.between('1962-01-01', '1966-12-31'),
-    y60_to_64: faker.date.between('1957-01-01', '1961-12-31'),
-    y65_over: faker.date.between('1950-01-01', '1956-12-31')
+    y21_under: faker.date.between({ from: '2000-01-01', to: '2001-12-31'}),
+    y22_to_24: faker.date.between({ from: '1997-01-01', to: '1999-12-31'}),
+    y25_to_29: faker.date.between({ from: '1992-01-01', to: '1996-12-31'}),
+    y30_to_34: faker.date.between({ from: '1987-01-01', to: '1991-12-31'}),
+    y35_to_39: faker.date.between({ from: '1982-01-01', to: '1986-12-31'}),
+    y40_to_44: faker.date.between({ from: '1977-01-01', to: '1981-12-31'}),
+    y45_to_49: faker.date.between({ from: '1972-01-01', to: '1976-12-31'}),
+    y50_to_54: faker.date.between({ from: '1967-01-01', to: '1971-12-31'}),
+    y55_to_59: faker.date.between({ from: '1962-01-01', to: '1966-12-31'}),
+    y60_to_64: faker.date.between({ from: '1957-01-01', to: '1961-12-31'}),
+    y65_over: faker.date.between({ from: '1950-01-01', to: '1956-12-31'})
   }
 
   const selectedDateOfBirth = weighted.select({
@@ -192,7 +192,7 @@ module.exports = () => {
   let ethnicGroup
   let ethnicBackground
 
-  const diversityQuestionnaireAnswered = faker.helpers.randomize(['Yes', 'Yes', 'No'])
+  const diversityQuestionnaireAnswered = faker.helpers.arrayElement(['Yes', 'Yes', 'No'])
 
   // Candidate's sex
   const sexOptions = {

--- a/app/data/generators/references.js
+++ b/app/data/generators/references.js
@@ -1,4 +1,4 @@
-const faker = require('faker')
+const faker = require('@faker-js/faker').faker
 faker.locale = 'en_GB'
 
 module.exports = (status) => {

--- a/app/data/generators/references.js
+++ b/app/data/generators/references.js
@@ -1,4 +1,4 @@
-const faker = require('@faker-js/faker').faker
+const { fakerUK: faker } = require('@faker-js/faker')
 
 module.exports = (status) => {
 

--- a/app/data/generators/references.js
+++ b/app/data/generators/references.js
@@ -1,5 +1,4 @@
 const faker = require('@faker-js/faker').faker
-faker.locale = 'en_GB'
 
 module.exports = (status) => {
 

--- a/app/data/generators/references.js
+++ b/app/data/generators/references.js
@@ -27,13 +27,16 @@ module.exports = (status) => {
   ])
 
   const referee = (status) => {
-    const firstName = faker.name.firstName()
-    const lastName = faker.name.lastName()
+    const firstName = faker.person.firstName()
+    const lastName = faker.person.lastName()
 
     let ref =  {
       type,
       name: `${firstName} ${lastName}`,
-      email: faker.internet.email(firstName, lastName).toLowerCase(),
+      email: faker.internet.email({
+        firstName,
+        lastName
+      }).toLowerCase(),
       relationship: {
         summary: relationshipSummary
       }

--- a/app/data/generators/references.js
+++ b/app/data/generators/references.js
@@ -4,14 +4,14 @@ module.exports = (status) => {
 
   console.log('generating reference for ' + status)
 
-  const type = faker.helpers.randomize([
+  const type = faker.helpers.arrayElement([
     'Academic',
     'Professional',
     'School based',
     'Character'
   ])
 
-  const comments = faker.helpers.randomize([
+  const comments = faker.helpers.arrayElement([
     'A charismatic talented and able person. Great with people, fantastic personality and a strong communicator passionate about teaching. Great potential. Go for them!',
     'Fantastic personality. Great with people. Strong communicator. Excellent character. Passionate about teaching with great potential.',
     'A very smart young person who I have had the pleasure of working with since spring last year (2019).\n\nWe rely on bar staff to be responsible, reliable, trustworthy with stock and takings, and maintain excellent time-keeping. In all of these respects they exceeded expectations, remaining calm in difficult situations and always equally happy to work independently or as part of a team.',
@@ -19,7 +19,7 @@ module.exports = (status) => {
     'Their enthusiasm and love of the subject made them an inspiration to be around.\n\nIf they’re able to bring the same patience, people skills and good humour to teaching, I believe that they will make a fantastic teacher.'
   ])
 
-  const relationshipSummary = faker.helpers.randomize([
+  const relationshipSummary = faker.helpers.arrayElement([
     'Course supervisor at university. I’ve known them for a year',
     'Was my line manager in my last job. I’ve known them for 2 years',
     'Deputy head at the school where I currently volunteer. I’ve known them for 3 years',

--- a/app/data/generators/rejection.js
+++ b/app/data/generators/rejection.js
@@ -1,4 +1,4 @@
-const faker = require('faker')
+const faker = require('@faker-js/faker').faker
 faker.locale = 'en_GB'
 
 function buildReasons(params) {

--- a/app/data/generators/rejection.js
+++ b/app/data/generators/rejection.js
@@ -1,5 +1,4 @@
 const faker = require('@faker-js/faker').faker
-faker.locale = 'en_GB'
 
 function buildReasons(params) {
 

--- a/app/data/generators/rejection.js
+++ b/app/data/generators/rejection.js
@@ -63,7 +63,7 @@ module.exports = () => {
     personalStatement: true
   })
 
-  return faker.helpers.randomize([all, qualifications, personalStatement])
+  return faker.helpers.arrayElement([all, qualifications, personalStatement])
 
 
 }

--- a/app/data/generators/rejection.js
+++ b/app/data/generators/rejection.js
@@ -1,4 +1,4 @@
-const faker = require('@faker-js/faker').faker
+const { fakerUK: faker } = require('@faker-js/faker')
 
 function buildReasons(params) {
 

--- a/app/data/generators/safeguarding.js
+++ b/app/data/generators/safeguarding.js
@@ -1,5 +1,4 @@
 const faker = require('@faker-js/faker').faker
-faker.locale = 'en_GB'
 
 module.exports = () => {
   let response = faker.helpers.randomize([true])

--- a/app/data/generators/safeguarding.js
+++ b/app/data/generators/safeguarding.js
@@ -1,7 +1,7 @@
 const faker = require('@faker-js/faker').faker
 
 module.exports = () => {
-  let response = faker.helpers.randomize([true])
+  let response = faker.helpers.arrayElement([true])
 
   let details;
 

--- a/app/data/generators/safeguarding.js
+++ b/app/data/generators/safeguarding.js
@@ -1,4 +1,4 @@
-const faker = require('faker')
+const faker = require('@faker-js/faker').faker
 faker.locale = 'en_GB'
 
 module.exports = () => {

--- a/app/data/generators/safeguarding.js
+++ b/app/data/generators/safeguarding.js
@@ -1,4 +1,4 @@
-const faker = require('@faker-js/faker').faker
+const { fakerUK: faker } = require('@faker-js/faker')
 
 module.exports = () => {
   let response = faker.helpers.arrayElement([true])

--- a/app/data/generators/school-experience.js
+++ b/app/data/generators/school-experience.js
@@ -1,4 +1,4 @@
-const faker = require('@faker-js/faker').faker
+const { fakerUK: faker } = require('@faker-js/faker')
 const DateHelper = require('../helpers/dates');
 
 module.exports = (submittedDate) => {

--- a/app/data/generators/school-experience.js
+++ b/app/data/generators/school-experience.js
@@ -1,5 +1,4 @@
 const faker = require('@faker-js/faker').faker
-faker.locale = 'en_GB'
 const DateHelper = require('../helpers/dates');
 
 module.exports = (submittedDate) => {

--- a/app/data/generators/school-experience.js
+++ b/app/data/generators/school-experience.js
@@ -1,4 +1,4 @@
-const faker = require('faker')
+const faker = require('@faker-js/faker').faker
 faker.locale = 'en_GB'
 const DateHelper = require('../helpers/dates');
 

--- a/app/data/generators/school-experience.js
+++ b/app/data/generators/school-experience.js
@@ -2,7 +2,7 @@ const faker = require('@faker-js/faker').faker
 const DateHelper = require('../helpers/dates');
 
 module.exports = (submittedDate) => {
-  const hasExperience = faker.helpers.randomize([true, false])
+  const hasExperience = faker.helpers.arrayElement([true, false])
   if(hasExperience) {
     const count = faker.number.int({ min: 1, max: 4 })
     const items = []
@@ -21,7 +21,7 @@ module.exports = (submittedDate) => {
       items.push({
         role: faker.name.jobTitle(),
         org: faker.company.companyName(),
-        workedWithChildren: faker.helpers.randomize(['Yes', 'No']),
+        workedWithChildren: faker.helpers.arrayElement(['Yes', 'No']),
         startDate: startDate,
         endDate: endDate,
         timeCommitment: faker.lorem.sentences(1)

--- a/app/data/generators/school-experience.js
+++ b/app/data/generators/school-experience.js
@@ -4,7 +4,7 @@ const DateHelper = require('../helpers/dates');
 module.exports = (submittedDate) => {
   const hasExperience = faker.helpers.randomize([true, false])
   if(hasExperience) {
-    const count = faker.datatype.number({ min: 1, max: 4 })
+    const count = faker.number.int({ min: 1, max: 4 })
     const items = []
 
     // get a date previously to the application submitted date

--- a/app/data/generators/school-experience.js
+++ b/app/data/generators/school-experience.js
@@ -19,8 +19,8 @@ module.exports = (submittedDate) => {
       startDate = DateHelper.getPastDate(endDate, 30, 500)
 
       items.push({
-        role: faker.name.jobTitle(),
-        org: faker.company.companyName(),
+        role: faker.person.jobTitle(),
+        org: faker.company.name(),
         workedWithChildren: faker.helpers.arrayElement(['Yes', 'No']),
         startDate: startDate,
         endDate: endDate,

--- a/app/data/generators/submittedDate.js
+++ b/app/data/generators/submittedDate.js
@@ -6,42 +6,42 @@ module.exports = (params) => {
 
   if(params.status == "Offered") {
     submittedDate = SystemHelper.now().minus({
-      days: faker.datatype.number({ 'min': 60, 'max': 70 })
+      days: faker.number.int({ 'min': 60, 'max': 70 })
     })
   } else if(params.status == "Offer withdrawn") {
     submittedDate = SystemHelper.now().minus({
-      days: faker.datatype.number({ 'min': 60, 'max': 180 })
+      days: faker.number.int({ 'min': 60, 'max': 180 })
     })
   } else if(params.status == "Rejected") {
     submittedDate = SystemHelper.now().minus({
-      days: faker.datatype.number({ 'min': 60, 'max': 180 })
+      days: faker.number.int({ 'min': 60, 'max': 180 })
     })
   } else if(params.status == "Recruited") {
     submittedDate = SystemHelper.now().minus({
-      days: faker.datatype.number({ 'min': 60, 'max': 180 })
+      days: faker.number.int({ 'min': 60, 'max': 180 })
     })
   } else if(params.status == "Conditions not met") {
     submittedDate = SystemHelper.now().minus({
-      days: faker.datatype.number({ 'min': 20, 'max': 180 })
+      days: faker.number.int({ 'min': 20, 'max': 180 })
     })
   } else if(params.status == "Offer declined") {
     submittedDate = SystemHelper.now().minus({
-      days: faker.datatype.number({ 'min': 60, 'max': 180 })
+      days: faker.number.int({ 'min': 60, 'max': 180 })
     })
   } else if(params.status == "Application withdrawn") {
     submittedDate = SystemHelper.now().minus({
-      days: faker.datatype.number({ 'min': 60, 'max': 180 })
+      days: faker.number.int({ 'min': 60, 'max': 180 })
     })
   } else if(params.status == "Offer accepted") {
     submittedDate = SystemHelper.now().minus({
-      days: faker.datatype.number({ 'min': 60, 'max': 180 })
+      days: faker.number.int({ 'min': 60, 'max': 180 })
     })
   } else {
     submittedDate = SystemHelper.now().minus({
-      days: faker.datatype.number({ 'min': 0, 'max': 40 })
+      days: faker.number.int({ 'min': 0, 'max': 40 })
     })
-    .plus({ hours: faker.datatype.number({ 'min': 8, 'max': 16 }) })
-    .plus({ minutes: faker.datatype.number({ 'min': 1, 'max': 59 }) })
+    .plus({ hours: faker.number.int({ 'min': 8, 'max': 16 }) })
+    .plus({ minutes: faker.number.int({ 'min': 1, 'max': 59 }) })
   }
 
   return submittedDate.toISO()

--- a/app/data/generators/submittedDate.js
+++ b/app/data/generators/submittedDate.js
@@ -1,5 +1,5 @@
 const SystemHelper = require('../helpers/system');
-const faker = require('@faker-js/faker').faker
+const { fakerUK: faker } = require('@faker-js/faker')
 
 module.exports = (params) => {
   let submittedDate

--- a/app/data/generators/submittedDate.js
+++ b/app/data/generators/submittedDate.js
@@ -1,6 +1,5 @@
 const SystemHelper = require('../helpers/system');
 const faker = require('@faker-js/faker').faker
-faker.locale = 'en_GB'
 
 module.exports = (params) => {
   let submittedDate

--- a/app/data/generators/submittedDate.js
+++ b/app/data/generators/submittedDate.js
@@ -1,5 +1,5 @@
 const SystemHelper = require('../helpers/system');
-const faker = require('faker')
+const faker = require('@faker-js/faker').faker
 faker.locale = 'en_GB'
 
 module.exports = (params) => {

--- a/app/data/generators/user.js
+++ b/app/data/generators/user.js
@@ -1,9 +1,9 @@
 module.exports = (faker, params = {}) => {
   return {
     id: faker.string.uuid(),
-    firstName: params.firstName || faker.name.firstName(),
-    lastName: params.lastName || faker.name.lastName(),
-    emailAddress: params.emailAddress || faker.name.emailAddress(),
+    firstName: params.firstName || faker.person.firstName(),
+    lastName: params.lastName || faker.person.lastName(),
+    emailAddress: params.emailAddress || faker.person.emailAddress(),
     organisation: params.organisation,
     permissions: params.permissions
   }

--- a/app/data/generators/user.js
+++ b/app/data/generators/user.js
@@ -1,6 +1,6 @@
 module.exports = (faker, params = {}) => {
   return {
-    id: faker.datatype.uuid(),
+    id: faker.string.uuid(),
     firstName: params.firstName || faker.name.firstName(),
     lastName: params.lastName || faker.name.lastName(),
     emailAddress: params.emailAddress || faker.name.emailAddress(),

--- a/app/data/generators/withdrawal.js
+++ b/app/data/generators/withdrawal.js
@@ -1,5 +1,4 @@
 const faker = require('@faker-js/faker').faker
-faker.locale = 'en_GB'
 
 module.exports = () => {
 

--- a/app/data/generators/withdrawal.js
+++ b/app/data/generators/withdrawal.js
@@ -5,7 +5,7 @@ module.exports = () => {
   let withdrawal = {
     date: faker.date.past(),
     feedback: {
-      reason: faker.helpers.randomize([
+      reason: faker.helpers.arrayElement([
         'Candidate asked to withdraw their application',
         'Candidate did not reply to messages',
         'Other'

--- a/app/data/generators/withdrawal.js
+++ b/app/data/generators/withdrawal.js
@@ -1,4 +1,4 @@
-const faker = require('faker')
+const faker = require('@faker-js/faker').faker
 faker.locale = 'en_GB'
 
 module.exports = () => {

--- a/app/data/generators/withdrawal.js
+++ b/app/data/generators/withdrawal.js
@@ -1,4 +1,4 @@
-const faker = require('@faker-js/faker').faker
+const { fakerUK: faker } = require('@faker-js/faker')
 
 module.exports = () => {
 

--- a/app/data/generators/work-history.js
+++ b/app/data/generators/work-history.js
@@ -1,4 +1,4 @@
-const faker = require('@faker-js/faker').faker
+const { fakerUK: faker } = require('@faker-js/faker')
 const DateHelper = require('../helpers/dates');
 
 module.exports = (submittedDate) => {

--- a/app/data/generators/work-history.js
+++ b/app/data/generators/work-history.js
@@ -1,5 +1,4 @@
 const faker = require('@faker-js/faker').faker
-faker.locale = 'en_GB'
 const DateHelper = require('../helpers/dates');
 
 module.exports = (submittedDate) => {

--- a/app/data/generators/work-history.js
+++ b/app/data/generators/work-history.js
@@ -34,7 +34,7 @@ module.exports = (submittedDate) => {
             'Legal executive',
             'Planner',
           ]),
-          org: faker.company.companyName(),
+          org: faker.company.name(),
           type: faker.helpers.arrayElement(['Full time', 'Part time']),
           relevantToTeaching: faker.helpers.arrayElement(['Yes', 'No']),
           category: 'job',

--- a/app/data/generators/work-history.js
+++ b/app/data/generators/work-history.js
@@ -5,7 +5,7 @@ module.exports = (submittedDate) => {
   const answer = faker.helpers.randomize(['yes', 'no-work-history', 'no--in-full-time-education'])
   const reason = (answer === 'no-work-history') ? 'I was unemployed': null;
   const items = []
-  const count = faker.datatype.number({ min: 0, max: 8 })
+  const count = faker.number.int({ min: 0, max: 8 })
 
   // get a date previously to the application submitted date
   let endDate = DateHelper.getPastDate(submittedDate, 30, 150)
@@ -53,7 +53,7 @@ module.exports = (submittedDate) => {
         items.push({
           description: description,
           category: 'break',
-          duration: `${faker.datatype.number({ min: 1, max: 12 })} months`,
+          duration: `${faker.number.int({ min: 1, max: 12 })} months`,
           startDate: startDate,
           endDate: endDate
         })

--- a/app/data/generators/work-history.js
+++ b/app/data/generators/work-history.js
@@ -2,7 +2,7 @@ const faker = require('@faker-js/faker').faker
 const DateHelper = require('../helpers/dates');
 
 module.exports = (submittedDate) => {
-  const answer = faker.helpers.randomize(['yes', 'no-work-history', 'no--in-full-time-education'])
+  const answer = faker.helpers.arrayElement(['yes', 'no-work-history', 'no--in-full-time-education'])
   const reason = (answer === 'no-work-history') ? 'I was unemployed': null;
   const items = []
   const count = faker.number.int({ min: 0, max: 8 })
@@ -19,11 +19,11 @@ module.exports = (submittedDate) => {
       // get a start date that is between 30 and 500 days prior to the end date
       startDate = DateHelper.getPastDate(endDate, 30, 500)
 
-      const jobType = faker.helpers.randomize(['job', 'break'])
+      const jobType = faker.helpers.arrayElement(['job', 'break'])
       if (jobType === 'job') {
 
         items.push({
-          role: faker.helpers.randomize([
+          role: faker.helpers.arrayElement([
             'Analyst',
             'Consultant',
             'Life coach',
@@ -35,17 +35,17 @@ module.exports = (submittedDate) => {
             'Planner',
           ]),
           org: faker.company.companyName(),
-          type: faker.helpers.randomize(['Full time', 'Part time']),
-          relevantToTeaching: faker.helpers.randomize(['Yes', 'No']),
+          type: faker.helpers.arrayElement(['Full time', 'Part time']),
+          relevantToTeaching: faker.helpers.arrayElement(['Yes', 'No']),
           category: 'job',
           startDate: startDate,
-          isStartDateApproximate: faker.helpers.randomize([true, false, false, false]),
-          endDate: faker.helpers.randomize([endDate, false]),
+          isStartDateApproximate: faker.helpers.arrayElement([true, false, false, false]),
+          endDate: faker.helpers.arrayElement([endDate, false]),
           isEndDateApproximate: false
         })
       } else {
 
-        let description = faker.helpers.randomize([
+        let description = faker.helpers.arrayElement([
           null,
           'I volunteered with a marine conservation charity in the Seychelles as part of a career break.'
         ])

--- a/app/data/generators/work-history.js
+++ b/app/data/generators/work-history.js
@@ -1,4 +1,4 @@
-const faker = require('faker')
+const faker = require('@faker-js/faker').faker
 faker.locale = 'en_GB'
 const DateHelper = require('../helpers/dates');
 

--- a/app/data/helpers/generators.js
+++ b/app/data/helpers/generators.js
@@ -1,5 +1,4 @@
 const faker = require('@faker-js/faker').faker
-faker.locale = 'en_GB'
 const fs = require('fs')
 const path = require('path')
 

--- a/app/data/helpers/generators.js
+++ b/app/data/helpers/generators.js
@@ -1,4 +1,4 @@
-const faker = require('faker')
+const faker = require('@faker-js/faker').faker
 faker.locale = 'en_GB'
 const fs = require('fs')
 const path = require('path')

--- a/app/data/helpers/generators.js
+++ b/app/data/helpers/generators.js
@@ -1,4 +1,4 @@
-const faker = require('@faker-js/faker').faker
+const { fakerUK: faker } = require('@faker-js/faker')
 const fs = require('fs')
 const path = require('path')
 

--- a/app/data/helpers/generators.js
+++ b/app/data/helpers/generators.js
@@ -4,7 +4,7 @@ const path = require('path')
 
 exports.firstName = (sex) => {
   if (sex === 'male') {
-    return faker.helpers.randomize([
+    return faker.helpers.arrayElement([
       'Bruce',
       'Clinton',
       'Harold',
@@ -26,7 +26,7 @@ exports.firstName = (sex) => {
       'Wade'
     ])
   } else {
-    return faker.helpers.randomize([
+    return faker.helpers.arrayElement([
       'Barbara',
       'Bonita',
       'Carol',
@@ -48,7 +48,7 @@ exports.firstName = (sex) => {
 }
 
 exports.lastName = () => {
-  return faker.helpers.randomize([
+  return faker.helpers.arrayElement([
     'Banner',
     'Barton',
     'Carpenter',

--- a/app/routes/feedback.js
+++ b/app/routes/feedback.js
@@ -1,5 +1,4 @@
 const faker = require('@faker-js/faker').faker
-faker.locale = 'en_GB'
 
 const path = require('path')
 const directoryPath = path.join(__dirname, '../views/feedback/_content/')

--- a/app/routes/feedback.js
+++ b/app/routes/feedback.js
@@ -1,4 +1,4 @@
-const faker = require('@faker-js/faker').faker
+const { fakerUK: faker } = require('@faker-js/faker')
 
 const path = require('path')
 const directoryPath = path.join(__dirname, '../views/feedback/_content/')

--- a/app/routes/feedback.js
+++ b/app/routes/feedback.js
@@ -9,7 +9,7 @@ module.exports = router => {
   // router.get('/complaints', (req, res) => {
   //
   //   // TODO: dynamically parse chat content on page
-  //   const chatStatus = faker.helpers.randomize(['online', 'offline', 'unavailable'])
+  //   const chatStatus = faker.helpers.arrayElement(['online', 'offline', 'unavailable'])
   //   const markdown = MarkdownHelper.getMarkdownContent(directoryPath, 'complaints-' + chatStatus)
   //
   //   res.render('feedback/index', {

--- a/app/routes/feedback.js
+++ b/app/routes/feedback.js
@@ -1,4 +1,4 @@
-const faker = require('faker')
+const faker = require('@faker-js/faker').faker
 faker.locale = 'en_GB'
 
 const path = require('path')

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "manage-teacher-training-applications-prototype",
       "hasInstallScript": true,
       "dependencies": {
+        "@faker-js/faker": "^8.4.1",
         "@govuk-prototype-kit/common-templates": "^1.2.2",
         "@x-govuk/govuk-prototype-filters": "^1.4.0",
         "archiver-promise": "^1.0.0",
@@ -15,7 +16,6 @@
         "cross-spawn": "^7.0.3",
         "csv-writer": "^1.6.0",
         "del": "^7.1.0",
-        "faker": "^5.5.3",
         "fancy-log": "^2.0.0",
         "govuk-frontend": "^5.4.1",
         "govuk-prototype-kit": "^13.16.2",
@@ -33,6 +33,22 @@
       },
       "engines": {
         "node": "20.11.0"
+      }
+    },
+    "node_modules/@faker-js/faker": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-8.4.1.tgz",
+      "integrity": "sha512-XQ3cU+Q8Uqmrbf2e0cIC/QN43sTBSC8KF12u29Mb47tWrt2hAgBXSgpZMj4Ao8Uk0iJcU99QsOCaIL8934obCg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fakerjs"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0",
+        "npm": ">=6.14.13"
       }
     },
     "node_modules/@govuk-prototype-kit/common-templates": {
@@ -1785,11 +1801,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/faker": {
-      "version": "5.5.3",
-      "resolved": "https://registry.npmjs.org/faker/-/faker-5.5.3.tgz",
-      "integrity": "sha512-wLTv2a28wjUyWkbnX7u/ABZBkUkIF2fCd73V6P2oFqEGEktDfzWx4UxrSqtPRw0xPRAcjeAOIiJWqZm3pP4u3g=="
     },
     "node_modules/fancy-log": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "postinstall": "npm run generate-data"
   },
   "dependencies": {
+    "@faker-js/faker": "^8.4.1",
     "@govuk-prototype-kit/common-templates": "^1.2.2",
     "@x-govuk/govuk-prototype-filters": "^1.4.0",
     "archiver-promise": "^1.0.0",
@@ -19,7 +20,6 @@
     "cross-spawn": "^7.0.3",
     "csv-writer": "^1.6.0",
     "del": "^7.1.0",
-    "faker": "^5.5.3",
     "fancy-log": "^2.0.0",
     "govuk-frontend": "^5.4.1",
     "govuk-prototype-kit": "^13.16.2",

--- a/scripts/applications/generate-interviews.js
+++ b/scripts/applications/generate-interviews.js
@@ -1,4 +1,4 @@
-const faker = require('faker');
+const faker = require('@faker-js/faker').faker;
 
 const { EVENTS } = require('./constants');
 const users = require('../../app/data/users.json');
@@ -93,4 +93,3 @@ exports.generateInterviews = (applications) => applications.map((application) =>
 
   return application;
 });
-

--- a/scripts/applications/generate-interviews.js
+++ b/scripts/applications/generate-interviews.js
@@ -1,4 +1,4 @@
-const faker = require('@faker-js/faker').faker;
+const { fakerUK: faker } = require('@faker-js/faker');
 
 const { EVENTS } = require('./constants');
 const users = require('../../app/data/users.json');

--- a/scripts/applications/generate-interviews.js
+++ b/scripts/applications/generate-interviews.js
@@ -35,7 +35,7 @@ exports.generateInterviews = (applications) => applications.map((application) =>
       for(let i = 0; i < totalInterviews; i++){
         const isSuccessful = i === successfulInterview;
         const interview = {
-          id: faker.datatype.uuid(),
+          id: faker.string.uuid(),
           details: randomize([faker.lorem.sentence(20), '']),
           location: randomize([[faker.address.streetAddress(), faker.address.city(), faker.address.zipCode()].join(', '), 'https://zoom.us/z1234/']),
           organisation: randomize(["The Royal Borough Teaching School Alliance", "Kingston University"]),

--- a/scripts/applications/generate-interviews.js
+++ b/scripts/applications/generate-interviews.js
@@ -37,7 +37,7 @@ exports.generateInterviews = (applications) => applications.map((application) =>
         const interview = {
           id: faker.string.uuid(),
           details: randomize([faker.lorem.sentence(20), '']),
-          location: randomize([[faker.address.streetAddress(), faker.address.city(), faker.address.zipCode()].join(', '), 'https://zoom.us/z1234/']),
+          location: randomize([[faker.location.streetAddress(), faker.location.city(), faker.location.zipCode()].join(', '), 'https://zoom.us/z1234/']),
           organisation: randomize(["The Royal Borough Teaching School Alliance", "Kingston University"]),
           date: isSuccessful ? dateFrom(offerMade.date, randomNumber(1,3)) : randomDateTo(randomDate(1,5), randomNumber(1, 10)),
         };

--- a/scripts/applications/generate-notes.js
+++ b/scripts/applications/generate-notes.js
@@ -19,7 +19,7 @@ exports.generateNotes = (applications) => applications.map((application) => {
             'Waiting on candidate to send information about teaching skills aquired during their Saturday job.',
             'Waiting on academic tutor to confirm availability before scheduling an interview'
           ]),
-          sender: faker.name.findName(),
+          sender: faker.person.fullName(),
           date,
         }
 

--- a/scripts/applications/generate-notes.js
+++ b/scripts/applications/generate-notes.js
@@ -1,4 +1,4 @@
-const faker = require('@faker-js/faker').faker;
+const { fakerUK: faker } = require('@faker-js/faker');
 
 const { EVENTS } = require('./constants');
 

--- a/scripts/applications/generate-notes.js
+++ b/scripts/applications/generate-notes.js
@@ -14,7 +14,7 @@ exports.generateNotes = (applications) => applications.map((application) => {
 
         const { date } = event;
         const newNote = {
-          id: faker.datatype.uuid(),
+          id: faker.string.uuid(),
           message: faker.helpers.randomize([
             'Waiting on candidate to send information about teaching skills aquired during their Saturday job.',
             'Waiting on academic tutor to confirm availability before scheduling an interview'

--- a/scripts/applications/generate-notes.js
+++ b/scripts/applications/generate-notes.js
@@ -15,7 +15,7 @@ exports.generateNotes = (applications) => applications.map((application) => {
         const { date } = event;
         const newNote = {
           id: faker.string.uuid(),
-          message: faker.helpers.randomize([
+          message: faker.helpers.arrayElement([
             'Waiting on candidate to send information about teaching skills aquired during their Saturday job.',
             'Waiting on academic tutor to confirm availability before scheduling an interview'
           ]),

--- a/scripts/applications/generate-notes.js
+++ b/scripts/applications/generate-notes.js
@@ -1,4 +1,4 @@
-const faker = require('faker');
+const faker = require('@faker-js/faker').faker;
 
 const { EVENTS } = require('./constants');
 
@@ -41,4 +41,3 @@ exports.generateNotes = (applications) => applications.map((application) => {
 
   return application;
 });
-

--- a/scripts/applications/generate-skeleton.js
+++ b/scripts/applications/generate-skeleton.js
@@ -1,4 +1,4 @@
-const faker = require('faker');
+const faker = require('@faker-js/faker').faker;
 
 const { STATUS, EVENTS } = require('./constants');
 const { randomDate, randomNumber } = require('./helpers');

--- a/scripts/applications/generate-skeleton.js
+++ b/scripts/applications/generate-skeleton.js
@@ -1,4 +1,4 @@
-const faker = require('@faker-js/faker').faker;
+const { fakerUK: faker } = require('@faker-js/faker');
 
 const { STATUS, EVENTS } = require('./constants');
 const { randomDate, randomNumber } = require('./helpers');

--- a/scripts/applications/helpers.js
+++ b/scripts/applications/helpers.js
@@ -1,4 +1,4 @@
-const faker = require('faker');
+const faker = require('@faker-js/faker').faker;
 const { DateTime } = require('luxon');
 
 const SystemHelper = require('../../app/data/helpers/system');

--- a/scripts/applications/helpers.js
+++ b/scripts/applications/helpers.js
@@ -1,4 +1,4 @@
-const faker = require('@faker-js/faker').faker;
+const { fakerUK: faker } = require('@faker-js/faker');
 const { DateTime } = require('luxon');
 
 const SystemHelper = require('../../app/data/helpers/system');

--- a/scripts/applications/helpers.js
+++ b/scripts/applications/helpers.js
@@ -3,7 +3,7 @@ const { DateTime } = require('luxon');
 
 const SystemHelper = require('../../app/data/helpers/system');
 
-const randomNumber = ( min, max ) => faker.datatype.number({ min, max });
+const randomNumber = ( min, max ) => faker.number.int({ min, max });
 const dateFrom = (date, days) => DateTime.fromISO(date).minus({days}).toISO();
 const randomDateFrom = (date, min, max) => dateFrom(date, randomNumber(min, max));
 

--- a/scripts/generate-applications.js
+++ b/scripts/generate-applications.js
@@ -177,7 +177,7 @@ const generateFakeApplication = (params = {}) => {
   }
 
   return {
-    id: params.id || ('' + faker.datatype.number({min: 123456, max: 999999})),
+    id: params.id || ('' + faker.number.int({min: 123456, max: 999999})),
     assignedUsers: params.assignedUsers || assignedUsers,
     deferredOfferUnavailable,
     cycle,
@@ -222,7 +222,7 @@ const generateFakeApplications = () => {
   const organisations = user.organisations
   const applications = []
   const now = SystemHelper.now()
-  const randomNumber = faker.datatype.number({ 'min': 1, 'max': 20 })
+  const randomNumber = faker.number.int({ 'min': 1, 'max': 20 })
   const past = now.minus({ days: randomNumber }).set({
     hour: faker.helpers.randomize([9, 10, 11]),
     minute: faker.helpers.randomize([0, 15, 30, 45])

--- a/scripts/generate-applications.js
+++ b/scripts/generate-applications.js
@@ -1,7 +1,6 @@
 const fs = require('fs')
 const path = require('path')
 const faker = require('@faker-js/faker').faker
-faker.locale = 'en_GB'
 const { DateTime } = require('luxon')
 const _ = require('lodash')
 const SystemHelper = require('../app/data/helpers/system')

--- a/scripts/generate-applications.js
+++ b/scripts/generate-applications.js
@@ -1,6 +1,6 @@
 const fs = require('fs')
 const path = require('path')
-const faker = require('faker')
+const faker = require('@faker-js/faker').faker
 faker.locale = 'en_GB'
 const { DateTime } = require('luxon')
 const _ = require('lodash')

--- a/scripts/generate-applications.js
+++ b/scripts/generate-applications.js
@@ -1,6 +1,6 @@
 const fs = require('fs')
 const path = require('path')
-const faker = require('@faker-js/faker').faker
+const { fakerUK: faker } = require('@faker-js/faker')
 const { DateTime } = require('luxon')
 const _ = require('lodash')
 const SystemHelper = require('../app/data/helpers/system')

--- a/scripts/generate-applications.js
+++ b/scripts/generate-applications.js
@@ -58,13 +58,13 @@ const generateFakeApplication = (params = {}) => {
   // ---------------------------------------------------------------------------
   const courses = GeneratorsHelper.getCourseData(provider)
 
-  const tempCourse = faker.helpers.randomize(courses)
+  const tempCourse = faker.helpers.arrayElement(courses)
 
   const courseCode = tempCourse.code
   const course = `${tempCourse.name} (${tempCourse.code})`
   const subjects = tempCourse.subjects
-  const location = faker.helpers.randomize(tempCourse.locations)
-  const studyMode = faker.helpers.randomize(tempCourse.studyModes)
+  const location = faker.helpers.arrayElement(tempCourse.locations)
+  const studyMode = faker.helpers.arrayElement(tempCourse.studyModes)
   const subjectLevel = tempCourse.subjectLevel
   const fundingType = tempCourse.fundingType
   const qualifications = tempCourse.qualifications
@@ -224,12 +224,12 @@ const generateFakeApplications = () => {
   const now = SystemHelper.now()
   const randomNumber = faker.number.int({ 'min': 1, 'max': 20 })
   const past = now.minus({ days: randomNumber }).set({
-    hour: faker.helpers.randomize([9, 10, 11]),
-    minute: faker.helpers.randomize([0, 15, 30, 45])
+    hour: faker.helpers.arrayElement([9, 10, 11]),
+    minute: faker.helpers.arrayElement([0, 15, 30, 45])
   })
   const future = now.plus({ days: randomNumber }).set({
-    hour: faker.helpers.randomize([9, 10, 11]),
-    minute: faker.helpers.randomize([0, 15, 30, 45])
+    hour: faker.helpers.arrayElement([9, 10, 11]),
+    minute: faker.helpers.arrayElement([0, 15, 30, 45])
   })
 
 

--- a/scripts/generate-courses.js
+++ b/scripts/generate-courses.js
@@ -1,5 +1,4 @@
 const faker = require('@faker-js/faker').faker
-faker.locale = 'en_GB'
 const fs = require('fs')
 const path = require('path')
 

--- a/scripts/generate-courses.js
+++ b/scripts/generate-courses.js
@@ -1,4 +1,4 @@
-const faker = require('faker')
+const faker = require('@faker-js/faker').faker
 faker.locale = 'en_GB'
 const fs = require('fs')
 const path = require('path')

--- a/scripts/generate-courses.js
+++ b/scripts/generate-courses.js
@@ -1,4 +1,4 @@
-const faker = require('@faker-js/faker').faker
+const { fakerUK: faker } = require('@faker-js/faker')
 const fs = require('fs')
 const path = require('path')
 

--- a/scripts/generate-courses.js
+++ b/scripts/generate-courses.js
@@ -48,6 +48,6 @@ const generateCoursesFile = (filePath, count) => {
   )
 }
 
-// faker.datatype.number({ 'min': 10, 'max': 25 })
+// faker.number.int({ 'min': 10, 'max': 25 })
 
 generateCoursesFile(path.join(__dirname, '../app/data/courses.json'), 25)

--- a/scripts/generate-locations.js
+++ b/scripts/generate-locations.js
@@ -1,5 +1,4 @@
 const faker = require('@faker-js/faker').faker
-faker.locale = 'en_GB'
 const fs = require('fs')
 const path = require('path')
 

--- a/scripts/generate-locations.js
+++ b/scripts/generate-locations.js
@@ -1,4 +1,4 @@
-const faker = require('faker')
+const faker = require('@faker-js/faker').faker
 faker.locale = 'en_GB'
 const fs = require('fs')
 const path = require('path')

--- a/scripts/generate-locations.js
+++ b/scripts/generate-locations.js
@@ -1,4 +1,4 @@
-const faker = require('@faker-js/faker').faker
+const { fakerUK: faker } = require('@faker-js/faker')
 const fs = require('fs')
 const path = require('path')
 

--- a/scripts/generate-locations.js
+++ b/scripts/generate-locations.js
@@ -16,7 +16,7 @@ const generateFakeLocations = (count) => {
 
   // TODO: generate locations per organisation
   locations.push({
-    id: faker.datatype.uuid(),
+    id: faker.string.uuid(),
     name: 'Main site',
     address: {
       address1: '123 Main Street',

--- a/scripts/generate-organisations.js
+++ b/scripts/generate-organisations.js
@@ -1,6 +1,6 @@
 const fs = require('fs')
 const path = require('path')
-const faker = require('@faker-js/faker').faker
+const { fakerUK: faker } = require('@faker-js/faker')
 
 const generateOrganisation = require('../app/data/generators/organisation')
 

--- a/scripts/generate-organisations.js
+++ b/scripts/generate-organisations.js
@@ -1,6 +1,6 @@
 const fs = require('fs')
 const path = require('path')
-const faker = require('faker')
+const faker = require('@faker-js/faker').faker
 faker.locale = 'en_GB'
 
 const generateOrganisation = require('../app/data/generators/organisation')

--- a/scripts/generate-organisations.js
+++ b/scripts/generate-organisations.js
@@ -1,7 +1,6 @@
 const fs = require('fs')
 const path = require('path')
 const faker = require('@faker-js/faker').faker
-faker.locale = 'en_GB'
 
 const generateOrganisation = require('../app/data/generators/organisation')
 

--- a/scripts/generate-users.js
+++ b/scripts/generate-users.js
@@ -1,7 +1,6 @@
 const fs = require('fs')
 const path = require('path')
 const faker = require('@faker-js/faker').faker
-faker.locale = 'en_GB'
 const generatorHelpers = require('../app/data/helpers/generators')
 const OrgHelper = require('../app/data/helpers/organisation')
 const generateUser = require('../app/data/generators/user')

--- a/scripts/generate-users.js
+++ b/scripts/generate-users.js
@@ -36,7 +36,7 @@ const generateFakeUsers = (count) => {
 
   // organisations.forEach(organisation => {
   //   for(var i = 0; i < 5; i++) {
-  //     let firstName = generatorHelpers.firstName(faker.helpers.randomize([0,1]))
+  //     let firstName = generatorHelpers.firstName(faker.helpers.arrayElement([0,1]))
   //     let lastName = generatorHelpers.lastName()
   //     users.push({
   //       id: faker.string.uuid(),
@@ -45,12 +45,12 @@ const generateFakeUsers = (count) => {
   //       emailAddress: `${firstName.replace(/\s/g, '').toLowerCase()}.${lastName.toLowerCase()}@${organisation.domain}`,
   //       organisation,
   //       permissions: {
-  //         manageOrganisation: faker.helpers.randomize([true, false]),
-  //         manageUsers: faker.helpers.randomize([true, false]),
-  //         setupInterviews: faker.helpers.randomize([true, false]),
-  //         makeDecisions: faker.helpers.randomize([true, false]),
-  //         viewSafeguardingInformation: faker.helpers.randomize([true, false]),
-  //         viewDiversityInformation: faker.helpers.randomize([true, false])
+  //         manageOrganisation: faker.helpers.arrayElement([true, false]),
+  //         manageUsers: faker.helpers.arrayElement([true, false]),
+  //         setupInterviews: faker.helpers.arrayElement([true, false]),
+  //         makeDecisions: faker.helpers.arrayElement([true, false]),
+  //         viewSafeguardingInformation: faker.helpers.arrayElement([true, false]),
+  //         viewDiversityInformation: faker.helpers.arrayElement([true, false])
   //       }
   //     })
   //   }

--- a/scripts/generate-users.js
+++ b/scripts/generate-users.js
@@ -19,7 +19,7 @@ const generateFakeUsers = (count) => {
   const emailAddress = 'l.obirek@warwick.ac.uk'
 
   users.push({
-    id: faker.datatype.uuid(),
+    id: faker.string.uuid(),
     firstName: firstName,
     lastName: lastName,
     emailAddress: emailAddress,
@@ -39,7 +39,7 @@ const generateFakeUsers = (count) => {
   //     let firstName = generatorHelpers.firstName(faker.helpers.randomize([0,1]))
   //     let lastName = generatorHelpers.lastName()
   //     users.push({
-  //       id: faker.datatype.uuid(),
+  //       id: faker.string.uuid(),
   //       firstName,
   //       lastName,
   //       emailAddress: `${firstName.replace(/\s/g, '').toLowerCase()}.${lastName.toLowerCase()}@${organisation.domain}`,

--- a/scripts/generate-users.js
+++ b/scripts/generate-users.js
@@ -1,6 +1,6 @@
 const fs = require('fs')
 const path = require('path')
-const faker = require('@faker-js/faker').faker
+const { fakerUK: faker } = require('@faker-js/faker')
 const generatorHelpers = require('../app/data/helpers/generators')
 const OrgHelper = require('../app/data/helpers/organisation')
 const generateUser = require('../app/data/generators/user')

--- a/scripts/generate-users.js
+++ b/scripts/generate-users.js
@@ -1,6 +1,6 @@
 const fs = require('fs')
 const path = require('path')
-const faker = require('faker')
+const faker = require('@faker-js/faker').faker
 faker.locale = 'en_GB'
 const generatorHelpers = require('../app/data/helpers/generators')
 const OrgHelper = require('../app/data/helpers/organisation')


### PR DESCRIPTION
The `faker` package was compromised long ago and can no longer be updated. This PR replaces it with `@faker-js/faker`.

This PR also replaces several functions:

| Old | New |
| --- | ---| 
| faker.address | faker.location |
| faker.company.companyName | faker.company.name |
| faker.datatype.number | faker.number.int |
| faker.datatype.uuid | faker.string.uuid |
| faker.date.between() | faker.date.between({}) |
| faker.helpers.randomize | faker.helpers.arrayElement |
| faker.internet.email() | faker.internet.email({}) |
| faker.name | faker.person |
| faker.name.findName | faker.person.fullName |
| faker.random.alphaNumeric | faker.string.alphanumeric |