### PR TITLE
Withdrawal updates

### DIFF
--- a/app/filters.js
+++ b/app/filters.js
@@ -1,4 +1,6 @@
 const govukPrototypeKit = require('govuk-prototype-kit')
+const dateFilter = require('nunjucks-date-filter')
+
 const addFilter = govukPrototypeKit.views.addFilter
 
 function statusClass (status) {
@@ -35,6 +37,8 @@ function statusClass (status) {
         return 'govuk-tag--red'
     }
   }
+
+addFilter('date', dateFilter)
 
 addFilter('statusClass', statusClass)
 

--- a/app/routes/withdraw-application.js
+++ b/app/routes/withdraw-application.js
@@ -12,7 +12,16 @@ module.exports = router => {
   router.post('/applications/:applicationId/withdraw', (req, res) => {
     const applicationId = req.params.applicationId
     const application = req.session.data.applications.find(app => app.id === applicationId)
+    const reason = req.session.data['withdrawal-reason']
 
+    if ( reason == 'withdraw-offer' ) {
+      res.redirect(`/applications/${applicationId}/offer/withdraw` )
+    } else {
+      application.pendingWithdrawal = true
+      res.redirect(`/applications/${applicationId}?confirm=withdraw-request` )
+    }
+
+    /*
     application.status = 'Application withdrawn'
 
     application.withdrawal = {
@@ -35,6 +44,8 @@ module.exports = router => {
     })
 
     res.redirect(`/applications/${applicationId}/` )
+
+    */
   })
 
 }

--- a/app/views/_components/offer-panel/template.njk
+++ b/app/views/_components/offer-panel/template.njk
@@ -7,14 +7,9 @@
 
 <div class="app-offer-panel">
   {% if not params.transferred %}
-    {% if params.withdraw or params.defer %}
+    {% if params.defer %}
       <p class="govuk-body govuk-!-margin-bottom-2">
-        {% if params.withdraw %}
-          <a class="govuk-!-margin-right-2" href="{{params.withdraw.href}}">Withdraw offer</a>
-        {% endif %}
-        {% if params.defer %}
           <a href="{{params.defer.href}}">Defer offer</a>
-        {% endif %}
       </p>
     {% endif %}
   {% endif %}

--- a/app/views/_includes/application-card.njk
+++ b/app/views/_includes/application-card.njk
@@ -40,7 +40,9 @@
     </div>
     <div class="govuk-grid-column-one-third">
       <dl class="app-application-card__list app-application-card__list--secondary">
-        {% if a.status == 'Received' or a.status == 'New' or a.status == 'In review' or a.status == 'Interviewing' or a.status == 'Shortlisted' %}
+        {% if a.pendingWithdrawal %}
+          <dd class="govuk-body-s app-status-indicator--red">Pending withdrawal</dd>
+        {% elif a.status == 'Received' or a.status == 'New' or a.status == 'In review' or a.status == 'Interviewing' or a.status == 'Shortlisted' %}
           <dd class="govuk-body-s{% if ( a.submittedDate | daysAgo ) >= 30 %} app-status-indicator--red{% endif %}">Received {{ a.submittedDate | daysAgo }} days ago
           </dd>
         {% elif a.status == 'Offered' %}

--- a/app/views/applications/offer/withdraw/check.njk
+++ b/app/views/applications/offer/withdraw/check.njk
@@ -1,10 +1,11 @@
 {% extends "_layout.njk" %}
+{% from "_components/rejection-reasons/macro.njk" import rejectionReasons %}
 
 {% set primaryNavId = 'applications' %}
 {% set name = application.personalDetails.name %}
-{% set caption = content.withdrawOffer.caption + ' - ' + name %}
-{% set heading = content.withdrawOffer.checkAnswers.heading %}
-{% set title = heading + ' - ' + caption %}
+
+{% set heading = 'Check and confirm withdrawal' %}
+{% set title = heading %}
 {% set buttonText = 'Withdraw offer' %}
 
 {% block pageNavigation %}
@@ -13,24 +14,87 @@
   }) }}
 {% endblock %}
 
+{% set withdrawalReasons %}
+
+{% for reasonCategory in data['rejection']['categories'] %}
+  <p class="govuk-body">{{reasonCategory}}</p>
+  {% if reasonCategory == 'Qualifications' %}
+    {% set reasons =  data['rejection']['qualifications-reasons'] %}
+  {% else %}
+    {% set reasons = null %}
+  {% endif %}
+
+  {% for reason in reasons %}
+  <p class="govuk-body"> - {{reason}}{{reasonDetails}}</p>
+  {% endfor %}
+
+{% endfor %}
+
+
+{% endset %}
+
 {% block content %}
+
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <span class="govuk-caption-l">{{caption}}</span>
       <h1 class="govuk-heading-l">{{heading}}</h1>
 
-      {% set rejectionReasons = data.rejection %}
       {% set showChangeLinks = true %}
-      {% include "_includes/candidate-feedback.njk" %}
+
+      {{ govukSummaryList({
+        rows: [
+          {
+            key: {
+              text: "Full name"
+            },
+            value: {
+              text: name
+            }
+          },
+          {
+            key: {
+              text: "Course"
+            },
+            value: {
+              text: application.course
+            }
+          },
+          {
+            key: {
+              text: "Starting"
+            },
+            value: {
+              text: '2025'
+            }
+          },
+          {
+            key: {
+              text: "Preferred location"
+            },
+            value: {
+              html: appLocation(application.location) if application.location.name else application.location
+            }
+          },
+          {
+            key: {
+              text: "Reason for withdrawal"
+            },
+            value: {
+              html: withdrawalReasons
+            }
+          }
+        ]
+      }) }}
 
       {{ govukWarningText({
-        text: "The candidate will be sent an email to tell them why you withdrew the offer.",
+        text: "We will tell the candidate you withdrew your offer, and share your reasons.",
         iconFallbackText: "Fallback text"
       }) }}
 
       <form method="post">
         {{ govukButton({
-          text: buttonText
+          text: buttonText,
+          classes: "govuk-button--warning"
         }) }}
       </form>
 

--- a/app/views/applications/offer/withdraw/index.njk
+++ b/app/views/applications/offer/withdraw/index.njk
@@ -2,8 +2,15 @@
 
 {% set primaryNavId = 'applications' %}
 {% set name = application.personalDetails.name %}
-{% set caption = content.withdrawOffer.caption + ' - ' + name %}
-{% set heading = "Tell the candidate why you’re withdrawing their offer" %}
+
+{% set caption %}
+{% if content.withdrawOffer.caption %}
+{{ content.withdrawOffer.caption }} -
+{% endif %}
+{{ name }}
+{% endset %}
+
+{% set heading = "Tell the candidate why you do not want to offer them a place" %}
 {% set title = heading + ' - ' + caption %}
 
 {% block pageNavigation %}
@@ -51,6 +58,14 @@
 
         {% set sponsorshipHtml %}
           {{appRejectionDetails({ category: 'sponsorship', reason: 'details', data: data })}}
+        {% endset %}
+
+        {% set conditionsHtml %}
+          {{appRejectionDetails({ category: 'conditions', reason: 'details', data: data })}}
+        {% endset %}
+
+        {% set fundingHtml %}
+          {{appRejectionDetails({ category: 'fundingHtml', reason: 'details', data: data })}}
         {% endset %}
 
         {% set otherDetailsHtml %}
@@ -129,6 +144,22 @@
               text: "Course full",
               checked: checked("['rejection']['categories']", "Course full")
             },
+            {
+              value: "Candidate has not met the conditions of this offer",
+              text: "Candidate has not met the conditions of this offer",
+              checked: checked("['rejection']['categories']", "Candidate has not met the conditions of this offer"),
+              conditional: {
+                html: conditionsHtml
+              }
+            } if data['withdrawal-reason'] == "withdraw-offer",
+            {
+              value: "Funding",
+              text: "Funding",
+              checked: checked("['rejection']['categories']", "Funding"),
+              conditional: {
+                html: fundingHtml
+              }
+            } if data['withdrawal-reason'] == "withdraw-offer",
             {
               value: "Other",
               text: "Other",

--- a/app/views/applications/show.njk
+++ b/app/views/applications/show.njk
@@ -11,16 +11,20 @@
   {% if showBanner %}
 
     {% if showBanner == 'withdraw' %}
-      {% set showBannerText = 'Application withdrawn' %}
+      {% set showBannerHeading = 'Application withdrawn' %}
     {% elseif showBanner == 'review' %}
-     {% set showBannerText = 'Application marked as In review' %}
+     {% set showBannerHeading = 'Application marked as In review' %}
     {% elseif showBanner == 'shortlist' %}
-      {% set showBannerText = 'Application shortlisted' %}
+      {% set showBannerHeading = 'Application shortlisted' %}
+    {% elseif showBanner == 'withdraw-request' %}
+      {% set showBannerHeading = 'We have contacted the candidate to confirm they want to withdraw' %}
+      {% set showBannerText%}If they do not respond by {{ date | date("h:mma")}} on on {{ date | date("add", 2, "days") | date("D MMMM Y")}}, their application will be withdrawn automatically.{% endset %}
     {% endif %}
 
     {% set showBannerHtml %}
-      <h3 class="govuk-notification-banner__heading">{{ showBannerText }}</h3>
-    <p class="govuk-body"><a class="govuk-notification-banner__link" href="/applications/{{application.id}}/notes/new">Add a note</a></p>
+      <h3 class="govuk-notification-banner__heading">{{ showBannerHeading }}</h3>
+      {% if showBannerText %}<p class="govuk-body">{{ showBannerText }}</p>{% endif %}
+      <p class="govuk-body"><a class="govuk-notification-banner__link" href="/applications/{{application.id}}/notes/new">Add a note</a></p>
     {% endset %}
 
     {{ govukNotificationBanner({
@@ -44,37 +48,41 @@
     html: html
     }) }}
 
- {# {%  elif application.personalDetails.name == 'Freida Jackson'%}
-       {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
-
-    {% set html %}
-    <p class="govuk-notification-banner__heading">
-      {{name}}
-      updated their application on 31 July 2023 at 9:15am.<br><br>
-      <a class="govuk-notification-banner__link" href="/applications/{{application.id}}/timeline">View the timeline to see their updates</a>.
-    </p>
-    {% endset %}
-
-    {{ govukNotificationBanner({
-    html: html
-    }) }} #}
-
-
 {% endif %}
 
 
   {% include "_includes/applications/h1.njk" %}
   {% include "_includes/applications/sub-nav.njk" %}
 
+
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h2 class="govuk-heading-l govuk-!-margin-bottom govuk-!-font-size-36">Application</h2>
+
+
+      {% if application.pendingWithdrawal and showBanner != 'withdraw-request' %}
+        <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+          <div class="govuk-notification-banner__header">
+            <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+              Important
+            </h2>
+          </div>
+          <div class="govuk-notification-banner__content">
+            <p class="govuk-body">
+              This application is pending withdrawal. The candidate has until {{ date | date("h:mma")}} on {{ date | date("add", 2, "days") | date("D MMMM Y")}} to confirm, or their application will be withdrawn.
+            </p>
+          </div>
+        </div>
+      {% endif %}
+
       {% if not query.transferred %}
         {% if application.status not in["Rejected", "Declined", "Offer withdrawn", "Application withdrawn", "Conditions not met"] %}
           <p class="govuk-body">{{name}}
             will be able to edit some sections of their application. You'll get a notification if they add any new information.</p>
           <p class="govuk-body">
-            <a class="govuk-link govuk-!-margin-right-2" href="/applications/{{application.id}}/withdraw">Withdraw application</a>
+            {% if not application.pendingWithdrawal %}
+              <a class="govuk-link govuk-!-margin-right-2" href="/applications/{{application.id}}/withdraw">Close this application</a>
+            {% endif %}
           {% endif %}
           <a class="govuk-link" href="#" download>Download application (PDF)</a>
         </p>

--- a/app/views/applications/withdraw/index.njk
+++ b/app/views/applications/withdraw/index.njk
@@ -15,16 +15,38 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <span class="govuk-caption-l">{{name}}</span>
-      <h1 class="govuk-heading-l">Confirm that the candidate wants to withdraw their application</h1>
-      <p class="govuk-body">The candidate will be told that their application has been withdrawn</p>
 
       <form method="post" action="/applications/{{application.id}}/withdraw">
-        <input type="hidden" name="withdraw-application[reason]" value="Candidate asked to withdraw the application" />
+
+      {{ govukRadios({
+        name: "withdrawal-reason",
+        fieldset: {
+          legend: {
+            text: "Why do you want to close this application?",
+            isPageHeading: true,
+            classes: "govuk-fieldset__legend--l"
+          }
+        },
+        items: [
+          {
+            value: "withdraw-offer",
+            text: "We do not want to offer this candidate a place anymore"
+          } if application.status != 'New' and application.status != 'In review' and application.status != 'Shortlisted' and application.status != 'Interviewing',
+          {
+            value: "no-response",
+            text: "The candidate has not responded to communications"
+          },
+          {
+            value: "candidate-behalf",
+            text: "The candidate has asked us to withdraw their application"
+          }
+        ]
+      }) }}
+
         {{ govukButton({
-          text: "Withdraw application"
+          text: "Continue"
         }) }}
       </form>
-
       <p class="govuk-body"><a class="govuk-link--no-visited-state" href="/applications/{{ application.id }}">Cancel</a></p>
     </div>
   </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,8 @@
         "weighted": "^1.0.0"
       },
       "devDependencies": {
-        "glob": "^10.3.4"
+        "glob": "^10.3.4",
+        "nunjucks-date-filter": "^0.1.1"
       },
       "engines": {
         "node": "20.11.0"
@@ -3064,6 +3065,16 @@
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-1.2.0.tgz",
       "integrity": "sha512-r6lj77KlwqLhIUku9UWYes7KJtsczvolZkzp8hbaDPPaE24OmWl5s539Mytlj22siEQKosZ26qCBgda2PKwoJw=="
     },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -3171,6 +3182,15 @@
         "chokidar": {
           "optional": true
         }
+      }
+    },
+    "node_modules/nunjucks-date-filter": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/nunjucks-date-filter/-/nunjucks-date-filter-0.1.1.tgz",
+      "integrity": "sha512-xKIMGB+UH1mRnk1/ofAVpU+6Fm52KQWfkCCjMWYohuBTj/Id/qy8zIVuE5lpwtavPyHz96sW2dCawNdPPhn0SQ==",
+      "dev": true,
+      "dependencies": {
+        "moment": "^2.9.0"
       }
     },
     "node_modules/object-assign": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     ]
   },
   "devDependencies": {
-    "glob": "^10.3.4"
+    "glob": "^10.3.4",
+    "nunjucks-date-filter": "^0.1.1"
   }
 }


### PR DESCRIPTION
[Trello card](https://trello.com/c/9EBsw6zd/524-design-an-alternative-to-withdraw-on-candidates-behalf)

Allowing providers to end an application post-offer, and allowing to candidates to confirm when a provider submits a 'withdraw on candidate's behalf' request.