### PR TITLE
More granular Received statuses and new navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ You can regenerate the data:
 
 - In Terminal, change the path to the repository
 - Type `npm run generate-data`
+- Clear the data in your prototype
 
 ## Tools
 

--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -411,6 +411,22 @@ $statuses: (
   margin-bottom: 30px;
 }
 
+.app-status-header {
+  width: 100%;
+  margin-bottom: 10px;
+  overflow: hidden;
+}
+
+.app-status-header a {
+  background-color: govuk-colour("light-grey");
+  border-bottom-color: $govuk-secondary-text-colour;
+  color: $govuk-secondary-text-colour;
+  width: 100%;
+}
+
+.app-status-header a:hover {
+  background-color: govuk-tint( govuk-colour("mid-grey"), 65%);
+}
 
 .app-status-blocks {
   width: 100%;
@@ -419,33 +435,33 @@ $statuses: (
   gap: 10px;
 }
 
-.app-status-blocks a {
+.app-status-blocks a, .app-status-header a {
   display: block;
   padding: 10px;
   padding-bottom: 16px;
 }
 
-.app-status-blocks a.selected, .app-status-blocks a:hover {
+.app-status-blocks a.selected, .app-status-blocks a:hover, .app-status-header a.selected, .app-status-header a:hover {
   border-bottom-style: solid;
   border-bottom-width: 6px;
   padding-bottom: 10px;
 }
 
-.app-status-blocks a.selected {
+.app-status-blocks a.selected, .app-status-header a.selected {
   font-weight: bold;
 }
 
-.app-status-blocks a:focus {
+.app-status-blocks a:focus, .app-status-header a:focus {
   box-shadow: none;
   border-bottom-style: solid;
   border-bottom-width: 6px;
   padding-bottom: 10px;
 }
-.app-status-blocks a {
+.app-status-blocks a, .app-status-header a {
   text-decoration: none;
 }
 
-.app-status-blocks a:hover {
+.app-status-blocks a:hover, .app-status-header a:hover {
   text-decoration: underline;
 }
 
@@ -460,6 +476,9 @@ $app-colour-failed: govuk-colour("red");
   background-color: govuk-tint($app-colour-new, 70%);
   color: govuk-shade($app-colour-new, 60%);
 }
+.app-status-blocks a.new:hover {
+  background-color: govuk-tint($app-colour-new, 65%);
+}
 
 .app-status-blocks a.progress {
   border-bottom-color: govuk-shade($app-colour-progress, 65%);
@@ -467,10 +486,17 @@ $app-colour-failed: govuk-colour("red");
   color: govuk-shade($app-colour-progress, 65%);
 }
 
+.app-status-blocks a.progress:hover {
+  background-color: govuk-tint($app-colour-progress, 65%);
+}
+
 .app-status-blocks a.success {
   border-bottom-color: govuk-shade($app-colour-success, 20%);
   background-color: govuk-tint($app-colour-success, 80%);
   color: govuk-shade($app-colour-success, 20%);
+}
+.app-status-blocks a.success:hover {
+  background-color: govuk-tint($app-colour-success, 65%);
 }
 
 .app-status-blocks a.waiting {
@@ -478,15 +504,22 @@ $app-colour-failed: govuk-colour("red");
   background-color: govuk-tint($app-colour-waiting, 80%);
   color: govuk-shade($app-colour-waiting, 20%);
 }
+.app-status-blocks a.waiting:hover {
+  background-color: govuk-tint($app-colour-waiting, 65%);
+}
 
 .app-status-blocks a.failed {
   border-bottom-color: govuk-shade($app-colour-failed, 20%);
   background-color: govuk-tint($app-colour-failed, 80%);
   color: govuk-shade($app-colour-failed, 20%);
 }
+.app-status-blocks a.failed:hover {
+  background-color: govuk-tint($app-colour-failed, 65%);
+}
 
-.app-status-blocks a strong {
+.app-status-blocks a strong, .app-status-header a strong {
     display: block;
+    font-size: x-large;
 }
 
 .app-application-header {

--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -410,3 +410,93 @@ $statuses: (
   padding: 20px;
   margin-bottom: 30px;
 }
+
+
+.app-status-blocks {
+  width: 100%;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 10px;
+}
+
+.app-status-blocks a {
+  display: block;
+  padding: 10px;
+  padding-bottom: 16px;
+}
+
+.app-status-blocks a.selected, .app-status-blocks a:hover {
+  border-bottom-style: solid;
+  border-bottom-width: 6px;
+  padding-bottom: 10px;
+}
+
+.app-status-blocks a.selected {
+  font-weight: bold;
+}
+
+.app-status-blocks a:focus {
+  box-shadow: none;
+  border-bottom-style: solid;
+  border-bottom-width: 6px;
+  padding-bottom: 10px;
+}
+.app-status-blocks a {
+  text-decoration: none;
+}
+
+.app-status-blocks a:hover {
+  text-decoration: underline;
+}
+
+$app-colour-new: govuk-colour("blue");
+$app-colour-progress: govuk-colour("yellow");
+$app-colour-success: govuk-colour("green");
+$app-colour-waiting: govuk-colour("orange");
+$app-colour-failed: govuk-colour("red");
+
+.app-status-blocks a.new {
+  border-bottom-color: govuk-shade($app-colour-new, 60%);
+  background-color: govuk-tint($app-colour-new, 70%);
+  color: govuk-shade($app-colour-new, 60%);
+}
+
+.app-status-blocks a.progress {
+  border-bottom-color: govuk-shade($app-colour-progress, 65%);
+  background-color: govuk-tint($app-colour-progress, 75%);
+  color: govuk-shade($app-colour-progress, 65%);
+}
+
+.app-status-blocks a.success {
+  border-bottom-color: govuk-shade($app-colour-success, 20%);
+  background-color: govuk-tint($app-colour-success, 80%);
+  color: govuk-shade($app-colour-success, 20%);
+}
+
+.app-status-blocks a.waiting {
+  border-bottom-color: govuk-shade($app-colour-waiting, 20%);
+  background-color: govuk-tint($app-colour-waiting, 80%);
+  color: govuk-shade($app-colour-waiting, 20%);
+}
+
+.app-status-blocks a.failed {
+  border-bottom-color: govuk-shade($app-colour-failed, 20%);
+  background-color: govuk-tint($app-colour-failed, 80%);
+  color: govuk-shade($app-colour-failed, 20%);
+}
+
+.app-status-blocks a strong {
+    display: block;
+}
+
+.app-application-header {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 32px;
+}
+
+.app-application-header h1, .app-application-header a {
+  margin-bottom: 0;
+}

--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -500,3 +500,7 @@ $app-colour-failed: govuk-colour("red");
 .app-application-header h1, .app-application-header a {
   margin-bottom: 0;
 }
+
+.app-status-indicator--red {
+  color: $govuk-error-colour;
+}

--- a/app/assets/sass/core/_filter-layout.scss
+++ b/app/assets/sass/core/_filter-layout.scss
@@ -39,3 +39,19 @@
   overflow-x: auto;
 }
 
+
+.app-checkbox-filter__container {
+  position: relative;
+
+  max-height: 200px;
+  overflow-x: hidden;
+  overflow-y: auto;
+
+  background-color: govuk-colour("white");
+  border-bottom: 1px solid $govuk-border-colour;
+}
+
+.app-checkbox-filter__container-inner {
+  @include govuk-clearfix;
+  padding: govuk-spacing(1) govuk-spacing(2);
+}

--- a/app/assets/sass/core/_tag.scss
+++ b/app/assets/sass/core/_tag.scss
@@ -2,4 +2,5 @@
   white-space: nowrap;
   font-weight: lighter !important;
   font-size: 1.1875rem !important;
+  max-width: fit-content;
 }

--- a/app/data/helpers/cycles.js
+++ b/app/data/helpers/cycles.js
@@ -70,7 +70,7 @@ const CYCLES = {
   2024: {
     code: '2023 to 2024',
     shortDesc: '2023 to 2024',
-    longDesc: '2023 to 2023 (starts 2024)',
+    longDesc: '2023 to 2022 (starts 2024)',
     findOpens: DateTime.fromISO('2023-10-05T09:00:00').toJSDate(),
     applyOpens: DateTime.fromISO('2023-10-12T09:00:00').toJSDate(),
     showDeadlineBanner: DateTime.fromISO('2024-08-01T09:00:00').toJSDate(),
@@ -79,11 +79,24 @@ const CYCLES = {
     rejectByDefault: DateTime.fromISO('2024-09-29T23:59:59').toJSDate(),
     findCloses: DateTime.fromISO('2024-10-04T23:59:59').toJSDate(),
     ageCalculationDate: DateTime.fromISO('2024-08-31T23:59:59').toJSDate()
+  },
+  2025: {
+    code: '2024 to 2025',
+    shortDesc: '2024 to 2025',
+    longDesc: '2024 to 2025 (starts 2025)',
+    findOpens: DateTime.fromISO('2024-10-05T09:00:00').toJSDate(),
+    applyOpens: DateTime.fromISO('2024-10-12T09:00:00').toJSDate(),
+    showDeadlineBanner: DateTime.fromISO('2025-08-01T09:00:00').toJSDate(),
+    apply1Deadline: DateTime.fromISO('2025-09-07T18:00:00').toJSDate(),
+    apply2Deadline: DateTime.fromISO('2025-09-21T18:00:00').toJSDate(),
+    rejectByDefault: DateTime.fromISO('2025-09-29T23:59:59').toJSDate(),
+    findCloses: DateTime.fromISO('2025-10-04T23:59:59').toJSDate(),
+    ageCalculationDate: DateTime.fromISO('2025-08-31T23:59:59').toJSDate()
   }
 }
 
 const getCurrentCycle = () => {
-  const currentCycleYear = '2023'
+  const currentCycleYear = '2025'
   let cycle = {}
 
   for (const [year, data] of Object.entries(CYCLES)) {
@@ -164,8 +177,8 @@ const getNextCycle = () => {
 exports.NEXT_CYCLE = getNextCycle()
 
 exports.getCycleOptions = (selectedItems) => {
-  const currentCycleYear = '2023'
-  const previousCycleYear = '2022'
+  const currentCycleYear = '2025'
+  const previousCycleYear = '2024'
   const items = []
 
   for (const [year, data] of Object.entries(CYCLES)) {

--- a/app/data/helpers/cycles.js
+++ b/app/data/helpers/cycles.js
@@ -70,7 +70,7 @@ const CYCLES = {
   2024: {
     code: '2023 to 2024',
     shortDesc: '2023 to 2024',
-    longDesc: '2023 to 2022 (starts 2024)',
+    longDesc: '2023 to 2024 (starts 2024)',
     findOpens: DateTime.fromISO('2023-10-05T09:00:00').toJSDate(),
     applyOpens: DateTime.fromISO('2023-10-12T09:00:00').toJSDate(),
     showDeadlineBanner: DateTime.fromISO('2024-08-01T09:00:00').toJSDate(),

--- a/app/filters.js
+++ b/app/filters.js
@@ -10,19 +10,19 @@ function statusClass (status) {
       case 'Shortlisted':
         return 'govuk-tag--green'
       case 'Deferred':
-        return 'app-tag--orange'
+        return 'govuk-tag--orange'
       case 'Offer withdrawn':
-        return 'app-tag--red'
+        return 'govuk-tag--red'
       case 'Application withdrawn':
-        return 'app-tag--red'
+        return 'govuk-tag--red'
       case 'Declined':
-        return 'app-tag--red'
+        return 'govuk-tag--red'
       case 'Rejected':
-        return 'app-tag--red'
+        return 'govuk-tag--red'
       case 'Conditions not met':
-        return 'app-tag--red'
+        return 'govuk-tag--red'
       case 'Conditions pending':
-        return 'app-tag--orange'
+        return 'govuk-tag--orange'
       case 'Recruited':
         return 'govuk-tag--green'
       case 'Offered':
@@ -32,7 +32,7 @@ function statusClass (status) {
       case 'Interviewing':
         return 'govuk-tag--yellow'
       case 'Closed':
-        return 'app-tag--red'
+        return 'govuk-tag--red'
     }
   }
 

--- a/app/filters.js
+++ b/app/filters.js
@@ -3,24 +3,30 @@ const addFilter = govukPrototypeKit.views.addFilter
 
 function statusClass (status) {
     switch (status) {
-      case 'Deferred':
+      case 'New':
+        return 'govuk-tag--blue'
+      case 'In review':
         return 'govuk-tag--yellow'
+      case 'Shortlisted':
+        return 'govuk-tag--green'
+      case 'Deferred':
+        return 'app-tag--orange'
       case 'Offer withdrawn':
-        return 'govuk-tag--orange'
+        return 'app-tag--red'
       case 'Application withdrawn':
         return 'app-tag--red'
       case 'Declined':
         return 'app-tag--red'
       case 'Rejected':
-        return 'app-tag--orange'
+        return 'app-tag--red'
       case 'Conditions not met':
         return 'app-tag--red'
       case 'Conditions pending':
-        return 'govuk-tag--blue'
+        return 'app-tag--orange'
       case 'Recruited':
         return 'govuk-tag--green'
       case 'Offered':
-        return 'govuk-tag--turquoise'
+        return 'govuk-tag--green'
       case 'Received':
         return 'govuk-tag--purple'
       case 'Interviewing':

--- a/app/routes/application-list.js
+++ b/app/routes/application-list.js
@@ -447,7 +447,8 @@ const sortApplications = (applications, sort) => {
 }
 
 const getCheckboxValues = (name, data) => {
-  return name && (Array.isArray(name) ? name : [name].filter((name) => {
+
+  return name && ((Array.isArray(name) ? name : [name]).filter((name) => {
     return name !== '_unchecked'
   })) || data && (Array.isArray(data) ? data : [data])
 }

--- a/app/routes/application-list.js
+++ b/app/routes/application-list.js
@@ -467,7 +467,7 @@ module.exports = router => {
   router.all('/applications', (req, res) => {
 
     var sort = req.session.data.sort = req.query.sort || req.session.data.sort
-    var statusTab = req.session.data.statusTab
+    var statusTab = req.session.data.statusTab || 'action'
     var statuses
 
     if ( statusTab == 'action' || statusTab == 'Received' ) {
@@ -788,7 +788,7 @@ module.exports = router => {
         })
       }
 
-      if (statuses && statuses.length) {
+      if (statuses && statuses.length && !statusTab) {
         selectedFilters.categories.push({
           heading: { text: 'Statuses' },
           items: statuses.map((status) => {
@@ -951,7 +951,8 @@ module.exports = router => {
       appsShortlistedCount,
       appsRecruitedCount,
       appsUnsuccessfulCount,
-      appsDeferredCount
+      appsDeferredCount,
+      statusTab
     })
   })
 

--- a/app/routes/application-list.js
+++ b/app/routes/application-list.js
@@ -8,26 +8,6 @@ const { default: request } = require('sync-request')
 
 const getApplicationsByGroup = (applications) => {
 
-  /*
-  const actionReceivedNew = applications
-    .filter(app => app.status === "New")
-    .sort(function(a, b) {
-      return a.daysToRespond - b.daysToRespond
-    })
-
-  const actionReceivedInReview = applications
-    .filter(app => app.status === "In review")
-    .sort(function(a, b) {
-      return a.daysToRespond - b.daysToRespond
-    })
-
-  const actionReceivedShortlisted = applications
-  .filter(app => app.status === "Shortlisted")
-  .sort(function(a, b) {
-    return a.daysToRespond - b.daysToRespond
-  })
-*/
-
   const previousCyclePendingConditions = applications
     .filter(app => app.status === "Conditions pending")
     .filter(app => app.cycle === CycleHelper.PREVIOUS_CYCLE.code)
@@ -471,7 +451,7 @@ module.exports = router => {
     var statusTab = req.session.data.statusTab || 'action'
     var statuses
 
-    if ( req.query.status && req.query.status != '_unchecked'  ) {
+    if ( ( req.query.status && req.query.status != '_unchecked' ) || ( req.query.keywords || req.session.data.keywords ) ) {
       statusTab = 'all'
     }
 
@@ -892,7 +872,7 @@ module.exports = router => {
         })
       }
 
-    } else {
+    } else if ( statusTab != 'all' ) {
       delete req.session.data.statusTab
     }
 
@@ -938,6 +918,7 @@ module.exports = router => {
       pagination,
       selectedFilters,
       hasFilters,
+      hasSearch,
       subjectItems,
       trainingProviderItems,
       accreditedBodyItems,

--- a/app/routes/application-list.js
+++ b/app/routes/application-list.js
@@ -470,11 +470,12 @@ module.exports = router => {
     var statusTab = req.session.data.statusTab
     var statuses
 
-// console.log('statusTab');
-// console.log(statusTab);
-
-    if ( statusTab == 'action' ) {
+    if ( statusTab == 'action' || statusTab == 'Received' ) {
       statuses = [ 'New', 'In review', 'Shortlisted' ]
+    } else if ( statusTab == 'In progress' ) {
+      statuses = [ 'Interviewing', 'Offered', 'Conditions pending' ]
+    } else if ( statusTab == 'Complete' ) {
+      statuses = [ 'Recruited', 'Conditions not met', 'Declined', 'Rejected', 'Application withdrawn', 'Offer withdrawn', 'Deferred' ]
     } else if ( statusTab == 'Unsuccessful' ) {
       statuses = [ 'Conditions not met', 'Declined', 'Rejected', 'Application withdrawn', 'Offer withdrawn' ]
     } else if ( statusTab == 'all' ) {
@@ -536,9 +537,6 @@ module.exports = router => {
     if (!statusTab) {
       statuses = getCheckboxValues(status, req.session.data.status)
     }
-//    console.log('statuses')
-//    console.log(statuses)
-
 
     const providers = getCheckboxValues(provider, req.session.data.provider)
     const locations = getCheckboxValues(location, req.session.data.location)
@@ -694,7 +692,7 @@ module.exports = router => {
           && ageValid
       })
 
-      if ( statusTab == 'New' || statusTab == 'In review' || statusTab == 'Shortlisted' ) {
+      if ( statusTab == 'New' || statusTab == 'In review' || statusTab == 'Shortlisted' || statusTab == 'Received' ) {
         let appsNew = apps.filter((app) => {
           return app.status == 'New'
         })
@@ -712,7 +710,7 @@ module.exports = router => {
 
       }
 
-      if ( statusTab == 'Interviewing' || statusTab == 'Offered' || statusTab == 'Conditions pending' ) {
+      if ( statusTab == 'In progress' || statusTab == 'Interviewing' || statusTab == 'Offered' || statusTab == 'Conditions pending' ) {
         let appsInterviewing = apps.filter((app) => {
           return app.status == 'Interviewing'
         })
@@ -731,7 +729,7 @@ module.exports = router => {
       }
 
 
-      if ( statusTab == 'Recruited' || statusTab == 'Unsuccessful' || statusTab == 'Deferred' ) {
+      if ( statusTab == 'Complete' || statusTab == 'Recruited' || statusTab == 'Unsuccessful' || statusTab == 'Deferred' ) {
         let appsRecruited = apps.filter((app) => {
           return app.status == 'Recruited'
         })

--- a/app/routes/application-list.js
+++ b/app/routes/application-list.js
@@ -76,7 +76,7 @@ const getSubjectItems = (selectedItems) => {
   return items
 }
 
-const getStatusCheckboxItems = (selectedItems, ) => {
+const getStatusCheckboxItems = (selectedItems) => {
   const items = []
 
   const statuses = ['New', 'In review', 'Shortlisted', 'Interviewing', 'Offered', 'Conditions pending', 'Recruited', 'Deferred', 'Conditions not met', 'Declined', 'Rejected', 'Application withdrawn', 'Offer withdrawn']

--- a/app/routes/application-list.js
+++ b/app/routes/application-list.js
@@ -507,6 +507,13 @@ module.exports = router => {
 
     let apps = req.session.data.applications.map(app => app).reverse()
 
+    let appsNewCount
+    let appsReviewCount
+    let appsShortlistedCount
+    let appsInterviewingCount
+    let appsOfferedCount
+    let appsConditionsCount
+
     // for use in the filters
     const users = req.session.data.users.filter(user => {
       return user.organisation.id == req.session.data.user.organisation.id
@@ -561,7 +568,6 @@ module.exports = router => {
     if (hasFilters) {
       apps = apps.filter((app) => {
         let cycleValid = true
-        let statusValid = true
         let providerValid = true
         let locationValid = true
         let accreditedBodyValid = true
@@ -576,11 +582,6 @@ module.exports = router => {
           cycleValid = cycles.includes(app.cycle)
         }
 
-        if (statuses && statuses.length) {
-          statusValid = statuses.includes(app.status)
-//          console.log(app.status)
-//          console.log(statuses.includes(app.status))
-        }
 
         if (locations && locations.length) {
           locationValid = locations.includes(app.location.name)
@@ -666,7 +667,6 @@ module.exports = router => {
         }
 
         return cycleValid
-          && statusValid
           && locationValid
           && providerValid
           && accreditedBodyValid
@@ -677,6 +677,52 @@ module.exports = router => {
           && importantItemValid
           && noteItemValid
       })
+
+      if ( statusTab == 'New' || statusTab == 'In review' || statusTab == 'Shortlisted' ) {
+        let appsNew = apps.filter((app) => {
+          return app.status == 'New'
+        })
+        appsNewCount = appsNew.length
+
+        let appsReview = apps.filter((app) => {
+          return app.status == 'In review'
+        })
+        appsReviewCount = appsReview.length
+
+        let appsShortlisted = apps.filter((app) => {
+          return app.status == 'Shortlisted'
+        })
+        appsShortlistedCount = appsShortlisted.length
+
+      }
+
+      if ( statusTab == 'Interviewing' || statusTab == 'Offered' || statusTab == 'Conditions pending' ) {
+        let appsInterviewing = apps.filter((app) => {
+          return app.status == 'Interviewing'
+        })
+        appsInterviewingCount = appsInterviewing.length
+
+        let appsOffered = apps.filter((app) => {
+          return app.status == 'Offered'
+        })
+        appsOfferedCount = appsOffered.length
+
+        let appsConditions = apps.filter((app) => {
+          return app.status == 'Conditions pending'
+        })
+        appsConditionsCount = appsConditions.length
+
+      }
+
+
+      apps = apps.filter((app) => {
+        let statusValid = true
+        if (statuses && statuses.length) {
+          statusValid = statuses.includes(app.status)
+        }
+        return statusValid
+      })
+
     }
 
     let selectedFilters = null
@@ -862,7 +908,13 @@ module.exports = router => {
       cycleItems,
       statusCheckboxItems,
       importantCheckboxItems,
-      noteCheckboxItems
+      noteCheckboxItems,
+      appsNewCount,
+      appsReviewCount,
+      appsShortlistedCount,
+      appsInterviewingCount,
+      appsOfferedCount,
+      appsConditionsCount
     })
   })
 

--- a/app/routes/application-list.js
+++ b/app/routes/application-list.js
@@ -513,6 +513,9 @@ module.exports = router => {
     let appsInterviewingCount
     let appsOfferedCount
     let appsConditionsCount
+    let appsRecruitedCount
+    let appsUnsuccessfulCount
+    let appsDeferredCount
 
     // for use in the filters
     const users = req.session.data.users.filter(user => {
@@ -711,6 +714,25 @@ module.exports = router => {
           return app.status == 'Conditions pending'
         })
         appsConditionsCount = appsConditions.length
+
+      }
+
+
+      if ( statusTab == 'Recruited' || statusTab == 'Unsuccessful' || statusTab == 'Deferred' ) {
+        let appsRecruited = apps.filter((app) => {
+          return app.status == 'Recruited'
+        })
+        appsRecruitedCount = appsRecruited.length
+
+        let appsUnsuccessful = apps.filter((app) => {
+          return app.status == 'Unsuccessful'
+        })
+        appsUnsuccessfulCount = appsUnsuccessful.length
+
+        let appsDeferred = apps.filter((app) => {
+          return app.status == 'Deferred'
+        })
+        appsDeferredCount = appsDeferred.length
 
       }
 
@@ -914,7 +936,11 @@ module.exports = router => {
       appsShortlistedCount,
       appsInterviewingCount,
       appsOfferedCount,
-      appsConditionsCount
+      appsConditionsCount,
+      appsShortlistedCount,
+      appsRecruitedCount,
+      appsUnsuccessfulCount,
+      appsDeferredCount
     })
   })
 

--- a/app/routes/application-list.js
+++ b/app/routes/application-list.js
@@ -474,7 +474,7 @@ module.exports = router => {
 // console.log(statusTab);
 
     if ( statusTab == 'action' ) {
-      statuses = [ 'New', 'In review' ]
+      statuses = [ 'New', 'In review', 'Shortlisted' ]
     } else if ( statusTab == 'Unsuccessful' ) {
       statuses = [ 'Conditions not met', 'Declined', 'Rejected', 'Application withdrawn', 'Offer withdrawn' ]
     } else if ( statusTab == 'all' ) {
@@ -511,9 +511,6 @@ module.exports = router => {
     let apps = req.session.data.applications.map(app => app).sort(function(a, b) {
       return new Date( a.submittedDate ) - new Date( b.submittedDate )
     })
-
-
-
 
     let appsNewCount
     let appsReviewCount
@@ -588,11 +585,18 @@ module.exports = router => {
         let unassignedUserValid = true
         let importantItemValid = true
         let noteItemValid = true
+        let ageValid = true
+
+        const appAge =  Math.round( ( new Date().getTime() - new Date( app.submittedDate ).getTime() ) / (24 * 60 * 60 * 1000) );
+
+        if ( statusTab == 'action' ) {
+          const appAge =  Math.round( ( new Date().getTime() - new Date( app.submittedDate ).getTime() ) / (24 * 60 * 60 * 1000) );
+          ageValid = appAge >= 30
+        }
 
         if (cycles && cycles.length) {
           cycleValid = cycles.includes(app.cycle)
         }
-
 
         if (locations && locations.length) {
           locationValid = locations.includes(app.location.name)
@@ -687,6 +691,7 @@ module.exports = router => {
           && unassignedUserValid
           && importantItemValid
           && noteItemValid
+          && ageValid
       })
 
       if ( statusTab == 'New' || statusTab == 'In review' || statusTab == 'Shortlisted' ) {

--- a/app/routes/application-list.js
+++ b/app/routes/application-list.js
@@ -79,7 +79,7 @@ const getSubjectItems = (selectedItems) => {
 const getStatusCheckboxItems = (selectedItems, ) => {
   const items = []
 
-  const statuses = ['Received', 'New', 'In review', 'Shortlisted', 'Interviewing', 'Offered', 'Conditions pending', 'Recruited', 'Deferred', 'Conditions not met', 'Declined', 'Rejected', 'Application withdrawn', 'Offer withdrawn']
+  const statuses = ['New', 'In review', 'Shortlisted', 'Interviewing', 'Offered', 'Conditions pending', 'Recruited', 'Deferred', 'Conditions not met', 'Declined', 'Rejected', 'Application withdrawn', 'Offer withdrawn']
 
   statuses.forEach((status, i) => {
     const item = {}

--- a/app/routes/application-list.js
+++ b/app/routes/application-list.js
@@ -208,7 +208,7 @@ const getSubjectItems = (selectedItems) => {
   return items
 }
 
-const getStatusCheckboxItems = (selectedItems) => {
+const getStatusCheckboxItems = (selectedItems, ) => {
   const items = []
 
   const statuses = ['Received', 'New', 'In review', 'Shortlisted', 'Interviewing', 'Offered', 'Conditions pending', 'Recruited', 'Deferred', 'Conditions not met', 'Declined', 'Rejected', 'Application withdrawn', 'Offer withdrawn']
@@ -471,6 +471,10 @@ module.exports = router => {
     var statusTab = req.session.data.statusTab || 'action'
     var statuses
 
+    if ( req.query.status && req.query.status != '_unchecked'  ) {
+      statusTab = 'all'
+    }
+
     if ( statusTab == 'action' || statusTab == 'Received' ) {
       statuses = [ 'New', 'In review', 'Shortlisted' ]
     } else if ( statusTab == 'In progress' ) {
@@ -484,6 +488,7 @@ module.exports = router => {
     } else {
       statuses = [ statusTab ]
     }
+
 
     var filters = [
       'cycle',
@@ -535,9 +540,11 @@ module.exports = router => {
 
     const cycles = getCheckboxValues(cycle, req.session.data.cycle)
 
-    if (!statusTab) {
+     if (!statusTab || statusTab == 'all' ) {
       statuses = getCheckboxValues(status, req.session.data.status)
-    }
+     } else {
+      req.session.data.status = null
+     }
 
     const providers = getCheckboxValues(provider, req.session.data.provider)
     const locations = getCheckboxValues(location, req.session.data.location)
@@ -748,7 +755,6 @@ module.exports = router => {
 
       }
 
-
       apps = apps.filter((app) => {
         let statusValid = true
         if (statuses && statuses.length) {
@@ -789,7 +795,7 @@ module.exports = router => {
         })
       }
 
-      if (statuses && statuses.length && !statusTab) {
+      if (statuses && statuses.length && ( !statusTab || statusTab == 'all' ) ) {
         selectedFilters.categories.push({
           heading: { text: 'Statuses' },
           items: statuses.map((status) => {
@@ -886,6 +892,8 @@ module.exports = router => {
         })
       }
 
+    } else {
+      delete req.session.data.statusTab
     }
 
     // TODO: clean up

--- a/app/routes/application-list.js
+++ b/app/routes/application-list.js
@@ -8,6 +8,7 @@ const { default: request } = require('sync-request')
 
 const getApplicationsByGroup = (applications) => {
 
+  /*
   const actionReceivedNew = applications
     .filter(app => app.status === "New")
     .sort(function(a, b) {
@@ -25,6 +26,7 @@ const getApplicationsByGroup = (applications) => {
   .sort(function(a, b) {
     return a.daysToRespond - b.daysToRespond
   })
+*/
 
   const previousCyclePendingConditions = applications
     .filter(app => app.status === "Conditions pending")
@@ -473,12 +475,13 @@ module.exports = router => {
 
     if ( statusTab == 'action' ) {
       statuses = [ 'New', 'In review' ]
+    } else if ( statusTab == 'Unsuccessful' ) {
+      statuses = [ 'Conditions not met', 'Declined', 'Rejected', 'Application withdrawn', 'Offer withdrawn' ]
     } else if ( statusTab == 'all' ) {
       statuses = null
     } else {
       statuses = [ statusTab ]
     }
-
 
     var filters = [
       'cycle',
@@ -505,7 +508,12 @@ module.exports = router => {
       })
     }
 
-    let apps = req.session.data.applications.map(app => app).reverse()
+    let apps = req.session.data.applications.map(app => app).sort(function(a, b) {
+      return new Date( a.submittedDate ) - new Date( b.submittedDate )
+    })
+
+
+
 
     let appsNewCount
     let appsReviewCount
@@ -725,7 +733,7 @@ module.exports = router => {
         appsRecruitedCount = appsRecruited.length
 
         let appsUnsuccessful = apps.filter((app) => {
-          return app.status == 'Unsuccessful'
+          return [ 'Conditions not met', 'Declined', 'Rejected', 'Application withdrawn', 'Offer withdrawn' ].includes(app.status)
         })
         appsUnsuccessfulCount = appsUnsuccessful.length
 

--- a/app/routes/applications.js
+++ b/app/routes/applications.js
@@ -7,7 +7,13 @@ module.exports = router => {
     const application = req.session.data.applications.find(app => app.id === applicationId)
     const assignedUsers = ApplicationHelper.getAssignedUsers(application, req.session.data.user.id, req.session.data.user.organisation.id)
     const course = courses.find(course => course.code === application.courseCode)
-    const showWithdrawnBanner = typeof req.session.data['withdraw-application'] !== 'undefined'
+    let showBanner
+
+    if ( typeof req.session.data['withdraw-application'] !== 'undefined' ) {
+      showBanner = 'withdraw'
+    } else {
+      showBanner = req.query.confirm
+    }
 
     // remove the search keywords if present to reset the search
     delete req.session.data.keywords
@@ -38,7 +44,7 @@ module.exports = router => {
       course,
       hasOtherNonUkQualifications,
       assignedUsers,
-      showWithdrawnBanner,
+      showBanner,
       otherApplications: ApplicationHelper.getOtherApplications(application, req.session.data.applications)
     })
   })
@@ -155,6 +161,27 @@ module.exports = router => {
     } else {
       res.redirect(`/applications/${applicationId}/reject/reasons`)
     }
+  })
+
+
+  router.get('/applications/:applicationId/review', (req, res) => {
+    const applicationId = req.params.applicationId
+    const application = req.session.data.applications.find(app => app.id === applicationId)
+
+    application.status = 'In review'
+
+    res.redirect(`/applications/${applicationId}?confirm=review`)
+
+  })
+
+  router.get('/applications/:applicationId/shortlist', (req, res) => {
+    const applicationId = req.params.applicationId
+    const application = req.session.data.applications.find(app => app.id === applicationId)
+
+    application.status = 'Shortlisted'
+
+    res.redirect(`/applications/${applicationId}?confirm=shortlist`)
+
   })
 
 }

--- a/app/routes/reports.js
+++ b/app/routes/reports.js
@@ -589,7 +589,11 @@ module.exports = router => {
   })
 
   router.get('/reports/export', (req, res) => {
-    const organisation = req.session.data.user.organisations.find(org => org.id === req.params.organisationId)
+    let organisation
+
+    if ( req.session.data.user.organisations[0] ) {
+      organisation = req.session.data.user.organisations.find(org => org.id === req.params.organisationId)
+    }
     const cycleItems = CycleHelper.getCycleOptions(req.session.data.export_cycle)
     res.render('reports/applications/index', {
       organisation,

--- a/app/views/_includes/application-card.njk
+++ b/app/views/_includes/application-card.njk
@@ -40,8 +40,8 @@
     </div>
     <div class="govuk-grid-column-one-third">
       <dl class="app-application-card__list app-application-card__list--secondary">
-        {% if a.status == 'Received' or a.status == 'Interviewing' %}
-          <dd class="govuk-body-s">Received {{ a.submittedDate | daysAgo }} days ago
+        {% if a.status == 'Received' or a.status == 'New' or a.status == 'In review' or a.status == 'Interviewing' or a.status == 'Shortlisted' %}
+          <dd class="govuk-body-s{% if ( a.submittedDate | daysAgo ) >= 30 %} app-status-indicator--red{% endif %}">Received {{ a.submittedDate | daysAgo }} days ago
           </dd>
         {% elif a.status == 'Offered' %}
           <dd class="govuk-body-s">Offer made {{ a.offer.madeDate | daysAgo }} days ago</dd>

--- a/app/views/_includes/applications/h1.njk
+++ b/app/views/_includes/applications/h1.njk
@@ -7,7 +7,7 @@
         {{ govukTag({ classes: application.status | statusClass, text: application.status }) }}
       </h1>
       <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
+        <div class="govuk-grid-column-two-thirds govuk-!-padding-right-0">
           {% include "_includes/applications/prompts.njk" %}
         </div>
       </div>

--- a/app/views/_includes/applications/respond-prompt.njk
+++ b/app/views/_includes/applications/respond-prompt.njk
@@ -1,4 +1,4 @@
-{% if application.status == 'Received' %}
+{% if application.status == 'Received' or application.status == 'New' or application.status == 'In review' or application.status == 'Shortlisted' %}
   {% set promptHtml %}
 
     {% if canManageInterviews and canMakeOffersAndRejectApplications %}
@@ -9,10 +9,24 @@
       <h2 class="govuk-heading-m govuk-!-margin-bottom-3">Make a decision</h2>
     {% endif %}
       <p>This application was received {{ application.submittedDate | daysAgo }} days ago. You should try and respond to the candidate within 30 days.</p>
+      {% if application.status == 'Received' or application.status == 'New' %}
+        {{ govukButton({
+          text: "Mark as in review",
+          classes: "govuk-!-margin-bottom-0 govuk-!-margin-right-2 govuk-button--secondary",
+          href: "/applications/" + application.id + "/review"
+        }) }}
+      {% endif %}
+      {% if application.status == 'Received' or application.status == 'New' or application.status == 'In review' %}
+        {{ govukButton({
+          text: "Shortlist",
+          classes: "govuk-!-margin-bottom-0 govuk-!-margin-right-2 govuk-button--secondary",
+          href: "/applications/" + application.id + "/shortlist"
+        }) }}
+      {% endif %}
     {% if canManageInterviews %}
       {{ govukButton({
         text: "Set up interview",
-        classes: "govuk-!-margin-bottom-0 govuk-!-margin-right-2",
+        classes: "govuk-!-margin-bottom-0 govuk-!-margin-right-2 govuk-button--secondary",
         href: "/applications/" + application.id + "/interviews/new"
       }) }}
     {% endif %}

--- a/app/views/_includes/filter-panel.njk
+++ b/app/views/_includes/filter-panel.njk
@@ -14,19 +14,6 @@
     items: cycleItems
   }) }}
 
-  {{ govukCheckboxes({
-    idPrefix: 'status',
-    name: 'status',
-    classes: "govuk-checkboxes--small",
-    fieldset: {
-      legend: {
-        text: 'Status',
-        classes: 'govuk-fieldset__legend--s'
-      }
-    },
-    items: statusCheckboxItems
-  }) }}
-
   {% if trainingProviderItems.length > 1 %}
 
     {{ govukCheckboxes({
@@ -158,6 +145,22 @@
       }
     ]
   }) }}
+
+  <div class="app-checkbox-filter__container">
+  {{ govukCheckboxes({
+    idPrefix: 'status',
+    name: 'status',
+    classes: "govuk-checkboxes--small app-checkbox-filter__container-inner",
+    fieldset: {
+      legend: {
+        text: 'Status',
+        classes: 'govuk-fieldset__legend--s'
+      }
+    },
+    items: statusCheckboxItems
+  }) }}
+  </div>
+
 {% endset %}
 
 <div class="app-filter">

--- a/app/views/_includes/filter-panel.njk
+++ b/app/views/_includes/filter-panel.njk
@@ -162,7 +162,6 @@
   </div>
 
 {% endset %}
-
 <div class="app-filter">
   <div class="app-filter__header">
     <div class="app-filter__header-title">
@@ -173,7 +172,7 @@
     </div>
   </div>
   <div class="app-filter__content">
-    {% if selectedFilters %}
+    {% if selectedFilters.categories | length %}
       <div class="app-filter__selected">
         <div class="app-filter__selected-heading">
           <div class="app-filter__heading-title">

--- a/app/views/_layout.njk
+++ b/app/views/_layout.njk
@@ -106,6 +106,10 @@
           {
             text: 'Clear data',
             href: '/manage-prototype/clear-data'
+          },
+          {
+            text: 'Cycle settings',
+            href: '/admin/settings'
           }
         ]
       }

--- a/app/views/applications/index.njk
+++ b/app/views/applications/index.njk
@@ -22,33 +22,32 @@
       </div>
 
       {% include "_includes/search-panel.njk" %}
-
       <div class="govuk-tabs">
         <h2 class="govuk-tabs__title">
           Contents
         </h2>
         <ul class="govuk-tabs__list">
-          <li class="govuk-tabs__list-item{% if not data['statusTab'] or data['statusTab'] == 'action' %} govuk-tabs__list-item--selected{% endif %}">
+          <li class="govuk-tabs__list-item{% if not statusTab or statusTab == 'action' %} govuk-tabs__list-item--selected{% endif %}">
             <a class="govuk-tabs__tab" href="applications?statusTab=action">
               Action required
             </a>
           </li>
-          <li class="govuk-tabs__list-item{% if data['statusTab'] == 'New' or data['statusTab'] == 'In review' or data['statusTab'] == 'Shortlisted' or data['statusTab'] == 'Received' %} govuk-tabs__list-item--selected{% endif %}">
+          <li class="govuk-tabs__list-item{% if statusTab == 'New' or statusTab == 'In review' or statusTab == 'Shortlisted' or statusTab == 'Received' %} govuk-tabs__list-item--selected{% endif %}">
             <a class="govuk-tabs__tab" href="applications?statusTab=New">
               Received
             </a>
           </li>
-          <li class="govuk-tabs__list-item{% if data['statusTab'] == 'In progress' or data['statusTab'] == 'Interviewing' or data['statusTab'] == 'Offered' or data['statusTab'] == 'Conditions pending' %} govuk-tabs__list-item--selected{% endif %}">
+          <li class="govuk-tabs__list-item{% if statusTab == 'In progress' or statusTab == 'Interviewing' or statusTab == 'Offered' or statusTab == 'Conditions pending' %} govuk-tabs__list-item--selected{% endif %}">
             <a class="govuk-tabs__tab" href="applications?statusTab=In progress">
               In progress
             </a>
           </li>
-          <li class="govuk-tabs__list-item{% if data['statusTab'] == 'Complete' or data['statusTab'] == 'Recruited' or data['statusTab'] == 'Unsuccessful' or data['statusTab'] == 'Deferred' %} govuk-tabs__list-item--selected{% endif %}">
+          <li class="govuk-tabs__list-item{% if statusTab == 'Complete' or statusTab == 'Recruited' or statusTab == 'Unsuccessful' or statusTab == 'Deferred' %} govuk-tabs__list-item--selected{% endif %}">
             <a class="govuk-tabs__tab" href="applications?statusTab=Complete">
               Complete
             </a>
           </li>
-          <li class="govuk-tabs__list-item{% if data['statusTab'] == 'all' %} govuk-tabs__list-item--selected{% endif %}">
+          <li class="govuk-tabs__list-item{% if statusTab == 'all' %} govuk-tabs__list-item--selected{% endif %}">
             <a class="govuk-tabs__tab" href="applications?statusTab=all">
               All
             </a>
@@ -56,7 +55,7 @@
         </ul>
         <div class="govuk-tabs__panel">
 
-          {% if data['statusTab'] == '' or data['statusTab'] == 'action' %}
+          {% if not selectedFilters.length and ( not statusTab or statusTab == 'action' ) %}
 
             {% set bannerHtml %}
               <p class="govuk-notification-banner__heading">You have {{applications.length}} applications requiring action.</p>
@@ -67,20 +66,20 @@
               html: bannerHtml
             }) }}
 
-          {% elseif data['statusTab'] == 'New' or data['statusTab'] == 'In review' or data['statusTab'] == 'Shortlisted' or data['statusTab'] == 'Received' %}
-            <div class="app-status-header"><a href="applications?statusTab=Received" {% if data['statusTab'] == 'Received' %}class="selected"{% endif %}><strong>{{ appsNewCount + appsReviewCount + appsShortlistedCount }}</strong> applications received</a></div>
+          {% elseif statusTab == 'New' or statusTab == 'In review' or statusTab == 'Shortlisted' or statusTab == 'Received' %}
+            <div class="app-status-header"><a href="applications?statusTab=Received" {% if statusTab == 'Received' %}class="selected"{% endif %}><strong>{{ appsNewCount + appsReviewCount + appsShortlistedCount }}</strong> applications received</a></div>
             <div class="app-status-blocks">
-              <p><a href="applications?statusTab=New" class="new{% if data['statusTab'] == 'New' %} selected{% endif %}"><strong>{{appsNewCount}}</strong> new applications to review</a></p>
-              <p><a href="applications?statusTab=In review" class="progress{% if data['statusTab'] == 'In review' %} selected{% endif %}"><strong>{{appsReviewCount}}</strong> applications in review</a></p>
-              <p><a href="applications?statusTab=Shortlisted" class="success{% if data['statusTab'] == 'Shortlisted' %} selected{% endif %}"><strong>{{appsShortlistedCount}}</strong> shortlisted applications</a></p>
+              <p><a href="applications?statusTab=New" class="new{% if statusTab == 'New' %} selected{% endif %}"><strong>{{appsNewCount}}</strong> new applications to review</a></p>
+              <p><a href="applications?statusTab=In review" class="progress{% if statusTab == 'In review' %} selected{% endif %}"><strong>{{appsReviewCount}}</strong> applications in review</a></p>
+              <p><a href="applications?statusTab=Shortlisted" class="success{% if statusTab == 'Shortlisted' %} selected{% endif %}"><strong>{{appsShortlistedCount}}</strong> shortlisted applications</a></p>
             </div>
 
-              {% if data['statusTab'] == 'Received' %}
+              {% if statusTab == 'Received' %}
               <h1 class="govuk-heading-s">
                 Applications received ({{ appsNewCount + appsReviewCount + appsShortlistedCount }})
               </h1>
 
-              {% elseif data['statusTab'] == 'New' %}
+              {% elseif statusTab == 'New' %}
               <div class="app-application-header">
                 <h1 class="govuk-heading-s">
                   New applications to review ({{allApplications.length}})
@@ -91,78 +90,88 @@
                   classes: "govuk-button--secondary"
                 }) }}
               </div>
-              {% elseif data['statusTab'] == 'In review' %}
+              {% elseif statusTab == 'In review' %}
               <h1 class="govuk-heading-s">
                 Applications in review ({{allApplications.length}})
               </h1>
 
-              {% elseif data['statusTab'] == 'Shortlisted' %}
+              {% elseif statusTab == 'Shortlisted' %}
               <h1 class="govuk-heading-s">
                 Shortlisted applications ({{allApplications.length}})
               </h1>
 
               {% endif %}
 
-          {% elseif data['statusTab'] == 'In progress' or data['statusTab'] == 'Interviewing' or data['statusTab'] == 'Offered' or data['statusTab'] == 'Conditions pending' %}
-            <div class="app-status-header"><a href="applications?statusTab=In progress" {% if data['statusTab'] == 'In progress' %}class="selected"{% endif %}><strong>{{ appsInterviewingCount + appsOfferedCount + appsConditionsCount }}</strong> applications in progress</a></div>
+          {% elseif statusTab == 'In progress' or statusTab == 'Interviewing' or statusTab == 'Offered' or statusTab == 'Conditions pending' %}
+            <div class="app-status-header"><a href="applications?statusTab=In progress" {% if statusTab == 'In progress' %}class="selected"{% endif %}><strong>{{ appsInterviewingCount + appsOfferedCount + appsConditionsCount }}</strong> applications in progress</a></div>
             <div class="app-status-blocks">
-              <p><a href="applications?statusTab=Interviewing" class="progress{% if data['statusTab'] == 'Interviewing' %} selected{% endif %}"><strong>{{appsInterviewingCount}}</strong> in interview</a></p>
-              <p><a href="applications?statusTab=Offered" class="success{% if data['statusTab'] == 'Offered' %} selected{% endif %}"><strong>{{appsOfferedCount}}</strong> offers made</a></p>
-              <p><a href="applications?statusTab=Conditions pending" class="waiting{% if data['statusTab'] == 'Conditions pending' %} selected{% endif %}"><strong>{{appsConditionsCount}}</strong> pending conditions</a></p>
+              <p><a href="applications?statusTab=Interviewing" class="progress{% if statusTab == 'Interviewing' %} selected{% endif %}"><strong>{{appsInterviewingCount}}</strong> in interview</a></p>
+              <p><a href="applications?statusTab=Offered" class="success{% if statusTab == 'Offered' %} selected{% endif %}"><strong>{{appsOfferedCount}}</strong> offers made</a></p>
+              <p><a href="applications?statusTab=Conditions pending" class="waiting{% if statusTab == 'Conditions pending' %} selected{% endif %}"><strong>{{appsConditionsCount}}</strong> pending conditions</a></p>
             </div>
 
-            {% if data['statusTab'] == 'In progress' %}
+            {% if statusTab == 'In progress' %}
             <h1 class="govuk-heading-s">
               Applications in progress ({{ appsInterviewingCount + appsOfferedCount + appsConditionsCount }})
             </h1>
 
-            {% elseif data['statusTab'] == 'Interviewing' %}
+            {% elseif statusTab == 'Interviewing' %}
             <h1 class="govuk-heading-s">
               Applications in interview ({{allApplications.length}})
             </h1>
 
-            {% elseif data['statusTab'] == 'Offered' %}
+            {% elseif statusTab == 'Offered' %}
             <h1 class="govuk-heading-s">
               Places offered ({{allApplications.length}})
             </h1>
 
-            {% elseif data['statusTab'] == 'Conditions pending' %}
+            {% elseif statusTab == 'Conditions pending' %}
             <h1 class="govuk-heading-s">
               Applications with conditions pending ({{allApplications.length}})
             </h1>
 
           {% endif %}
 
-          {% elseif data['statusTab'] == 'Complete' or data['statusTab'] == 'Recruited' or data['statusTab'] == 'Unsuccessful' or data['statusTab'] == 'Deferred' %}
-            <div class="app-status-header"><a href="applications?statusTab=Complete" {% if data['statusTab'] == 'Complete' %}class="selected"{% endif %}><strong>{{ appsRecruitedCount + appsUnsuccessfulCount + appsDeferredCount }}</strong> applications completed</a></div>
+          {% elseif statusTab == 'Complete' or statusTab == 'Recruited' or statusTab == 'Unsuccessful' or statusTab == 'Deferred' %}
+            <div class="app-status-header"><a href="applications?statusTab=Complete" {% if statusTab == 'Complete' %}class="selected"{% endif %}><strong>{{ appsRecruitedCount + appsUnsuccessfulCount + appsDeferredCount }}</strong> applications completed</a></div>
             <div class="app-status-blocks">
-              <p><a href="applications?statusTab=Recruited" class="success{% if data['statusTab'] == 'Recruited' %} selected{% endif %}"><strong>{{appsRecruitedCount}}</strong> recruited</a></p>
-              <p><a href="applications?statusTab=Unsuccessful" class="failed{% if data['statusTab'] == 'Unsuccessful' %} selected{% endif %}"><strong>{{appsUnsuccessfulCount}}</strong> unsuccessful</a></p>
-              <p><a href="applications?statusTab=Deferred" class="waiting{% if data['statusTab'] == 'Deferred' %} selected{% endif %}"><strong>{{appsDeferredCount}}</strong> deferred</a></p>
+              <p><a href="applications?statusTab=Recruited" class="success{% if statusTab == 'Recruited' %} selected{% endif %}"><strong>{{appsRecruitedCount}}</strong> recruited</a></p>
+              <p><a href="applications?statusTab=Unsuccessful" class="failed{% if statusTab == 'Unsuccessful' %} selected{% endif %}"><strong>{{appsUnsuccessfulCount}}</strong> unsuccessful</a></p>
+              <p><a href="applications?statusTab=Deferred" class="waiting{% if statusTab == 'Deferred' %} selected{% endif %}"><strong>{{appsDeferredCount}}</strong> deferred</a></p>
             </div>
 
-            {% if data['statusTab'] == 'Complete' %}
+            {% if statusTab == 'Complete' %}
             <h1 class="govuk-heading-s">
               Applications completed ({{ appsRecruitedCount + appsUnsuccessfulCount + appsDeferredCount }})
             </h1>
 
-            {% elseif data['statusTab'] == 'Recruited' %}
+            {% elseif statusTab == 'Recruited' %}
             <h1 class="govuk-heading-s">
               Candidates recruited ({{allApplications.length}})
             </h1>
 
-            {% elseif data['statusTab'] == 'Unsuccessful' %}
+            {% elseif statusTab == 'Unsuccessful' %}
             <h1 class="govuk-heading-s">
               Unsuccessful applications ({{allApplications.length}})
             </h1>
 
-            {% elseif data['statusTab'] == 'Deferred' %}
+            {% elseif statusTab == 'Deferred' %}
             <h1 class="govuk-heading-s">
               Candidates deferred ({{allApplications.length}})
             </h1>
 
           {% endif %}
 
+
+          {% elseif statusTab == 'all' and selectedFilters %}
+          <h1 class="govuk-heading-s">
+            All matching applications ({{allApplications.length}})
+          </h1>
+
+          {% elseif statusTab == 'all' %}
+          <h1 class="govuk-heading-s">
+            All applications ({{allApplications.length}})
+          </h1>
           {% endif %}
 
           <div>

--- a/app/views/applications/index.njk
+++ b/app/views/applications/index.njk
@@ -126,9 +126,9 @@
 
           {% elseif data['statusTab'] == 'Recruited' or data['statusTab'] == 'Unsuccessful' or data['statusTab'] == 'Deferred' %}
             <div class="app-status-blocks">
-              <p><a href="applications?statusTab=Recruited" class="success{% if data['statusTab'] == 'Recruited' %} selected{% endif %}"><strong>XX</strong> recruited</a></p>
-              <p><a href="applications?statusTab=Unsuccessful" class="failed{% if data['statusTab'] == 'Unsuccessful' %} selected{% endif %}"><strong>XX</strong> unsuccessful</a></p>
-              <p><a href="applications?statusTab=Deferred" class="waiting{% if data['statusTab'] == 'Deferred' %} selected{% endif %}"><strong>XX</strong> deferred</a></p>
+              <p><a href="applications?statusTab=Recruited" class="success{% if data['statusTab'] == 'Recruited' %} selected{% endif %}"><strong>{{appsRecruitedCount}}</strong> recruited</a></p>
+              <p><a href="applications?statusTab=Unsuccessful" class="failed{% if data['statusTab'] == 'Unsuccessful' %} selected{% endif %}"><strong>{{appsUnsuccessfulCount}}</strong> unsuccessful</a></p>
+              <p><a href="applications?statusTab=Deferred" class="waiting{% if data['statusTab'] == 'Deferred' %} selected{% endif %}"><strong>{{appsDeferredCount}}</strong> deferred</a></p>
             </div>
 
             {% if data['statusTab'] == 'Recruited' %}

--- a/app/views/applications/index.njk
+++ b/app/views/applications/index.njk
@@ -22,6 +22,9 @@
       </div>
 
       {% include "_includes/search-panel.njk" %}
+
+      {%- if applications.length %}
+
       <div class="govuk-tabs">
         <h2 class="govuk-tabs__title">
           Contents
@@ -169,35 +172,30 @@
           </h1>
 
           {% elseif statusTab == 'all' %}
-          <h1 class="govuk-heading-s">
+          <h1 class="govuk-heading-m">
             All applications ({{allApplications.length}})
           </h1>
           {% endif %}
 
           <div>
-            {%- if allApplications.length %}
 
               <div class="app-application-cards">
-                {%- for a in allApplications %}
-
+                {%- for a in applications %}
 
                   {% if a.heading %}
-                    <h2 class="govuk-heading-m app-application-cards__heading">{{a.heading}}</h2>
+                    <h2 class="govuk-heading-s app-application-cards__heading">{{a.heading}}</h2>
                   {% else %}
                     {% include "_includes/application-card.njk" %}
                   {% endif %}
                 {% endfor -%}
               </div>
 
-            {% endif -%}
           </div>
 
         </div>
       </div>
 
-
-
-
+    {% endif %}
 
 
       {% if applications.length and pagination %}

--- a/app/views/applications/index.njk
+++ b/app/views/applications/index.njk
@@ -163,7 +163,7 @@
           {% endif %}
 
 
-          {% elseif statusTab == 'all' and selectedFilters %}
+          {% elseif statusTab == 'all' and ( selectedFilters or hasSearch ) %}
           <h1 class="govuk-heading-s">
             All matching applications ({{allApplications.length}})
           </h1>

--- a/app/views/applications/index.njk
+++ b/app/views/applications/index.njk
@@ -21,8 +21,6 @@
         <div class="app-action-bar__filter"></div>
       </div>
 
-
-
       {% include "_includes/search-panel.njk" %}
 
       <div class="govuk-tabs">
@@ -61,7 +59,7 @@
           {% if data['statusTab'] == '' or data['statusTab'] == 'action' %}
 
             {% set bannerHtml %}
-              <p class="govuk-notification-banner__heading">You have XX applications requiring action.</p>
+              <p class="govuk-notification-banner__heading">You have {{applications.length}} applications requiring action.</p>
               <p class="govuk-body">You received these applications over 30 working days ago. You need to make a decision as soon as possible or the candidate may choose to withdraw and apply to another provider.</a>
             {% endset %}
 

--- a/app/views/applications/index.njk
+++ b/app/views/applications/index.njk
@@ -89,7 +89,7 @@
                 </h1>
                 {{ govukButton({
                   text: "Export new applications",
-                  href: "/reports/export",
+                  href: "/reports/export?status=new",
                   classes: "govuk-button--secondary"
                 }) }}
               </div>

--- a/app/views/applications/index.njk
+++ b/app/views/applications/index.njk
@@ -28,7 +28,7 @@
           Contents
         </h2>
         <ul class="govuk-tabs__list">
-          <li class="govuk-tabs__list-item{% if data['statusTab'] == '' or data['statusTab'] == 'action' %} govuk-tabs__list-item--selected{% endif %}">
+          <li class="govuk-tabs__list-item{% if not data['statusTab'] or data['statusTab'] == 'action' %} govuk-tabs__list-item--selected{% endif %}">
             <a class="govuk-tabs__tab" href="applications?statusTab=action">
               Action required
             </a>

--- a/app/views/applications/index.njk
+++ b/app/views/applications/index.njk
@@ -33,18 +33,18 @@
               Action required
             </a>
           </li>
-          <li class="govuk-tabs__list-item{% if data['statusTab'] == 'New' or data['statusTab'] == 'In review' or data['statusTab'] == 'Shortlisted' %} govuk-tabs__list-item--selected{% endif %}">
+          <li class="govuk-tabs__list-item{% if data['statusTab'] == 'New' or data['statusTab'] == 'In review' or data['statusTab'] == 'Shortlisted' or data['statusTab'] == 'Received' %} govuk-tabs__list-item--selected{% endif %}">
             <a class="govuk-tabs__tab" href="applications?statusTab=New">
               Received
             </a>
           </li>
-          <li class="govuk-tabs__list-item{% if data['statusTab'] == 'Interviewing' or data['statusTab'] == 'Offered' or data['statusTab'] == 'Conditions pending' %} govuk-tabs__list-item--selected{% endif %}">
-            <a class="govuk-tabs__tab" href="applications?statusTab=Interviewing">
+          <li class="govuk-tabs__list-item{% if data['statusTab'] == 'In progress' or data['statusTab'] == 'Interviewing' or data['statusTab'] == 'Offered' or data['statusTab'] == 'Conditions pending' %} govuk-tabs__list-item--selected{% endif %}">
+            <a class="govuk-tabs__tab" href="applications?statusTab=In progress">
               In progress
             </a>
           </li>
-          <li class="govuk-tabs__list-item{% if data['statusTab'] == 'Recruited' or data['statusTab'] == 'Unsuccessful' or data['statusTab'] == 'Deferred' %} govuk-tabs__list-item--selected{% endif %}">
-            <a class="govuk-tabs__tab" href="applications?statusTab=Recruited">
+          <li class="govuk-tabs__list-item{% if data['statusTab'] == 'Complete' or data['statusTab'] == 'Recruited' or data['statusTab'] == 'Unsuccessful' or data['statusTab'] == 'Deferred' %} govuk-tabs__list-item--selected{% endif %}">
+            <a class="govuk-tabs__tab" href="applications?statusTab=Complete">
               Complete
             </a>
           </li>
@@ -67,15 +67,20 @@
               html: bannerHtml
             }) }}
 
-          {% elseif data['statusTab'] == 'New' or data['statusTab'] == 'In review' or data['statusTab'] == 'Shortlisted' %}
+          {% elseif data['statusTab'] == 'New' or data['statusTab'] == 'In review' or data['statusTab'] == 'Shortlisted' or data['statusTab'] == 'Received' %}
+            <div class="app-status-header"><a href="applications?statusTab=Received" {% if data['statusTab'] == 'Received' %}class="selected"{% endif %}><strong>{{ appsNewCount + appsReviewCount + appsShortlistedCount }}</strong> applications received</a></div>
             <div class="app-status-blocks">
               <p><a href="applications?statusTab=New" class="new{% if data['statusTab'] == 'New' %} selected{% endif %}"><strong>{{appsNewCount}}</strong> new applications to review</a></p>
               <p><a href="applications?statusTab=In review" class="progress{% if data['statusTab'] == 'In review' %} selected{% endif %}"><strong>{{appsReviewCount}}</strong> applications in review</a></p>
               <p><a href="applications?statusTab=Shortlisted" class="success{% if data['statusTab'] == 'Shortlisted' %} selected{% endif %}"><strong>{{appsShortlistedCount}}</strong> shortlisted applications</a></p>
             </div>
 
-              {% if data['statusTab'] == 'New' %}
+              {% if data['statusTab'] == 'Received' %}
+              <h1 class="govuk-heading-s">
+                Applications received ({{ appsNewCount + appsReviewCount + appsShortlistedCount }})
+              </h1>
 
+              {% elseif data['statusTab'] == 'New' %}
               <div class="app-application-header">
                 <h1 class="govuk-heading-s">
                   New applications to review ({{allApplications.length}})
@@ -98,14 +103,20 @@
 
               {% endif %}
 
-          {% elseif data['statusTab'] == 'Interviewing' or data['statusTab'] == 'Offered' or data['statusTab'] == 'Conditions pending' %}
+          {% elseif data['statusTab'] == 'In progress' or data['statusTab'] == 'Interviewing' or data['statusTab'] == 'Offered' or data['statusTab'] == 'Conditions pending' %}
+            <div class="app-status-header"><a href="applications?statusTab=In progress" {% if data['statusTab'] == 'In progress' %}class="selected"{% endif %}><strong>{{ appsInterviewingCount + appsOfferedCount + appsConditionsCount }}</strong> applications in progress</a></div>
             <div class="app-status-blocks">
               <p><a href="applications?statusTab=Interviewing" class="progress{% if data['statusTab'] == 'Interviewing' %} selected{% endif %}"><strong>{{appsInterviewingCount}}</strong> in interview</a></p>
               <p><a href="applications?statusTab=Offered" class="success{% if data['statusTab'] == 'Offered' %} selected{% endif %}"><strong>{{appsOfferedCount}}</strong> offers made</a></p>
               <p><a href="applications?statusTab=Conditions pending" class="waiting{% if data['statusTab'] == 'Conditions pending' %} selected{% endif %}"><strong>{{appsConditionsCount}}</strong> pending conditions</a></p>
             </div>
 
-            {% if data['statusTab'] == 'Interviewing' %}
+            {% if data['statusTab'] == 'In progress' %}
+            <h1 class="govuk-heading-s">
+              Applications in progress ({{ appsInterviewingCount + appsOfferedCount + appsConditionsCount }})
+            </h1>
+
+            {% elseif data['statusTab'] == 'Interviewing' %}
             <h1 class="govuk-heading-s">
               Applications in interview ({{allApplications.length}})
             </h1>
@@ -122,14 +133,20 @@
 
           {% endif %}
 
-          {% elseif data['statusTab'] == 'Recruited' or data['statusTab'] == 'Unsuccessful' or data['statusTab'] == 'Deferred' %}
+          {% elseif data['statusTab'] == 'Complete' or data['statusTab'] == 'Recruited' or data['statusTab'] == 'Unsuccessful' or data['statusTab'] == 'Deferred' %}
+            <div class="app-status-header"><a href="applications?statusTab=Complete" {% if data['statusTab'] == 'Complete' %}class="selected"{% endif %}><strong>{{ appsRecruitedCount + appsUnsuccessfulCount + appsDeferredCount }}</strong> applications completed</a></div>
             <div class="app-status-blocks">
               <p><a href="applications?statusTab=Recruited" class="success{% if data['statusTab'] == 'Recruited' %} selected{% endif %}"><strong>{{appsRecruitedCount}}</strong> recruited</a></p>
               <p><a href="applications?statusTab=Unsuccessful" class="failed{% if data['statusTab'] == 'Unsuccessful' %} selected{% endif %}"><strong>{{appsUnsuccessfulCount}}</strong> unsuccessful</a></p>
               <p><a href="applications?statusTab=Deferred" class="waiting{% if data['statusTab'] == 'Deferred' %} selected{% endif %}"><strong>{{appsDeferredCount}}</strong> deferred</a></p>
             </div>
 
-            {% if data['statusTab'] == 'Recruited' %}
+            {% if data['statusTab'] == 'Complete' %}
+            <h1 class="govuk-heading-s">
+              Applications completed ({{ appsRecruitedCount + appsUnsuccessfulCount + appsDeferredCount }})
+            </h1>
+
+            {% elseif data['statusTab'] == 'Recruited' %}
             <h1 class="govuk-heading-s">
               Candidates recruited ({{allApplications.length}})
             </h1>

--- a/app/views/applications/index.njk
+++ b/app/views/applications/index.njk
@@ -25,23 +25,156 @@
 
       {% include "_includes/search-panel.njk" %}
 
-      <div>
-        {%- if applications.length %}
+      <div class="govuk-tabs">
+        <h2 class="govuk-tabs__title">
+          Contents
+        </h2>
+        <ul class="govuk-tabs__list">
+          <li class="govuk-tabs__list-item{% if data['statusTab'] == '' or data['statusTab'] == 'action' %} govuk-tabs__list-item--selected{% endif %}">
+            <a class="govuk-tabs__tab" href="applications?statusTab=action">
+              Action required
+            </a>
+          </li>
+          <li class="govuk-tabs__list-item{% if data['statusTab'] == 'New' or data['statusTab'] == 'In review' or data['statusTab'] == 'Shortlisted' %} govuk-tabs__list-item--selected{% endif %}">
+            <a class="govuk-tabs__tab" href="applications?statusTab=New">
+              Received
+            </a>
+          </li>
+          <li class="govuk-tabs__list-item{% if data['statusTab'] == 'Interviewing' or data['statusTab'] == 'Offered' or data['statusTab'] == 'Conditions pending' %} govuk-tabs__list-item--selected{% endif %}">
+            <a class="govuk-tabs__tab" href="applications?statusTab=Interviewing">
+              In progress
+            </a>
+          </li>
+          <li class="govuk-tabs__list-item{% if data['statusTab'] == 'Recruited' or data['statusTab'] == 'Unsuccessful' or data['statusTab'] == 'Deferred' %} govuk-tabs__list-item--selected{% endif %}">
+            <a class="govuk-tabs__tab" href="applications?statusTab=Recruited">
+              Complete
+            </a>
+          </li>
+          <li class="govuk-tabs__list-item{% if data['statusTab'] == 'all' %} govuk-tabs__list-item--selected{% endif %}">
+            <a class="govuk-tabs__tab" href="applications?statusTab=all">
+              All
+            </a>
+          </li>
+        </ul>
+        <div class="govuk-tabs__panel">
 
-          <div class="app-application-cards">
-            {%- for a in applications %}
+          {% if data['statusTab'] == '' or data['statusTab'] == 'action' %}
 
+            {% set bannerHtml %}
+              <p class="govuk-notification-banner__heading">You have XX applications requiring action.</p>
+              <p class="govuk-body">You received these applications over 30 working days ago. You need to make a decision as soon as possible or the candidate may choose to withdraw and apply to another provider.</a>
+            {% endset %}
 
-              {% if a.heading %}
-                <h2 class="govuk-heading-m app-application-cards__heading">{{a.heading}}</h2>
-              {% else %}
-                {% include "_includes/application-card.njk" %}
+            {{ govukNotificationBanner({
+              html: bannerHtml
+            }) }}
+
+          {% elseif data['statusTab'] == 'New' or data['statusTab'] == 'In review' or data['statusTab'] == 'Shortlisted' %}
+            <div class="app-status-blocks">
+              <p><a href="applications?statusTab=New" class="new{% if data['statusTab'] == 'New' %} selected{% endif %}"><strong>XX</strong> new applications to review</a></p>
+              <p><a href="applications?statusTab=In review" class="progress{% if data['statusTab'] == 'In review' %} selected{% endif %}"><strong>XX</strong> applications in review</a></p>
+              <p><a href="applications?statusTab=Shortlisted" class="success{% if data['statusTab'] == 'Shortlisted' %} selected{% endif %}"><strong>XX</strong> shortlisted applications</a></p>
+            </div>
+
+              {% if data['statusTab'] == 'New' %}
+
+              <div class="app-application-header">
+                <h1 class="govuk-heading-s">
+                  New applications to review ({{applications.length}})
+                </h1>
+                {{ govukButton({
+                  text: "Export new applications",
+                  href: "/reports/export",
+                  classes: "govuk-button--secondary"
+                }) }}
+              </div>
+              {% elseif data['statusTab'] == 'In review' %}
+              <h1 class="govuk-heading-s">
+                Applications in review ({{applications.length}})
+              </h1>
+
+              {% elseif data['statusTab'] == 'Shortlisted' %}
+              <h1 class="govuk-heading-s">
+                Shortlisted applications ({{applications.length}})
+              </h1>
+
               {% endif %}
-            {% endfor -%}
+
+          {% elseif data['statusTab'] == 'Interviewing' or data['statusTab'] == 'Offered' or data['statusTab'] == 'Conditions pending' %}
+            <div class="app-status-blocks">
+              <p><a href="applications?statusTab=Interviewing" class="progress{% if data['statusTab'] == 'Interviewing' %} selected{% endif %}"><strong>XX</strong> in interview</a></p>
+              <p><a href="applications?statusTab=Offered" class="success{% if data['statusTab'] == 'Offered' %} selected{% endif %}"><strong>XX</strong> offers made</a></p>
+              <p><a href="applications?statusTab=Conditions pending" class="waiting{% if data['statusTab'] == 'Conditions pending' %} selected{% endif %}"><strong>XX</strong> pending conditions</a></p>
+            </div>
+
+            {% if data['statusTab'] == 'Interviewing' %}
+            <h1 class="govuk-heading-s">
+              Applications in interview ({{applications.length}})
+            </h1>
+
+            {% elseif data['statusTab'] == 'Offered' %}
+            <h1 class="govuk-heading-s">
+              Places offered ({{applications.length}})
+            </h1>
+
+            {% elseif data['statusTab'] == 'Conditions pending' %}
+            <h1 class="govuk-heading-s">
+              Applications with conditions pending ({{applications.length}})
+            </h1>
+
+          {% endif %}
+
+          {% elseif data['statusTab'] == 'Recruited' or data['statusTab'] == 'Unsuccessful' or data['statusTab'] == 'Deferred' %}
+            <div class="app-status-blocks">
+              <p><a href="applications?statusTab=Recruited" class="success{% if data['statusTab'] == 'Recruited' %} selected{% endif %}"><strong>XX</strong> recruited</a></p>
+              <p><a href="applications?statusTab=Unsuccessful" class="failed{% if data['statusTab'] == 'Unsuccessful' %} selected{% endif %}"><strong>XX</strong> unsuccessful</a></p>
+              <p><a href="applications?statusTab=Deferred" class="waiting{% if data['statusTab'] == 'Deferred' %} selected{% endif %}"><strong>XX</strong> deferred</a></p>
+            </div>
+
+            {% if data['statusTab'] == 'Recruited' %}
+            <h1 class="govuk-heading-s">
+              Candidates recruited ({{applications.length}})
+            </h1>
+
+            {% elseif data['statusTab'] == 'Unsuccessful' %}
+            <h1 class="govuk-heading-s">
+              Unsuccessful applications ({{applications.length}})
+            </h1>
+
+            {% elseif data['statusTab'] == 'Deferred' %}
+            <h1 class="govuk-heading-s">
+              Candidates deferred ({{applications.length}})
+            </h1>
+
+          {% endif %}
+
+          {% endif %}
+
+          <div>
+            {%- if allApplications.length %}
+
+              <div class="app-application-cards">
+                {%- for a in allApplications %}
+
+
+                  {% if a.heading %}
+                    <h2 class="govuk-heading-m app-application-cards__heading">{{a.heading}}</h2>
+                  {% else %}
+                    {% include "_includes/application-card.njk" %}
+                  {% endif %}
+                {% endfor -%}
+              </div>
+
+            {% endif -%}
           </div>
 
-        {% endif -%}
+        </div>
       </div>
+
+
+
+
+
 
       {% if applications.length and pagination %}
         {% include "_includes/pagination.njk" %}

--- a/app/views/applications/index.njk
+++ b/app/views/applications/index.njk
@@ -71,16 +71,16 @@
 
           {% elseif data['statusTab'] == 'New' or data['statusTab'] == 'In review' or data['statusTab'] == 'Shortlisted' %}
             <div class="app-status-blocks">
-              <p><a href="applications?statusTab=New" class="new{% if data['statusTab'] == 'New' %} selected{% endif %}"><strong>XX</strong> new applications to review</a></p>
-              <p><a href="applications?statusTab=In review" class="progress{% if data['statusTab'] == 'In review' %} selected{% endif %}"><strong>XX</strong> applications in review</a></p>
-              <p><a href="applications?statusTab=Shortlisted" class="success{% if data['statusTab'] == 'Shortlisted' %} selected{% endif %}"><strong>XX</strong> shortlisted applications</a></p>
+              <p><a href="applications?statusTab=New" class="new{% if data['statusTab'] == 'New' %} selected{% endif %}"><strong>{{appsNewCount}}</strong> new applications to review</a></p>
+              <p><a href="applications?statusTab=In review" class="progress{% if data['statusTab'] == 'In review' %} selected{% endif %}"><strong>{{appsReviewCount}}</strong> applications in review</a></p>
+              <p><a href="applications?statusTab=Shortlisted" class="success{% if data['statusTab'] == 'Shortlisted' %} selected{% endif %}"><strong>{{appsShortlistedCount}}</strong> shortlisted applications</a></p>
             </div>
 
               {% if data['statusTab'] == 'New' %}
 
               <div class="app-application-header">
                 <h1 class="govuk-heading-s">
-                  New applications to review ({{applications.length}})
+                  New applications to review ({{allApplications.length}})
                 </h1>
                 {{ govukButton({
                   text: "Export new applications",
@@ -90,36 +90,36 @@
               </div>
               {% elseif data['statusTab'] == 'In review' %}
               <h1 class="govuk-heading-s">
-                Applications in review ({{applications.length}})
+                Applications in review ({{allApplications.length}})
               </h1>
 
               {% elseif data['statusTab'] == 'Shortlisted' %}
               <h1 class="govuk-heading-s">
-                Shortlisted applications ({{applications.length}})
+                Shortlisted applications ({{allApplications.length}})
               </h1>
 
               {% endif %}
 
           {% elseif data['statusTab'] == 'Interviewing' or data['statusTab'] == 'Offered' or data['statusTab'] == 'Conditions pending' %}
             <div class="app-status-blocks">
-              <p><a href="applications?statusTab=Interviewing" class="progress{% if data['statusTab'] == 'Interviewing' %} selected{% endif %}"><strong>XX</strong> in interview</a></p>
-              <p><a href="applications?statusTab=Offered" class="success{% if data['statusTab'] == 'Offered' %} selected{% endif %}"><strong>XX</strong> offers made</a></p>
-              <p><a href="applications?statusTab=Conditions pending" class="waiting{% if data['statusTab'] == 'Conditions pending' %} selected{% endif %}"><strong>XX</strong> pending conditions</a></p>
+              <p><a href="applications?statusTab=Interviewing" class="progress{% if data['statusTab'] == 'Interviewing' %} selected{% endif %}"><strong>{{appsInterviewingCount}}</strong> in interview</a></p>
+              <p><a href="applications?statusTab=Offered" class="success{% if data['statusTab'] == 'Offered' %} selected{% endif %}"><strong>{{appsOfferedCount}}</strong> offers made</a></p>
+              <p><a href="applications?statusTab=Conditions pending" class="waiting{% if data['statusTab'] == 'Conditions pending' %} selected{% endif %}"><strong>{{appsConditionsCount}}</strong> pending conditions</a></p>
             </div>
 
             {% if data['statusTab'] == 'Interviewing' %}
             <h1 class="govuk-heading-s">
-              Applications in interview ({{applications.length}})
+              Applications in interview ({{allApplications.length}})
             </h1>
 
             {% elseif data['statusTab'] == 'Offered' %}
             <h1 class="govuk-heading-s">
-              Places offered ({{applications.length}})
+              Places offered ({{allApplications.length}})
             </h1>
 
             {% elseif data['statusTab'] == 'Conditions pending' %}
             <h1 class="govuk-heading-s">
-              Applications with conditions pending ({{applications.length}})
+              Applications with conditions pending ({{allApplications.length}})
             </h1>
 
           {% endif %}
@@ -133,17 +133,17 @@
 
             {% if data['statusTab'] == 'Recruited' %}
             <h1 class="govuk-heading-s">
-              Candidates recruited ({{applications.length}})
+              Candidates recruited ({{allApplications.length}})
             </h1>
 
             {% elseif data['statusTab'] == 'Unsuccessful' %}
             <h1 class="govuk-heading-s">
-              Unsuccessful applications ({{applications.length}})
+              Unsuccessful applications ({{allApplications.length}})
             </h1>
 
             {% elseif data['statusTab'] == 'Deferred' %}
             <h1 class="govuk-heading-s">
-              Candidates deferred ({{applications.length}})
+              Candidates deferred ({{allApplications.length}})
             </h1>
 
           {% endif %}

--- a/app/views/applications/notes/index.njk
+++ b/app/views/applications/notes/index.njk
@@ -55,10 +55,10 @@
                   {% endif %}
                 </span>
                 <span class="govuk-!-margin-bottom-1 govuk-hint govuk-!-margin-left-1 govuk-!-font-size-16">
-                  {{note.date | govukShortDateAtTime }}
+                  {{note.date | govukDateTime }}
 
                   {% if note.lastUpdatedDate %}
-                    (last updated {{note.lastUpdatedDate | govukShortDateAtTime}})
+                    (last updated {{note.lastUpdatedDate | govukDateTime}})
                   {% endif %}
                 </span>
               </p>

--- a/app/views/applications/notes/new.njk
+++ b/app/views/applications/notes/new.njk
@@ -4,8 +4,8 @@
 {% set subNavId = "notes" %}
 {% set status = application.status %}
 {% set name = application.personalDetails.name %}
-{% set caption = content.createNote.caption + ' - ' + application.personalDetails.name %}
-{% set heading = 'Note' %}
+{% set caption = application.personalDetails.name %}
+{% set heading = 'Add note' %}
 {% set title = heading + ' - ' + caption %}
 
 {% block pageNavigation %}
@@ -19,16 +19,15 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      {% set h1 %}
         <span class="govuk-caption-l">{{caption}}</span>
-        {{heading}}
-      {% endset %}
+      <h1 class="govuk-heading-l">{{ heading }}</h1>
+
       <form method="post">
         {{ govukCharacterCount({
           label: {
-            html: h1,
-            classes: "govuk-label--l",
-            isPageheading: true
+            text: 'Note',
+            classes: "govuk-label--m",
+            isPageheading: false
           },
           maxlength: 500,
           id: "note",
@@ -37,7 +36,7 @@
         }) }}
 
         {{govukButton({
-          text: content.createNote.checkAnswers.button
+          text: 'Save note'
         })}}
 
         <p><a href="/applications/{{application.id}}/notes">Cancel</a></p>

--- a/app/views/applications/offer/withdraw/check.njk
+++ b/app/views/applications/offer/withdraw/check.njk
@@ -5,7 +5,7 @@
 {% set caption = content.withdrawOffer.caption + ' - ' + name %}
 {% set heading = content.withdrawOffer.checkAnswers.heading %}
 {% set title = heading + ' - ' + caption %}
-{% set buttonText = content.withdrawOffer.checkAnswers.button %}
+{% set buttonText = 'Withdraw offer' %}
 
 {% block pageNavigation %}
   {{ govukBackLink({

--- a/app/views/applications/show.njk
+++ b/app/views/applications/show.njk
@@ -8,9 +8,23 @@
 
 {% block content %}
 
-  {% if showWithdrawnBanner %}
+  {% if showBanner %}
+
+    {% if showBanner == 'withdraw' %}
+      {% set showBannerText = 'Application withdrawn' %}
+    {% elseif showBanner == 'review' %}
+     {% set showBannerText = 'Application marked as In review' %}
+    {% elseif showBanner == 'shortlist' %}
+      {% set showBannerText = 'Application shortlisted' %}
+    {% endif %}
+
+    {% set showBannerHtml %}
+      <h3 class="govuk-notification-banner__heading">{{ showBannerText }}</h3>
+    <p class="govuk-body"><a class="govuk-notification-banner__link" href="/applications/{{application.id}}/notes/new">Add a note</a></p>
+    {% endset %}
+
     {{ govukNotificationBanner({
-      text: "Application withdrawn",
+      html: showBannerHtml,
       type: 'success'
     }) }}
   {% endif %}

--- a/app/views/reports/applications/index.njk
+++ b/app/views/reports/applications/index.njk
@@ -59,9 +59,19 @@
             },
             items: [
               {
-                value: 'Received',
-                text: 'Received',
-                checked: checked("export_status", "Received") == "checked"
+                value: 'New',
+                text: 'New',
+                checked: checked("export_status", "New") == "checked"
+              },
+              {
+                value: 'In review',
+                text: 'In review',
+                checked: checked("export_status", "In review") == "checked"
+              },
+              {
+                value: 'Shortlisted',
+                text: 'Shortlisted',
+                checked: checked("export_status", "Shortlisted") == "checked"
               },
               {
                 value: 'Interviewing',
@@ -84,14 +94,14 @@
                 checked: checked("export_status", "Recruited") == "checked"
               },
               {
-                value: 'Conditions not met',
-                text: 'Conditions not met',
-                checked: checked("export_status", "Conditions not met") == "checked"
-              },
-              {
                 value: 'Deferred',
                 text: 'Deferred',
                 checked: checked("export_status", "Deferred") == "checked"
+              },
+              {
+                value: 'Conditions not met',
+                text: 'Conditions not met',
+                checked: checked("export_status", "Conditions not met") == "checked"
               },
               {
                 value: 'Declined',
@@ -117,6 +127,23 @@
           }) }}
         {% endset %}
 
+        {% set newHtml %}
+
+        {{ govukCheckboxes({
+          idPrefix: 'mark_review',
+          name: 'mark_review',
+          items: [
+            {
+              value: "mark_review",
+              text: "Mark exported applications as in review",
+              checked: true
+            }
+         ]
+        }) }}
+
+        {% endset %}
+
+
         {{ govukRadios({
           idPrefix: "status",
           name: "status",
@@ -127,6 +154,14 @@
             }
           },
           items: [
+            {
+              value: "New applications",
+              text: "New applications",
+              conditional: {
+                html: newHtml
+              },
+              checked: checked("status", "new") == "checked"
+            },
             {
               value: "All statuses",
               text: "All statuses"

--- a/scripts/generate-applications.js
+++ b/scripts/generate-applications.js
@@ -222,7 +222,7 @@ const generateFakeApplications = () => {
   const organisations = user.organisations
   const applications = []
   const now = SystemHelper.now()
-  const randomNumber = faker.number.int({ 'min': 1, 'max': 20 })
+  const randomNumber = faker.number.int({ 'min': 1, 'max': 40 })
   const past = now.minus({ days: randomNumber }).set({
     hour: faker.helpers.arrayElement([9, 10, 11]),
     minute: faker.helpers.arrayElement([0, 15, 30, 45])
@@ -553,6 +553,206 @@ const generateFakeApplications = () => {
   applications.push(generateFakeApplication({
     id: '78562646',
     status: 'Offered',
+    assignedUsers: []
+  }))
+
+  applications.push(generateFakeApplication({
+    status: 'New',
+    assignedUsers: []
+  }))
+
+  applications.push(generateFakeApplication({
+    status: 'New',
+    assignedUsers: []
+  }))
+
+  applications.push(generateFakeApplication({
+    status: 'In review',
+    assignedUsers: []
+  }))
+
+  applications.push(generateFakeApplication({
+    status: 'In review',
+    assignedUsers: []
+  }))
+
+  applications.push(generateFakeApplication({
+    status: 'In review',
+    assignedUsers: []
+  }))
+
+  applications.push(generateFakeApplication({
+    status: 'Shortlisted',
+    assignedUsers: []
+  }))
+
+  applications.push(generateFakeApplication({
+    status: 'Shortlisted',
+    assignedUsers: []
+  }))
+
+  applications.push(generateFakeApplication({
+    status: 'Shortlisted',
+    assignedUsers: []
+  }))
+
+  applications.push(generateFakeApplication({
+    status: 'Interviewing',
+    assignedUsers: []
+  }))
+
+  applications.push(generateFakeApplication({
+    status: 'Interviewing',
+    assignedUsers: []
+  }))
+
+  applications.push(generateFakeApplication({
+    status: 'Interviewing',
+    assignedUsers: []
+  }))
+
+  applications.push(generateFakeApplication({
+    status: 'Offered',
+    assignedUsers: []
+  }))
+
+  applications.push(generateFakeApplication({
+    status: 'Offered',
+    assignedUsers: []
+  }))
+
+  applications.push(generateFakeApplication({
+    status: 'Conditions pending',
+    assignedUsers: []
+  }))
+
+  applications.push(generateFakeApplication({
+    status: 'Conditions pending',
+    assignedUsers: []
+  }))
+
+  applications.push(generateFakeApplication({
+    status: 'Recruited',
+    assignedUsers: []
+  }))
+
+  applications.push(generateFakeApplication({
+    status: 'Recruited',
+    assignedUsers: []
+  }))
+
+  applications.push(generateFakeApplication({
+    status: 'Recruited',
+    assignedUsers: []
+  }))
+
+  applications.push(generateFakeApplication({
+    status: 'Recruited',
+    assignedUsers: []
+  }))
+
+  applications.push(generateFakeApplication({
+    status: 'Recruited',
+    assignedUsers: []
+  }))
+
+  applications.push(generateFakeApplication({
+    status: 'Recruited',
+    assignedUsers: []
+  }))
+
+  applications.push(generateFakeApplication({
+    status: 'Deferred',
+    assignedUsers: []
+  }))
+
+  applications.push(generateFakeApplication({
+    status: 'Deferred',
+    assignedUsers: []
+  }))
+
+  applications.push(generateFakeApplication({
+    status: 'Conditions not met',
+    assignedUsers: []
+  }))
+
+  applications.push(generateFakeApplication({
+    status: 'Conditions not met',
+    assignedUsers: []
+  }))
+
+  applications.push(generateFakeApplication({
+    status: 'Offer withdrawn',
+    assignedUsers: []
+  }))
+
+  applications.push(generateFakeApplication({
+    status: 'Offer withdrawn',
+    assignedUsers: []
+  }))
+
+  applications.push(generateFakeApplication({
+    status: 'Application withdrawn',
+    assignedUsers: []
+  }))
+
+  applications.push(generateFakeApplication({
+    status: 'Application withdrawn',
+    assignedUsers: []
+  }))
+
+  applications.push(generateFakeApplication({
+    status: 'Application withdrawn',
+    assignedUsers: []
+  }))
+
+  applications.push(generateFakeApplication({
+    status: 'Declined',
+    assignedUsers: []
+  }))
+
+  applications.push(generateFakeApplication({
+    status: 'Declined',
+    assignedUsers: []
+  }))
+
+  applications.push(generateFakeApplication({
+    status: 'Declined',
+    assignedUsers: []
+  }))
+
+  applications.push(generateFakeApplication({
+    status: 'Rejected',
+    assignedUsers: []
+  }))
+
+  applications.push(generateFakeApplication({
+    status: 'Rejected',
+    assignedUsers: []
+  }))
+
+  applications.push(generateFakeApplication({
+    status: 'Rejected',
+    assignedUsers: []
+  }))
+
+  applications.push(generateFakeApplication({
+    status: 'Rejected',
+    assignedUsers: []
+  }))
+
+  applications.push(generateFakeApplication({
+    status: 'Rejected',
+    assignedUsers: []
+  }))
+
+  applications.push(generateFakeApplication({
+    status: 'Closed',
+    assignedUsers: []
+  }))
+
+  applications.push(generateFakeApplication({
+    status: 'Closed',
     assignedUsers: []
   }))
 

--- a/scripts/generate-applications.js
+++ b/scripts/generate-applications.js
@@ -546,7 +546,7 @@ const generateFakeApplications = () => {
 
   applications.push(generateFakeApplication({
     id: '5346436346',
-    status: 'Received',
+    status: 'New',
     assignedUsers: []
   }))
 

--- a/scripts/generate-applications.js
+++ b/scripts/generate-applications.js
@@ -235,7 +235,7 @@ const generateFakeApplications = () => {
 
   applications.push(generateFakeApplication({
     id: '46436',
-    status: 'Received',
+    status: 'In review',
     course: 'Modern languages (French) (MD9Q)',
     subject: [
       {
@@ -338,7 +338,7 @@ const generateFakeApplications = () => {
 
   applications.push(generateFakeApplication({
     id: '9475924',
-    status: 'Received',
+    status: 'New',
     course: 'History (H152)',
     subject: [
       {
@@ -434,7 +434,7 @@ const generateFakeApplications = () => {
 
   applications.push(generateFakeApplication({
     id: '18571512',
-    status: 'Received',
+    status: 'Shortlisted',
     course: 'Primary (2S8T)',
     subject: [
       {

--- a/scripts/generate-applications.js
+++ b/scripts/generate-applications.js
@@ -746,16 +746,6 @@ const generateFakeApplications = () => {
     assignedUsers: []
   }))
 
-  applications.push(generateFakeApplication({
-    status: 'Closed',
-    assignedUsers: []
-  }))
-
-  applications.push(generateFakeApplication({
-    status: 'Closed',
-    assignedUsers: []
-  }))
-
   return applications
 }
 


### PR DESCRIPTION
### Problem
Currently, when a provider receives an application, it stays in the ‘received’ status until a decision is made.
This might be a brand new application that nobody has looked at, one that is being reviewed offline, or one that has been shortlisted for an interview/offer.
This makes it hard for providers to tell which applications need their attention.
The change proposes more granular statuses to help providers manage their workload. and a new way of presenting/navigating applications.

### TLDR
* Replace 'received' with more granular statuses
   * New
   * In review
   * Shortlisted 
* Grouping of the new and proposed statuses into categories
   * Received
   * In progress
   * Complete
* Tabs to navigate between categories
* Pseudo-tabs/data blocks used to show the more granular statuses within
* New actions to applications to move into In review or Shortlisted. Also the ability to mark as In review when exporting 
* If they had any applications they haven't made a decision on in 30 days, they would be shown these when they first log in
* Otherwise, homepage would show newly received applications and allow them to export these

### Longer waffley version

https://github.com/user-attachments/assets/0ca12189-03c8-46d9-b8af-2efb67571e0c

### Note
My first deep dive into the Manage prototype - hope I didn't make too big a mess… 😬