### PR TITLE
Bug fixes - incorrect date plugin

### DIFF
--- a/app/filters.js
+++ b/app/filters.js
@@ -82,13 +82,6 @@ function falsify (input) {
 }
 addFilter('falsify', falsify)
 
-// TODO: refactor to using a plugin
-function govukDateAtTime (input) {
-  return input
-}
-addFilter('govukDateAtTime', govukDateAtTime)
-
-
 function arrayToList (array, join = ', ', final = ' and ') {
   const arr = array.slice(0)
 

--- a/app/views/_components/event-interview/template.njk
+++ b/app/views/_components/event-interview/template.njk
@@ -15,7 +15,7 @@
         text: "Time"
       },
       value: {
-        text: params.interview.date | time
+        text: params.interview.date | govukTime
       }
     },
     {

--- a/app/views/_components/interview-card/template.njk
+++ b/app/views/_components/interview-card/template.njk
@@ -6,7 +6,7 @@
     <p class="govuk-!-margin-bottom-1">
       <a href="{{params.link}}" class="govuk-link--no-visited-state">
       <time datetime="{{ params.date }}">
-        {{ params.date | time }}
+        {{ params.date | govukTime }}
       </time>
       <span class="govuk-visually-hidden"> on {{ params.date | govukDate }} with {{params.name}}</span>
       </a>

--- a/app/views/_components/timeline/template.njk
+++ b/app/views/_components/timeline/template.njk
@@ -11,7 +11,7 @@
         <p class="app-timeline__byline">
           {{ item.byline.html | safe if item.byline.html else item.byline.text -}}{% if item.datetime %}, {% endif %}
           <time datetime="{{ item.datetime.timestamp }}">
-            {{- item.datetime.timestamp | govukDateAtTime }}
+            {{- item.datetime.timestamp | govukDateTime }}
           </time>
         </p>
 

--- a/app/views/_includes/activity-log/events-timeline.njk
+++ b/app/views/_includes/activity-log/events-timeline.njk
@@ -15,14 +15,14 @@
             {{ event.event.title }}
           {% endif %}
           ({{ name }})
-          <span class="govuk-visually-hidden">{{- event.event.date | govukDateAtTime -}}</span>
+          <span class="govuk-visually-hidden">{{- event.event.date | govukDateTime -}}</span>
         </h2>
         <p class="app-activity-log__byline govuk-body-">
           {% if not isAutomaticRejection and not isAutomaticDecline %}
             {{ event.event.user }},
           {% endif %}
           <time datetime="{{ event.event.date }}">
-            {{- event.event.date | govukDateAtTime -}}
+            {{- event.event.date | govukDateTime -}}
           </time>
         </p>
       </div>
@@ -44,7 +44,7 @@
                 View note
                 <span class="govuk-visually-hidden">
                   Candidate {{ event.application.personalDetails.name }}
-                  Event date {{ event.event.date | govukDateAtTime }}
+                  Event date {{ event.event.date | govukDateTime }}
                 </span>
               </a>
             </p>
@@ -80,7 +80,7 @@
           </div>
 
           {% if event.event.meta.interviewExists %}
-            <p class="app-log-card__note--link"><a href="/applications/{{ event.application.id }}/interviews/#interview{{ event.meta.interview.id }}">View interview <span class="govuk-visually-hidden">{{ event.meta.interview.date | govukDateAtTime }}</span></a></p>
+            <p class="app-log-card__note--link"><a href="/applications/{{ event.application.id }}/interviews/#interview{{ event.meta.interview.id }}">View interview <span class="govuk-visually-hidden">{{ event.meta.interview.date | govukDateTime }}</span></a></p>
           {% endif %}
 
         {% endif %}
@@ -95,7 +95,7 @@
               View offer
               <span class="govuk-visually-hidden">
                 Candidate {{ event.application.personalDetails.name }}
-                Event date {{ event.event.date | govukDateAtTime }}
+                Event date {{ event.event.date | govukDateTime }}
               </span>
             </a></p>
         {% endif %}
@@ -111,7 +111,7 @@
               View feedback
               <span class="govuk-visually-hidden">
                 Candidate {{ event.application.personalDetails.name }}
-                Event date {{ event.event.date | govukDateAtTime }}
+                Event date {{ event.event.date | govukDateTime }}
               </span>
             </a></p>
           {% else %}
@@ -119,7 +119,7 @@
               View offer
               <span class="govuk-visually-hidden">
                 Candidate {{ event.application.personalDetails.name }}
-                Event date {{ event.event.date | govukDateAtTime }}
+                Event date {{ event.event.date | govukDateTime }}
               </span>
             </a></p>
           {% endif %}
@@ -136,7 +136,7 @@
               View feedback
               <span class="govuk-visually-hidden">
                 Candidate {{ event.application.personalDetails.name }}
-                Event date {{ event.event.date | govukDateAtTime }}
+                Event date {{ event.event.date | govukDateTime }}
               </span>
             </a></p>
           {% else %}
@@ -144,7 +144,7 @@
               View application
               <span class="govuk-visually-hidden">
                 Candidate {{ event.application.personalDetails.name }}
-                Event date {{ event.event.date | govukDateAtTime }}
+                Event date {{ event.event.date | govukDateTime }}
               </span>
             </a></p>
           {% endif %}

--- a/app/views/_includes/applications/application-details.njk
+++ b/app/views/_includes/applications/application-details.njk
@@ -7,7 +7,7 @@
         text: "Submitted"
       },
       value: {
-      text: application.submittedDate | govukDateAtTime
+      text: application.submittedDate | govukDateTime
       }
     },
     {

--- a/app/views/applications/interviews/index.njk
+++ b/app/views/applications/interviews/index.njk
@@ -95,15 +95,15 @@
             attributes: {
               id: "interview-" + interview.id
             },
-            titleText: interview.date | govukDateAtTime,
+            titleText: interview.date | govukDateTime,
             classes: "govuk-!-margin-bottom-6",
             actions: {
               items: [{
                 href: '/applications/' + application.id + '/interviews/' + interview.id + '/edit',
-                html: 'Change details <span class="govuk-visually-hidden">' + interview.date | govukDateAtTime + '</span>'
+                html: 'Change details <span class="govuk-visually-hidden">' + interview.date | govukDateTime + '</span>'
               } if application.status == "Received" or application.status == "Interviewing", {
                 href: '/applications/' + application.id + '/interviews/' + interview.id + '/delete',
-                html: 'Cancel interview <span class="govuk-visually-hidden">' + interview.date | govukDateAtTime + '</span>'
+                html: 'Cancel interview <span class="govuk-visually-hidden">' + interview.date | govukDateTime + '</span>'
               } if application.status == "Received" or application.status == "Interviewing"]
             } if canManageInterviews,
             html: interviewSummaryListHtml
@@ -184,10 +184,10 @@
           actions: {
             items: [{
               href: '/applications/' + application.id + '/interviews/' + interview.id + '/edit',
-              html: 'Change details <span class="govuk-visually-hidden">' + interview.date | govukDateAtTime + '</span>'
+              html: 'Change details <span class="govuk-visually-hidden">' + interview.date | govukDateTime + '</span>'
             } if application.status == "Received" or application.status == "Interviewing", {
               href: '/applications/' + application.id + '/interviews/'+ interview.id + '/delete',
-              html: 'Cancel interview <span class="govuk-visually-hidden">'+interview.date | govukDateAtTime+'</span>'
+              html: 'Cancel interview <span class="govuk-visually-hidden">'+interview.date | govukDateTime+'</span>'
             } if application.status == "Received" or application.status == "Interviewing"]
           } if canManageInterviews,
           html: interviewSummaryListHtml

--- a/app/views/applications/notes/show.njk
+++ b/app/views/applications/notes/show.njk
@@ -34,7 +34,7 @@
       </span>
       <h1 class="govuk-heading-l govuk-!-margin-bottom-5">Note</h1>
       <p>{{note.message}}</p>
-      <p class="govuk-hint govuk-!-font-size-16 govuk-!-margin-bottom-0">{{note.sender}}, {{note.date | govukDateAtTime }}</p>
+      <p class="govuk-hint govuk-!-font-size-16 govuk-!-margin-bottom-0">{{note.sender}}, {{note.date | govukDateTime }}</p>
     </div>
   </div>
 

--- a/app/views/applications/timeline/show.njk
+++ b/app/views/applications/timeline/show.njk
@@ -94,7 +94,7 @@
                 {% else %}
                   {{ event.title }}
                 {% endif %}
-                <span class="govuk-visually-hidden">{{- event.date | govukDateAtTime -}}</span>
+                <span class="govuk-visually-hidden">{{- event.date | govukDateTime -}}</span>
               </h2>
               <p class="app-activity-log__byline">
                 {% if not isAutomaticRejection and not isAutomaticDecline %}
@@ -122,7 +122,7 @@
                 {% if event.meta.interviewExists %}
                   <p class="app-log-card__note--link">
                     <a href="/applications/{{ application.id}}/interviews/#interview{{event.meta.interview.id}}">View interview
-                      <span class="govuk-visually-hidden">{{event.meta.interview.date | govukDateAtTime}}</span></a>
+                      <span class="govuk-visually-hidden">{{event.meta.interview.date | govukDateTime}}</span></a>
                   </p>
                 {% endif %}
               {% elseif event.title == content.updateInterview.event.title %}
@@ -134,7 +134,7 @@
                 {% if event.meta.interviewExists %}
                   <p class="app-log-card__note--link">
                     <a href="/applications/{{ application.id}}/interviews/#interview{{event.meta.interview.id}}">View interview
-                      <span class="govuk-visually-hidden">{{event.meta.interview.date | govukDateAtTime}}</span></a>
+                      <span class="govuk-visually-hidden">{{event.meta.interview.date | govukDateTime}}</span></a>
                   </p>
                 {% endif %}
               {% elseif event.title == content.cancelInterview.event.title %}
@@ -252,7 +252,7 @@
                 {% if event.meta.note.exists %}
                   <p class="app-log-card__note--link">
                     <a href="/applications/{{ application.id}}/notes/#note_{{event.meta.note.id}}">View note
-                      <span class="govuk-visually-hidden">{{event.meta.note.date | govukDateAtTime}}</span></a>
+                      <span class="govuk-visually-hidden">{{event.meta.note.date | govukDateTime}}</span></a>
                   </p>
                 {% endif %}
               {% elseif event.title in ["Assigned users updated", "User assigned", "Users assigned"] %}

--- a/app/views/applications/timeline/show.njk
+++ b/app/views/applications/timeline/show.njk
@@ -101,7 +101,7 @@
                   {{ event.user }},
                 {% endif %}
                 <time datetime="{{ event.date }}">
-                  {{- event.date | govukDateAtTime -}}
+                  {{- event.date | govukDateTime -}}
                 </time>
               </p>
             </div>


### PR DESCRIPTION
## Missing 'time' filter
There was a call to a filter called `time` which doesn't seem to exist and gave errors.

### Before
![There is an error](https://github.com/user-attachments/assets/c5bf4655-8502-4a84-8abf-ad23a6b1a5f0)
https://manage-applications-beta.herokuapp.com/interviews/past

### Fix
Replaced `time` calls with `govukTime`, the [x-govuk date filter](https://x-govuk.github.io/govuk-prototype-filters/get-started/) which was already included.

### After
![Interview schedule](https://github.com/user-attachments/assets/47679b2d-b1f6-4f70-be46-d58995abaa2f)


## Non-functional 'govukDateAtTime' filter in use
There was a placeholder filter created and in use called 'govukDateAtTime'. As the filter just returned whatever was input, it was showing standard ISO-format dates in the UI.

### Before
![13 July 2024](https://github.com/user-attachments/assets/55e5aa84-ccbc-4cd5-84ce-dd5993480e1f)
https://manage-applications-beta.herokuapp.com/activity

### Fix
Replaced `govukDateAtTime` calls with `govukDateTime`, another standard x-govuk date filter.

### After 
![image](https://github.com/user-attachments/assets/73aba7f9-c158-4087-8acf-386594c72f18)

