### PR TITLE
Confidential references

### DIFF
--- a/app/data/generators/references.js
+++ b/app/data/generators/references.js
@@ -26,13 +26,14 @@ module.exports = (status) => {
     'Was the head coach for my athletics club. I’ve known them for 5 years'
   ])
 
-  const referee = (status) => {
+  const referee = (status, confidential) => {
     const firstName = faker.person.firstName()
     const lastName = faker.person.lastName()
 
     let ref =  {
       type,
       name: `${firstName} ${lastName}`,
+      confidential,
       email: faker.internet.email({
         firstName,
         lastName
@@ -54,8 +55,8 @@ module.exports = (status) => {
   }
 
   let references = {}
-  references['12446'] = referee(status)
-  references['26436'] = referee(status)
+  references['12446'] = referee(status, true )
+  references['26436'] = referee(status, false )
 
   return references
 }

--- a/app/views/_includes/applications/references.njk
+++ b/app/views/_includes/applications/references.njk
@@ -22,6 +22,7 @@
 
 {% if referencesReceived | length > 0 %}
   <h2 class="govuk-heading-m">Received references</h2>
+
   {% for reference in referencesReceived %}
 
     {% set relationshipHtml %}
@@ -53,7 +54,26 @@
       {%- endif -%}
     {%- endset %}
 
+    {% set condfidentialResponseHtml -%}
+      {%- if reference['confidential'] -%}
+        <p class="govuk-body">No, this reference is confidential. Do not share it.</p>
+      {% else %}
+        <p class="govuk-body">Yes, if they request it.</p>
+      {%- endif -%}
+    {%- endset %}
+
     {% set summaryCardHtml %}
+
+      {%- if reference['confidential'] -%}
+
+      {{ govukWarningText({
+        text: "Confidential do not share with the candidate",
+        iconFallbackText: "Warning"
+      }) }}
+
+      {% endif %}
+
+
       {{ govukSummaryList({
         rows: [{
           key: {
@@ -92,9 +112,19 @@
           value: {
             html: reference.comments | nl2br
           }
+        },
+        {
+          key: {
+            html: "Can this reference be shared with the candidate?"
+          },
+          value: {
+            html: condfidentialResponseHtml
+          }
         }]
       }) }}
     {% endset %}
+
+
 
     {{appSummaryCard({
       titleText: reference.type + " reference from " + reference.name,


### PR DESCRIPTION
Marking confidential references when a provider views an application:

![image](https://github.com/user-attachments/assets/2d792a6c-6234-419c-92db-3354444a2921)
